### PR TITLE
Selects slurm cpus if available

### DIFF
--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 import os
 
 
-def available_cpus():
+def available_cpus() -> int:
     """ Determine the number of available CPU cores for parallel execution.
 
     This function checks if the SLURM_CPUS_ON_NODE environment variable is set (indicating a SLURM-managed cluster job).

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -44,7 +44,18 @@ if TYPE_CHECKING:
 
 
 import os
+
+
 def available_cpus():
+    """ Determine the number of available CPU cores for parallel execution.
+
+    This function checks if the SLURM_CPUS_ON_NODE environment variable is set (indicating a SLURM-managed cluster job).
+    If so, it returns the number of CPUs specified by SLURM. Otherwise, it returns the total number of CPUs available
+    on the machine as reported by multiprocessing.cpu_count().
+
+    Returns:
+        int: The number of available CPU cores for parallel execution.
+    """
     slurm_cpus = int(os.environ["SLURM_CPUS_ON_NODE"]) if "SLURM_CPUS_ON_NODE" in os.environ else None
     machine_cpus = multiprocessing.cpu_count()
 

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -42,6 +42,19 @@ if TYPE_CHECKING:
     from .core.data_structures.noise_model import NoiseModel
 
 
+
+import os
+def available_cpus():
+    slurm_cpus = int(os.environ["SLURM_CPUS_ON_NODE"]) if "SLURM_CPUS_ON_NODE" in os.environ else None
+    machine_cpus = multiprocessing.cpu_count()
+
+    if slurm_cpus is None:
+        return machine_cpus
+    else:
+        return slurm_cpus
+
+
+
 def _run_strong_sim(
     initial_state: MPS,
     operator: QuantumCircuit,
@@ -78,7 +91,7 @@ def _run_strong_sim(
 
     args = [(i, initial_state, noise_model, sim_params, operator) for i in range(sim_params.num_traj)]
     if parallel and sim_params.num_traj > 1:
-        max_workers = max(1, multiprocessing.cpu_count() - 1)
+        max_workers = max(1, available_cpus() - 1)
         with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {executor.submit(backend, arg): arg[0] for arg in args}
             with tqdm(total=sim_params.num_traj, desc="Running trajectories", ncols=80) as pbar:
@@ -135,7 +148,7 @@ def _run_weak_sim(
 
     args = [(i, initial_state, noise_model, sim_params, operator) for i in range(sim_params.num_traj)]
     if parallel and sim_params.num_traj > 1:
-        max_workers = max(1, multiprocessing.cpu_count() - 1)
+        max_workers = max(1, available_cpus() - 1)
         with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {executor.submit(backend, arg): arg[0] for arg in args}
             with tqdm(total=sim_params.num_traj, desc="Running trajectories", ncols=80) as pbar:
@@ -214,7 +227,7 @@ def _run_analog(
 
     args = [(i, initial_state, noise_model, sim_params, operator) for i in range(sim_params.num_traj)]
     if parallel and sim_params.num_traj > 1:
-        max_workers = max(1, multiprocessing.cpu_count() - 1)
+        max_workers = max(1, available_cpus() - 1)
         with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {executor.submit(backend, arg): arg[0] for arg in args}
             with tqdm(total=sim_params.num_traj, desc="Running trajectories", ncols=80) as pbar:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -34,6 +34,14 @@ from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import XX, YY, ZZ, X, Z
 
 
+
+def test_available_cpus() -> None:
+    """Test the available_cpus function."""
+    num_cpus = simulator.available_cpus()
+    assert isinstance(num_cpus, int), "Number of CPUs should be an integer."
+    assert num_cpus > 0, "Expected positive number of CPUs."
+
+
 def test_analog_simulation() -> None:
     """Test the branch for Hamiltonian simulation (analog simulation) using AnalogSimParams.
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -34,11 +34,34 @@ from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import XX, YY, ZZ, X, Z
 
 
-def test_available_cpus() -> None:
-    """Test the available_cpus function."""
-    num_cpus = simulator.available_cpus()
-    assert isinstance(num_cpus, int), "Number of CPUs should be an integer."
-    assert num_cpus > 0, "Expected positive number of CPUs."
+import multiprocessing
+import importlib
+import pytest
+
+
+def test_available_cpus_without_slurm(monkeypatch):
+    """
+    Path 1: SLURM_CPUS_ON_NODE *not* set.
+    Should return multiprocessing.cpu_count().
+    """
+    # Ensure the env var is absent
+    monkeypatch.delenv("SLURM_CPUS_ON_NODE", raising=False)
+
+    assert simulator.available_cpus() == multiprocessing.cpu_count()
+
+
+def test_available_cpus_with_slurm(monkeypatch):
+    """
+    Path 2: SLURM_CPUS_ON_NODE is set.
+    Should return that exact value.
+    """
+    monkeypatch.setenv("SLURM_CPUS_ON_NODE", "8")
+
+    # Reload the module only if available_cpus caches anything at import;
+    # here it's not necessary, but harmless:
+    importlib.reload(simulator)
+
+    assert simulator.available_cpus() == 8
 
 
 def test_analog_simulation() -> None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -34,7 +34,6 @@ from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import XX, YY, ZZ, X, Z
 
 
-
 def test_available_cpus() -> None:
     """Test the available_cpus function."""
     num_cpus = simulator.available_cpus()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -37,8 +37,9 @@ from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import XX, YY, ZZ, X, Z
 
 
-def test_available_cpus_without_slurm(monkeypatch) -> None:
+def test_available_cpus_without_slurm(monkeypatch: pytest.MonkeyPatch) -> None:
     """Path 1: SLURM_CPUS_ON_NODE *not* set.
+
     Should return multiprocessing.cpu_count().
     """
     # Ensure the env var is absent
@@ -47,8 +48,9 @@ def test_available_cpus_without_slurm(monkeypatch) -> None:
     assert simulator.available_cpus() == multiprocessing.cpu_count()
 
 
-def test_available_cpus_with_slurm(monkeypatch) -> None:
+def test_available_cpus_with_slurm(monkeypatch: pytest.MonkeyPatch) -> None:
     """Path 2: SLURM_CPUS_ON_NODE is set.
+
     Should return that exact value.
     """
     monkeypatch.setenv("SLURM_CPUS_ON_NODE", "8")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -18,6 +18,9 @@ qubit counts.
 
 from __future__ import annotations
 
+import importlib
+import multiprocessing
+
 import numpy as np
 import pytest
 
@@ -34,14 +37,8 @@ from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import XX, YY, ZZ, X, Z
 
 
-import multiprocessing
-import importlib
-import pytest
-
-
-def test_available_cpus_without_slurm(monkeypatch):
-    """
-    Path 1: SLURM_CPUS_ON_NODE *not* set.
+def test_available_cpus_without_slurm(monkeypatch) -> None:
+    """Path 1: SLURM_CPUS_ON_NODE *not* set.
     Should return multiprocessing.cpu_count().
     """
     # Ensure the env var is absent
@@ -50,9 +47,8 @@ def test_available_cpus_without_slurm(monkeypatch):
     assert simulator.available_cpus() == multiprocessing.cpu_count()
 
 
-def test_available_cpus_with_slurm(monkeypatch):
-    """
-    Path 2: SLURM_CPUS_ON_NODE is set.
+def test_available_cpus_with_slurm(monkeypatch) -> None:
+    """Path 2: SLURM_CPUS_ON_NODE is set.
     Should return that exact value.
     """
     monkeypatch.setenv("SLURM_CPUS_ON_NODE", "8")


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

If the scripts detects that it is in a slurm environment it selects as available_cpus the amount of cpus allocated for the slurm job, otherwise it selects the amount of cpus that the machine has. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ x] The pull request only contains commits that are focused and relevant to this change.
- [ x] I have added appropriate tests that cover the new/changed functionality.
- [ x] I have updated the documentation to reflect these changes.
- [ x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ x] I have added migration instructions to the upgrade guide (if needed).
- [ x] The changes follow the project's style guidelines and introduce no new warnings.
- [ x] The changes are fully tested and pass the CI checks.
- [ x] I have reviewed my own code changes.
