### PR TITLE
added U and U2 gate, deprecated U3 gate, changed CPhase and Phase attributes

### DIFF
--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -841,11 +841,11 @@ class U2(BaseGate):
 
         # U2(φ,λ) = U3(π/2, φ, λ) up to global phase
         # matrix = 1/sqrt(2) * [[1, -e^{iλ}], [e^{iφ}, e^{i(φ+λ)}]]
-        inv_sqrt2 = 1/np.sqrt(2)
-        mat = inv_sqrt2 * np.array([
-            [1,                   -np.exp(1j * self.lam)],
-            [np.exp(1j * self.phi), np.exp(1j * (self.phi + self.lam))]
-        ], dtype=np.complex128)
+        inv_sqrt2 = 1 / np.sqrt(2)
+        mat = inv_sqrt2 * np.array(
+            [[1, -np.exp(1j * self.lam)], [np.exp(1j * self.phi), np.exp(1j * (self.phi + self.lam))]],
+            dtype=np.complex128,
+        )
 
         super().__init__(mat)
 

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -388,7 +388,7 @@ class BaseGate:
         return Rz(params)
 
     @classmethod
-    def phase(cls, params: list[Parameter]) -> Phase:
+    def p(cls, params: list[Parameter]) -> Phase:
         """Returns the Phase gate.
 
         Args:
@@ -401,13 +401,13 @@ class BaseGate:
 
     @classmethod
     def u(cls, params: list[Parameter]) -> U:
-        """Returns the U2 gate.
+        """Returns the U gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameters.
+            params: The rotation angle parameters.
 
         Returns:
-            U: An instance of the U2 gate.
+            U: An instance of the U gate.
         """
         return U(params)
 
@@ -422,18 +422,6 @@ class BaseGate:
             U2: An instance of the U2 gate.
         """
         return U2(params)
-
-    @classmethod
-    def u3(cls, params: list[Parameter]) -> U3:
-        """Returns the U3 gate.
-
-        Args:
-            params: The rotation angle parameters.
-
-        Returns:
-            U3: An instance of the U3 gate.
-        """
-        return U3(params)
 
     @classmethod
     def cx(cls) -> CX:
@@ -454,7 +442,7 @@ class BaseGate:
         return CZ()
 
     @classmethod
-    def cphase(cls, params: list[Parameter]) -> CPhase:
+    def cp(cls, params: list[Parameter]) -> CPhase:
         """Returns the CPhase gate.
 
         Args:
@@ -816,12 +804,12 @@ class U2(BaseGate):
     """Class representing a U2 gate.
 
     Attributes:
-        name (str): The name of the gate ("u2").
-        matrix (ndarray[np.complex128]): The 2×2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (ndarray[np.complex128]): The tensor representation of the gate (same as the matrix).
-        phi (float): The first rotation parameter.
-        lam (float): The second rotation parameter.
+        name: The name of the gate ("u2").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+        phi: The first rotation parameter.
+        lam: The second rotation parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -839,8 +827,6 @@ class U2(BaseGate):
         """
         self.phi, self.lam = params
 
-        # U2(φ,λ) = U3(π/2, φ, λ) up to global phase
-        # matrix = 1/sqrt(2) * [[1, -e^{iλ}], [e^{iφ}, e^{i(φ+λ)}]]
         inv_sqrt2 = 1 / np.sqrt(2)
         mat = inv_sqrt2 * np.array(
             [[1, -np.exp(1j * self.lam)], [np.exp(1j * self.phi), np.exp(1j * (self.phi + self.lam))]],

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -812,45 +812,6 @@ class Phase(BaseGate):
         super().__init__(mat)
 
 
-class U(BaseGate):
-    """Class representing a generic U(θ,φ,λ) single-qubit gate.
-
-    Attributes:
-        name (str): The name of the gate ("u").
-        matrix (ndarray[np.complex128]): The 2×2 matrix representation.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (ndarray[np.complex128]): Tensor repr (same as matrix).
-        theta (float): first rotation angle.
-        phi (float): second rotation angle.
-        lam (float): third rotation angle.
-
-    Methods:
-        set_sites(*sites: int) -> None:
-            Sets the qubit(s) where the gate applies.
-    """
-    name = "u"
-
-    def __init__(self, params: list[Parameter]) -> None:
-        """Initializes the UGate.
-
-        Args:
-            params: list[Parameter]
-                A list of three rotation angles [theta, phi, lambda].
-        """
-        self.theta, self.phi, self.lam = params
-
-        # U(θ,φ,λ) = [[cos(θ/2), -e^{iλ} sin(θ/2)],
-        #             [e^{iφ} sin(θ/2), e^{i(φ+λ)} cos(θ/2)]]
-        mat = np.array([
-            [ np.cos(self.theta/2),
-             -np.exp(1j*self.lam)*np.sin(self.theta/2)],
-            [ np.exp(1j*self.phi)*np.sin(self.theta/2),
-              np.exp(1j*(self.phi + self.lam))*np.cos(self.theta/2)]
-        ], dtype=np.complex128)
-
-        super().__init__(mat)
-
-
 class U2(BaseGate):
     """Class representing a U2 gate.
 
@@ -876,7 +837,6 @@ class U2(BaseGate):
             params: list[Parameter]
                 A list containing two rotation angles [phi, lambda].
         """
-        # Unpack parameters
         self.phi, self.lam = params
 
         # U2(φ,λ) = U3(π/2, φ, λ) up to global phase
@@ -890,7 +850,7 @@ class U2(BaseGate):
         super().__init__(mat)
 
 
-class U3(BaseGate):
+class U(BaseGate):
     """Class representing a U3 gate.
 
     Attributes:
@@ -1434,7 +1394,6 @@ class GateLibrary:
     rz = Rz
     u = U
     u2 = U2
-    u3 = U3
     cx = CX
     cz = CZ
     swap = SWAP

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -304,11 +304,10 @@ def test_gate_u2() -> None:
     gate = GateLibrary.u2([phi, lam])
     gate.set_sites(0)  # For a single-qubit gate, only one site is needed.
 
-    inv_sqrt2 = 1/np.sqrt(2)
-    expected = inv_sqrt2 * np.array([
-            [1,                   -np.exp(1j * lam)],
-            [np.exp(1j * phi), np.exp(1j * (phi + lam))]
-        ], dtype=np.complex128)
+    inv_sqrt2 = 1 / np.sqrt(2)
+    expected = inv_sqrt2 * np.array(
+        [[1, -np.exp(1j * lam)], [np.exp(1j * phi), np.exp(1j * (phi + lam))]], dtype=np.complex128
+    )
     assert_allclose(gate.tensor, expected)
 
     base_gate = BaseGate.u([phi, lam])

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -310,7 +310,7 @@ def test_gate_u2() -> None:
     )
     assert_allclose(gate.tensor, expected)
 
-    base_gate = BaseGate.u([phi, lam])
+    base_gate = BaseGate.u2([phi, lam])
     assert_array_equal(gate.matrix, base_gate.matrix)
 
 

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -234,12 +234,12 @@ def test_gate_phase() -> None:
     is computed correctly. It also confirms that the tensor equals the matrix.
     """
     theta = np.pi / 3
-    gate = GateLibrary.phase([theta])
+    gate = GateLibrary.p([theta])
     gate.set_sites(4)
     assert gate.sites == [4]
     assert_array_equal(gate.tensor, gate.matrix)
 
-    base_gate = BaseGate.phase([theta])
+    base_gate = BaseGate.p([theta])
     assert_array_equal(gate.matrix, base_gate.matrix)
 
 
@@ -293,16 +293,38 @@ def test_gate_rz() -> None:
     assert_array_equal(gate.matrix, base_gate.matrix)
 
 
-def test_gate_u3() -> None:
-    """Test the U3 gate.
+def test_gate_u2() -> None:
+    """Test the U2 gate.
 
     This test sets the parameters (theta, phi, lambda) for the U3 gate and verifies that its tensor,
+    which is equivalent to the 2x2 unitary matrix representation, matches the expected matrix.
+    """
+    phi = np.pi / 4
+    lam = np.pi / 3
+    gate = GateLibrary.u2([phi, lam])
+    gate.set_sites(0)  # For a single-qubit gate, only one site is needed.
+
+    inv_sqrt2 = 1/np.sqrt(2)
+    expected = inv_sqrt2 * np.array([
+            [1,                   -np.exp(1j * lam)],
+            [np.exp(1j * phi), np.exp(1j * (phi + lam))]
+        ], dtype=np.complex128)
+    assert_allclose(gate.tensor, expected)
+
+    base_gate = BaseGate.u([phi, lam])
+    assert_array_equal(gate.matrix, base_gate.matrix)
+
+
+def test_gate_u() -> None:
+    """Test the U gate.
+
+    This test sets the parameters (theta, phi, lambda) for the U gate and verifies that its tensor,
     which is equivalent to the 2x2 unitary matrix representation, matches the expected matrix.
     """
     theta = np.pi / 2
     phi = np.pi / 4
     lam = np.pi / 3
-    gate = GateLibrary.u3([theta, phi, lam])
+    gate = GateLibrary.u([theta, phi, lam])
     gate.set_sites(0)  # For a single-qubit gate, only one site is needed.
 
     expected = np.array([
@@ -312,7 +334,7 @@ def test_gate_u3() -> None:
 
     assert_allclose(gate.tensor, expected)
 
-    base_gate = BaseGate.u3([theta, phi, lam])
+    base_gate = BaseGate.u([theta, phi, lam])
     assert_array_equal(gate.matrix, base_gate.matrix)
 
 
@@ -435,12 +457,12 @@ def test_gate_cphase_forward() -> None:
     It verifies that the tensor, when reshaped to (2,2,2,2), matches the expected matrix.
     """
     theta = np.pi / 2
-    gate = GateLibrary.cphase([theta])
+    gate = GateLibrary.cp([theta])
     gate.set_sites(0, 1)  # Forward order
     expected: NDArray[np.complex128] = np.reshape(gate.matrix, (2, 2, 2, 2))
     assert_array_equal(gate.tensor, expected)
 
-    base_gate = BaseGate.cphase([theta])
+    base_gate = BaseGate.cp([theta])
     assert_array_equal(gate.matrix, base_gate.matrix)
 
 
@@ -451,7 +473,7 @@ def test_gate_cphase_reverse() -> None:
     It then verifies that the tensor is correctly transposed (axes (1,0,3,2)) relative to the forward order.
     """
     theta = np.pi / 2
-    gate = GateLibrary.cphase([theta])
+    gate = GateLibrary.cp([theta])
     gate.set_sites(1, 0)  # Reverse order; tensor should be transposed on (1,0,3,2)
     expected: NDArray[np.complex128] = np.reshape(gate.matrix, (2, 2, 2, 2))
     expected = np.transpose(expected, (1, 0, 3, 2))


### PR DESCRIPTION
## Description

This pull request adds functionality for the U2 gate and replaces the U3 with the equivalent U.
Additionally, CPhase and Phase are now called by GateLibrary.cp() and GateLibrary.p(), respectively, to better align with Qiskit's implementation.


## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
