### PR TITLE
added ability to stop progress bar from printing via SimParams initialization

### DIFF
--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -158,6 +158,8 @@ class AnalogSimParams:
         The order of the simulation (default is 1).
     get_state:
         If True, output MPS is returned.
+    how_progress:
+        If True, a progress bar is printed as trajectories finish.
 
     Methods:
     --------
@@ -181,6 +183,7 @@ class AnalogSimParams:
         sample_timesteps: bool = True,
         evolution_mode: EvolutionMode = EvolutionMode.TDVP,
         get_state: bool = False,
+        show_progress: bool = True,
     ) -> None:
         """Physics simulation parameters initialization.
 
@@ -210,6 +213,8 @@ class AnalogSimParams:
             Mode of tensor evolution in the simulation, by default EvolutionMode.TDVP.
         get_state :
             If True, output MPS is returned.
+        show_progress:
+            If True, a progress bar is printed as trajectories finish.
         """
         assert all(n.gate.name == "pvm" for n in observables) or all(n.gate.name != "pvm" for n in observables), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -241,6 +246,7 @@ class AnalogSimParams:
         self.order = order
         self.evolution_mode = evolution_mode
         self.get_state = get_state
+        self.show_progress = show_progress
 
     def aggregate_trajectories(self) -> None:
         """Aggregates trajectories for result.
@@ -280,6 +286,8 @@ class WeakSimParams:
         If True, output MPS is returned.
     sample_layers:
         If True, sample layers.
+    show_progress:
+        If True, a progress bar is printed as trajectories finish.
 
     Methods:
     --------
@@ -302,6 +310,7 @@ class WeakSimParams:
         threshold: float = 1e-9,
         *,
         get_state: bool = False,
+        show_progress: bool = True,
     ) -> None:
         """Weak circuit simulation initialization.
 
@@ -319,6 +328,8 @@ class WeakSimParams:
             Accuracy threshold for truncating tensors, by default 1e-6.
         get_state:
             If True, output MPS is returned.
+        show_progress:
+            If True, a progress bar is printed as trajectories finish.
         """
         self.measurements: list[dict[int, int] | None] = [None] * shots
         self.shots = shots
@@ -326,6 +337,7 @@ class WeakSimParams:
         self.min_bond_dim = min_bond_dim
         self.threshold = threshold
         self.get_state = get_state
+        self.show_progress = show_progress
 
     def aggregate_measurements(self) -> None:
         """Aggregates shots into final result.
@@ -380,6 +392,8 @@ class StrongSimParams:
         The size of the window for the simulation. Default is None.
     get_state:
         If True, output MPS is returned.
+    show_progress:
+        If True, a progress bar is printed as trajectories finish.
 
     Methods:
     --------
@@ -405,6 +419,7 @@ class StrongSimParams:
         get_state: bool = False,
         sample_layers: bool = False,
         num_mid_measurements: int = 0,
+        show_progress: bool = True,
     ) -> None:
         """Strong circuit simulation parameters initialization.
 
@@ -422,6 +437,8 @@ class StrongSimParams:
             Threshold for simulation accuracy, by default 1e-6.
         get_state:
             If True, output MPS is returned.
+        show_progress:
+            If True, a progress bar is printed as trajectories finish.
         """
         assert all(n.gate.name == "pvm" for n in observables) or all(n.gate.name != "pvm" for n in observables), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -448,6 +465,7 @@ class StrongSimParams:
         self.get_state = get_state
         self.sample_layers = sample_layers
         self.num_mid_measurements = num_mid_measurements
+        self.show_progress = show_progress
 
     def aggregate_trajectories(self) -> None:
         """Aggregates trajectories for result.

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -278,6 +278,7 @@ def _run_backend_parallel(
     args: Sequence[TArg],
     *,
     max_workers: int,
+    show_progress: bool = True,
     desc: str,
     total: int | None = None,
     max_retries: int = 10,
@@ -293,6 +294,7 @@ def _run_backend_parallel(
         backend : The backend function to call.
         args: Sequence of argument objects, one per job.
         max_workers: Maximum number of worker processes.
+        show_progress: Whether to show a progress bar.
         desc: Description to display in the tqdm progress bar.
         total: Expected total jobs for progress bar.
             Defaults to ``len(args)`` if None.
@@ -326,7 +328,7 @@ def _run_backend_parallel(
             initializer=_limit_worker_threads,
             initargs=(1,),  # enforce 1 thread per worker
         ) as ex,
-        tqdm(total=total, desc=desc, ncols=80) as pbar,
+        tqdm(total=total, desc=desc, ncols=80, disable=show_progress) as pbar,
     ):
         # Retry bookkeeping per index
         retries = dict.fromkeys(range(len(args)), 0)

--- a/tests/analog/test_analog_tjm.py
+++ b/tests/analog/test_analog_tjm.py
@@ -68,6 +68,7 @@ def test_initialize() -> None:
         max_bond_dim=2,
         threshold=1e-6,
         order=1,
+        show_progress=False
     )
     with (
         patch("mqt.yaqs.analog.analog_tjm.apply_dissipation") as mock_dissipation,
@@ -103,6 +104,7 @@ def test_step_through() -> None:
         max_bond_dim=2,
         threshold=1e-6,
         order=1,
+        show_progress=False
     )
     with (
         patch("mqt.yaqs.analog.analog_tjm.local_dynamic_tdvp") as mock_dynamic_tdvp,
@@ -139,6 +141,7 @@ def test_analog_tjm_2() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=2,
+        show_progress=False
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_2(args)
@@ -169,6 +172,7 @@ def test_analog_tjm_2_sample_timesteps() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=2,
+        show_progress=False
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_2(args)
@@ -199,6 +203,7 @@ def test_analog_tjm_1() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=1,
+        show_progress=False
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_1(args)
@@ -229,6 +234,7 @@ def test_analog_tjm_1_sample_timesteps() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=1,
+        show_progress=False
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_1(args)
@@ -274,6 +280,7 @@ def test_analog_simulation_twositeprocesses() -> None:
         order=2,
         sample_timesteps=True,
         get_state=False,
+        show_progress=False
     )
 
     # Setup noise model with single-site and two-site crosstalk processes
@@ -402,6 +409,7 @@ def test_analog_simulation_two_site_lowering_against_qutip() -> None:
         order=2,
         sample_timesteps=True,
         get_state=False,
+        show_progress=False
     )
 
     gamma_single = 0.02

--- a/tests/analog/test_analog_tjm.py
+++ b/tests/analog/test_analog_tjm.py
@@ -68,7 +68,7 @@ def test_initialize() -> None:
         max_bond_dim=2,
         threshold=1e-6,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     with (
         patch("mqt.yaqs.analog.analog_tjm.apply_dissipation") as mock_dissipation,
@@ -104,7 +104,7 @@ def test_step_through() -> None:
         max_bond_dim=2,
         threshold=1e-6,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     with (
         patch("mqt.yaqs.analog.analog_tjm.local_dynamic_tdvp") as mock_dynamic_tdvp,
@@ -141,7 +141,7 @@ def test_analog_tjm_2() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=2,
-        show_progress=False
+        show_progress=False,
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_2(args)
@@ -172,7 +172,7 @@ def test_analog_tjm_2_sample_timesteps() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=2,
-        show_progress=False
+        show_progress=False,
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_2(args)
@@ -203,7 +203,7 @@ def test_analog_tjm_1() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_1(args)
@@ -234,7 +234,7 @@ def test_analog_tjm_1_sample_timesteps() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     args = (0, state, noise_model, sim_params, H)
     results = analog_tjm_1(args)
@@ -280,7 +280,7 @@ def test_analog_simulation_twositeprocesses() -> None:
         order=2,
         sample_timesteps=True,
         get_state=False,
-        show_progress=False
+        show_progress=False,
     )
 
     # Setup noise model with single-site and two-site crosstalk processes
@@ -409,7 +409,7 @@ def test_analog_simulation_two_site_lowering_against_qutip() -> None:
         order=2,
         sample_timesteps=True,
         get_state=False,
-        show_progress=False
+        show_progress=False,
     )
 
     gamma_single = 0.02

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -783,7 +783,9 @@ def test_convert_to_vector_fidelity() -> None:
     threshold = 0
     window_size = 0
     measurements = [Observable(Z(), site) for site in range(num_qubits)]
-    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True, show_progress=False)
+    sim_params = StrongSimParams(
+        measurements, N, max_bond_dim, threshold, window_size, get_state=True, show_progress=False
+    )
     noise_model = None
     simulator.run(state, circ, sim_params, noise_model)
     assert sim_params.output_state is not None
@@ -811,7 +813,9 @@ def test_convert_to_vector_fidelity_long_range() -> None:
     threshold = 0
     window_size = 0
     measurements = [Observable(Z(), site) for site in range(num_qubits)]
-    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True, show_progress=False)
+    sim_params = StrongSimParams(
+        measurements, N, max_bond_dim, threshold, window_size, get_state=True, show_progress=False
+    )
     noise_model = None
     simulator.run(state, circ, sim_params, noise_model)
     assert sim_params.output_state is not None
@@ -1159,7 +1163,9 @@ def test_evaluate_observables_meta_validation_errors() -> None:
     mps = _product_state_mps(4)
 
     # Wrong length (entropy expects exactly two adjacent indices)
-    sim_bad_len = AnalogSimParams([Observable(GateLibrary.entropy(), [1])], elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False)
+    sim_bad_len = AnalogSimParams(
+        [Observable(GateLibrary.entropy(), [1])], elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False
+    )
     results_len: NDArray[np.object_] = np.empty((1, 1), dtype=object)
     with pytest.raises(AssertionError):
         mps.evaluate_observables(sim_bad_len, results_len, column_index=0)

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -783,7 +783,7 @@ def test_convert_to_vector_fidelity() -> None:
     threshold = 0
     window_size = 0
     measurements = [Observable(Z(), site) for site in range(num_qubits)]
-    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True)
+    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True, show_progress=False)
     noise_model = None
     simulator.run(state, circ, sim_params, noise_model)
     assert sim_params.output_state is not None
@@ -811,7 +811,7 @@ def test_convert_to_vector_fidelity_long_range() -> None:
     threshold = 0
     window_size = 0
     measurements = [Observable(Z(), site) for site in range(num_qubits)]
-    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True)
+    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True, show_progress=False)
     noise_model = None
     simulator.run(state, circ, sim_params, noise_model)
     assert sim_params.output_state is not None
@@ -1094,7 +1094,7 @@ def test_evaluate_observables_diagnostics_and_meta_then_pvm_separately() -> None
         Observable(GateLibrary.entropy(), [1, 2]),
         Observable(GateLibrary.schmidt_spectrum(), [1, 2]),
     ]
-    sim_diag = AnalogSimParams(diagnostics_and_meta, elapsed_time=0.0, dt=0.1, num_traj=1)
+    sim_diag = AnalogSimParams(diagnostics_and_meta, elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False)
 
     results_diag: NDArray[np.object_] = np.empty((len(diagnostics_and_meta), 2), dtype=object)
     mps.evaluate_observables(sim_diag, results_diag, column_index=0)
@@ -1118,7 +1118,7 @@ def test_evaluate_observables_diagnostics_and_meta_then_pvm_separately() -> None
 
     # ---- PVM ONLY (no mixing) ----
     pvm_only = [Observable(GateLibrary.pvm("0000"), 0)]
-    sim_pvm = AnalogSimParams(pvm_only, elapsed_time=0.0, dt=0.1, num_traj=1)
+    sim_pvm = AnalogSimParams(pvm_only, elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False)
 
     results_pvm: NDArray[np.object_] = np.empty((len(pvm_only), 1), dtype=object)
     mps.evaluate_observables(sim_pvm, results_pvm, column_index=0)
@@ -1142,7 +1142,7 @@ def test_evaluate_observables_local_ops_and_center_shifts() -> None:
         Observable(GateLibrary.x(), 2),
         Observable(GateLibrary.z(), 3),
     ]
-    sim_params = AnalogSimParams(obs_seq, elapsed_time=0.0, dt=0.1, num_traj=1)
+    sim_params = AnalogSimParams(obs_seq, elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False)
 
     results: NDArray[np.object_] = np.empty((len(obs_seq), 3), dtype=object)
     mps.evaluate_observables(sim_params, results, column_index=2)
@@ -1159,14 +1159,14 @@ def test_evaluate_observables_meta_validation_errors() -> None:
     mps = _product_state_mps(4)
 
     # Wrong length (entropy expects exactly two adjacent indices)
-    sim_bad_len = AnalogSimParams([Observable(GateLibrary.entropy(), [1])], elapsed_time=0.0, dt=0.1, num_traj=1)
+    sim_bad_len = AnalogSimParams([Observable(GateLibrary.entropy(), [1])], elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False)
     results_len: NDArray[np.object_] = np.empty((1, 1), dtype=object)
     with pytest.raises(AssertionError):
         mps.evaluate_observables(sim_bad_len, results_len, column_index=0)
 
     # Non-adjacent Schmidt cut
     sim_non_adj = AnalogSimParams(
-        [Observable(GateLibrary.schmidt_spectrum(), [0, 2])], elapsed_time=0.0, dt=0.1, num_traj=1
+        [Observable(GateLibrary.schmidt_spectrum(), [0, 2])], elapsed_time=0.0, dt=0.1, num_traj=1, show_progress=False
     )
     results_adj: NDArray[np.object_] = np.empty((1, 1), dtype=object)
     with pytest.raises(AssertionError):

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -54,7 +54,7 @@ def test_analog_simparams_basic() -> None:
     obs_list = [Observable(X(), 0)]
     elapsed_time = 1.0
     dt = 0.2
-    params = AnalogSimParams(obs_list, elapsed_time, dt=dt, sample_timesteps=True, num_traj=50)
+    params = AnalogSimParams(obs_list, elapsed_time, dt=dt, sample_timesteps=True, num_traj=50, show_progress=False)
 
     assert params.observables == obs_list
     assert params.elapsed_time == elapsed_time
@@ -74,7 +74,7 @@ def test_analog_simparams_defaults() -> None:
     """
     obs_list: list[Observable] = []
     elapsed_time = 2.0
-    params = AnalogSimParams(obs_list, elapsed_time)
+    params = AnalogSimParams(obs_list, elapsed_time, show_progress=False)
 
     assert params.observables == obs_list
     assert params.elapsed_time == 2.0
@@ -96,7 +96,7 @@ def test_observable_initialize_with_sample_timesteps() -> None:
     trajectories array has shape (num_traj, len(times)).
     """
     obs = Observable(X(), 1)
-    sim_params = AnalogSimParams([obs], elapsed_time=1.0, dt=0.5, sample_timesteps=True, num_traj=10)
+    sim_params = AnalogSimParams([obs], elapsed_time=1.0, dt=0.5, sample_timesteps=True, num_traj=10, show_progress=False)
     # sim_params.times => [0.0, 0.5, 1.0]
 
     obs.initialize(sim_params)
@@ -114,7 +114,7 @@ def test_observable_initialize_without_sample_timesteps() -> None:
     has shape (num_traj, 1), and that the observable's times attribute is set to elapsed_time.
     """
     obs = Observable(X(), 0)
-    sim_params = AnalogSimParams([obs], elapsed_time=1.0, dt=0.25, sample_timesteps=False, num_traj=5)
+    sim_params = AnalogSimParams([obs], elapsed_time=1.0, dt=0.25, sample_timesteps=False, num_traj=5, show_progress=False)
     # times => [0.0, 0.25, 0.5, 0.75, 1.0]
 
     obs.initialize(sim_params)
@@ -207,7 +207,7 @@ def test_aggregate_trajectories_regular_observable_mean() -> None:
     z_obs.trajectories = traj
 
     # Params (no PVM mixing, so just this observable)
-    sim = AnalogSimParams([z_obs], elapsed_time=0.2, dt=0.1, num_traj=2)
+    sim = AnalogSimParams([z_obs], elapsed_time=0.2, dt=0.1, num_traj=2, show_progress=False)
 
     sim.aggregate_trajectories()
 
@@ -230,7 +230,7 @@ def test_aggregate_trajectories_schmidt_concatenation() -> None:
     c = np.array([0.2, 0.1], dtype=np.float64)  # will ravel to [0.2, 0.1]
     ss_obs.trajectories = np.array([a, b, c])
 
-    sim = AnalogSimParams([ss_obs], elapsed_time=0.1, dt=0.1, num_traj=3)
+    sim = AnalogSimParams([ss_obs], elapsed_time=0.1, dt=0.1, num_traj=3, show_progress=False)
 
     sim.aggregate_trajectories()
 
@@ -248,7 +248,7 @@ def test_aggregate_trajectories_mixed_regular_and_schmidt() -> None:
     ss_obs = Observable(GateLibrary.schmidt_spectrum(), sites=[0, 1])
     ss_obs.trajectories = np.array([np.array([1.0, 0.5], dtype=np.float64), np.array([0.5, 0.25], dtype=np.float64)])
 
-    sim = AnalogSimParams([x_obs, ss_obs], elapsed_time=0.2, dt=0.1, num_traj=3)
+    sim = AnalogSimParams([x_obs, ss_obs], elapsed_time=0.2, dt=0.1, num_traj=3, show_progress=False)
 
     sim.aggregate_trajectories()
 
@@ -266,7 +266,7 @@ def test_aggregate_trajectories_schmidt_requires_array() -> None:
     # Wrong type: a single ndarray (method expects list[...] and asserts)
     ss_obs.trajectories = [0.9, 0.1]
 
-    sim = AnalogSimParams([ss_obs], elapsed_time=0.1, dt=0.1, num_traj=1)
+    sim = AnalogSimParams([ss_obs], elapsed_time=0.1, dt=0.1, num_traj=1, show_progress=False)
 
     with pytest.raises(AssertionError):
         sim.aggregate_trajectories()
@@ -296,6 +296,7 @@ def test_strong_params_sorting_and_fields() -> None:
         get_state=True,
         sample_layers=True,
         num_mid_measurements=2,
+        show_progress=False
     )
 
     # Expect sortable by site: y@1, x@2, z@3 then diagnostics/meta in given order
@@ -353,7 +354,7 @@ def test_strong_aggregate_regular_mean() -> None:
     )
     x.trajectories = traj
 
-    params = StrongSimParams([x], num_traj=3)
+    params = StrongSimParams([x], num_traj=3, show_progress=False)
     params.aggregate_trajectories()
 
     assert isinstance(x.results, np.ndarray)

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -96,7 +96,9 @@ def test_observable_initialize_with_sample_timesteps() -> None:
     trajectories array has shape (num_traj, len(times)).
     """
     obs = Observable(X(), 1)
-    sim_params = AnalogSimParams([obs], elapsed_time=1.0, dt=0.5, sample_timesteps=True, num_traj=10, show_progress=False)
+    sim_params = AnalogSimParams(
+        [obs], elapsed_time=1.0, dt=0.5, sample_timesteps=True, num_traj=10, show_progress=False
+    )
     # sim_params.times => [0.0, 0.5, 1.0]
 
     obs.initialize(sim_params)
@@ -114,7 +116,9 @@ def test_observable_initialize_without_sample_timesteps() -> None:
     has shape (num_traj, 1), and that the observable's times attribute is set to elapsed_time.
     """
     obs = Observable(X(), 0)
-    sim_params = AnalogSimParams([obs], elapsed_time=1.0, dt=0.25, sample_timesteps=False, num_traj=5, show_progress=False)
+    sim_params = AnalogSimParams(
+        [obs], elapsed_time=1.0, dt=0.25, sample_timesteps=False, num_traj=5, show_progress=False
+    )
     # times => [0.0, 0.25, 0.5, 0.75, 1.0]
 
     obs.initialize(sim_params)
@@ -296,7 +300,7 @@ def test_strong_params_sorting_and_fields() -> None:
         get_state=True,
         sample_layers=True,
         num_mid_measurements=2,
-        show_progress=False
+        show_progress=False,
     )
 
     # Expect sortable by site: y@1, x@2, z@3 then diagnostics/meta in given order

--- a/tests/core/methods/test_bug.py
+++ b/tests/core/methods/test_bug.py
@@ -231,7 +231,7 @@ def test_local_update() -> None:
     right_block = np.eye(5).reshape(5, 1, 5)
     site = 2
     right_m_block = np.eye(5)
-    sim_params = AnalogSimParams(observables=[], elapsed_time=1)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=1, show_progress=False)
     # Perform the local update
     result = local_update(
         mps, mpo, left_envs, right_block, canon_sites, site, right_m_block, sim_params, numiter_lanczos=25
@@ -256,7 +256,7 @@ def test_bug_single_site() -> None:
     mpo = MPO()
     mpo.init_ising(1, 1, 0.5)
     ref_mpo = deepcopy(mpo)
-    sim_params = AnalogSimParams(observables=[], elapsed_time=1, threshold=1e-16, max_bond_dim=10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=1, threshold=1e-16, max_bond_dim=10, show_progress=False)
     # Perform BUG
     bug(mps, mpo, sim_params, numiter_lanczos=25)
     # Check against exact evolution
@@ -274,7 +274,7 @@ def test_bug_three_sites() -> None:
     mpo = MPO()
     mpo.init_ising(3, 1, 0.5)
     ref_mpo = deepcopy(mpo)
-    sim_params = AnalogSimParams(observables=[], elapsed_time=1, threshold=1e-16, max_bond_dim=10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=1, threshold=1e-16, max_bond_dim=10, show_progress=False)
     # Perform BUG
     bug(mps, mpo, sim_params, numiter_lanczos=25)
     # Check against exact evolution

--- a/tests/core/methods/test_decompositions.py
+++ b/tests/core/methods/test_decompositions.py
@@ -132,6 +132,7 @@ def test_truncated_right_svd_thresh() -> None:
         max_bond_dim=4,
         threshold=0.2,
         order=1,
+        show_progress=False
     )
     s_vector_i = np.array([1, 0.5, 0.1, 0.01])
     u_tensor_i, _ = right_qr(crandn(2, 3, 4))
@@ -163,6 +164,7 @@ def test_truncated_right_svd_maxbd() -> None:
         max_bond_dim=3,
         threshold=1e-4,
         order=1,
+        show_progress=False
     )
 
     s_vector_i = np.array([1, 0.5, 0.1, 0.01])

--- a/tests/core/methods/test_decompositions.py
+++ b/tests/core/methods/test_decompositions.py
@@ -132,7 +132,7 @@ def test_truncated_right_svd_thresh() -> None:
         max_bond_dim=4,
         threshold=0.2,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     s_vector_i = np.array([1, 0.5, 0.1, 0.01])
     u_tensor_i, _ = right_qr(crandn(2, 3, 4))
@@ -164,7 +164,7 @@ def test_truncated_right_svd_maxbd() -> None:
         max_bond_dim=3,
         threshold=1e-4,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
 
     s_vector_i = np.array([1, 0.5, 0.1, 0.01])

--- a/tests/core/methods/test_dissipation.py
+++ b/tests/core/methods/test_dissipation.py
@@ -44,7 +44,7 @@ def test_apply_dissipation_one_site_canonical_0() -> None:
         {"name": name, "sites": [i], "strength": 0.1} for i in range(length) for name in ["lowering", "pauli_z"]
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10, show_progress=False)
 
     apply_dissipation(state, noise_model, dt, sim_params)
 
@@ -81,7 +81,7 @@ def test_apply_dissipation_two_site_canonical_0() -> None:
         for name in ["crosstalk_xx", "crosstalk_yy"]
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10, show_progress=False)
 
     apply_dissipation(state, noise_model, dt, sim_params)
 

--- a/tests/core/methods/test_dissipation.py
+++ b/tests/core/methods/test_dissipation.py
@@ -44,7 +44,9 @@ def test_apply_dissipation_one_site_canonical_0() -> None:
         {"name": name, "sites": [i], "strength": 0.1} for i in range(length) for name in ["lowering", "pauli_z"]
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10, show_progress=False)
+    sim_params = AnalogSimParams(
+        observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10, show_progress=False
+    )
 
     apply_dissipation(state, noise_model, dt, sim_params)
 
@@ -81,7 +83,9 @@ def test_apply_dissipation_two_site_canonical_0() -> None:
         for name in ["crosstalk_xx", "crosstalk_yy"]
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10, show_progress=False)
+    sim_params = AnalogSimParams(
+        observables=[], elapsed_time=0.0, max_bond_dim=10, threshold=1e-10, show_progress=False
+    )
 
     apply_dissipation(state, noise_model, dt, sim_params)
 

--- a/tests/core/methods/test_stochastic_process.py
+++ b/tests/core/methods/test_stochastic_process.py
@@ -107,7 +107,7 @@ def test_create_probability_distribution_no_noise() -> None:
     state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)])
     noise_model = NoiseModel([])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10, show_progress=False)
     probabilities = create_probability_distribution(state, noise_model, dt, sim_params)
     assert len(probabilities) == 0, "No probabilities should be computed with empty noise model."
 
@@ -126,7 +126,7 @@ def test_create_probability_distribution_one_site() -> None:
         {"name": "lowering", "sites": [1], "strength": 0.5, "matrix": id_op},
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10, show_progress=False)
     probabilities = create_probability_distribution(state, noise_model, dt, sim_params)
     # One applicable process
     assert len(probabilities) == 1
@@ -147,7 +147,7 @@ def test_stochastic_process_no_jump() -> None:
     state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)])
     noise_model = None
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10, show_progress=False)
     new_state = stochastic_process(state, noise_model, dt, sim_params)
     # Should still be the same type
     assert isinstance(new_state, MPS)
@@ -168,7 +168,7 @@ def test_stochastic_process_jump() -> None:
         {"name": "pauli_x", "sites": [0], "strength": 1000.0},
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10, show_progress=False)
     state_copy = copy.deepcopy(state)
     new_state = stochastic_process(state_copy, noise_model, dt, sim_params)
     # Should still be the same type
@@ -192,7 +192,7 @@ def test_create_probability_distribution_two_site() -> None:
         {"name": "crosstalk_xx", "sites": [0, 1], "strength": 0.2},
     ])
     dt = 0.1
-    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10)
+    sim_params = AnalogSimParams(observables=[], elapsed_time=0.0, max_bond_dim=5, threshold=1e-10, show_progress=False)
     probabilities = create_probability_distribution(state, noise_model, dt, sim_params)
     # One applicable process
     assert len(probabilities) == 1

--- a/tests/core/methods/test_tdvp.py
+++ b/tests/core/methods/test_tdvp.py
@@ -77,7 +77,7 @@ def test_split_mps_tensor_left_right_sqrt() -> None:
         max_bond_dim=100,
         threshold=1e-16,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     physical_dimensions = [A.shape[0] // 2, A.shape[0] // 2]
     for distr in ["left", "right", "sqrt"]:
@@ -115,7 +115,7 @@ def test_split_mps_tensor_invalid_shape() -> None:
         max_bond_dim=100,
         threshold=1e-8,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     physical_dimensions = [3, 3]
     with pytest.raises(
@@ -263,7 +263,7 @@ def test_single_site_tdvp() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     single_site_tdvp(state, H, sim_params, numiter_lanczos=5)
     assert state.length == L
@@ -299,7 +299,7 @@ def test_two_site_tdvp() -> None:
         max_bond_dim=16,
         threshold=1e-12,
         order=1,
-        show_progress=False
+        show_progress=False,
     )
     two_site_tdvp(state, H, sim_params, numiter_lanczos=25)
     assert state.length == L
@@ -358,7 +358,7 @@ def test_dynamic_tdvp_one_site() -> None:
         threshold,
         order,
         sample_timesteps=sample_timesteps,
-        show_progress=False
+        show_progress=False,
     )
 
     with patch("mqt.yaqs.core.methods.tdvp.single_site_tdvp") as mock_single_site:
@@ -405,7 +405,7 @@ def test_dynamic_tdvp_two_site() -> None:
         threshold,
         order,
         sample_timesteps=sample_timesteps,
-        show_progress=False
+        show_progress=False,
     )
 
     with patch("mqt.yaqs.core.methods.tdvp.two_site_tdvp") as mock_two_site:

--- a/tests/core/methods/test_tdvp.py
+++ b/tests/core/methods/test_tdvp.py
@@ -77,6 +77,7 @@ def test_split_mps_tensor_left_right_sqrt() -> None:
         max_bond_dim=100,
         threshold=1e-16,
         order=1,
+        show_progress=False
     )
     physical_dimensions = [A.shape[0] // 2, A.shape[0] // 2]
     for distr in ["left", "right", "sqrt"]:
@@ -114,6 +115,7 @@ def test_split_mps_tensor_invalid_shape() -> None:
         max_bond_dim=100,
         threshold=1e-8,
         order=1,
+        show_progress=False
     )
     physical_dimensions = [3, 3]
     with pytest.raises(
@@ -261,6 +263,7 @@ def test_single_site_tdvp() -> None:
         max_bond_dim=4,
         threshold=1e-6,
         order=1,
+        show_progress=False
     )
     single_site_tdvp(state, H, sim_params, numiter_lanczos=5)
     assert state.length == L
@@ -296,6 +299,7 @@ def test_two_site_tdvp() -> None:
         max_bond_dim=16,
         threshold=1e-12,
         order=1,
+        show_progress=False
     )
     two_site_tdvp(state, H, sim_params, numiter_lanczos=25)
     assert state.length == L
@@ -354,6 +358,7 @@ def test_dynamic_tdvp_one_site() -> None:
         threshold,
         order,
         sample_timesteps=sample_timesteps,
+        show_progress=False
     )
 
     with patch("mqt.yaqs.core.methods.tdvp.single_site_tdvp") as mock_single_site:
@@ -400,6 +405,7 @@ def test_dynamic_tdvp_two_site() -> None:
         threshold,
         order,
         sample_timesteps=sample_timesteps,
+        show_progress=False
     )
 
     with patch("mqt.yaqs.core.methods.tdvp.two_site_tdvp") as mock_two_site:

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -206,7 +206,7 @@ def test_apply_two_qubit_gate() -> None:
     threshold = 1e-12
     min_bond_dim = 2
     observable = Observable(Z(), 0)
-    sim_params = StrongSimParams([observable], num_traj, max_bond_dim, min_bond_dim, threshold)
+    sim_params = StrongSimParams([observable], num_traj, max_bond_dim, min_bond_dim, threshold, show_progress=False)
     copy.deepcopy(mps0.tensors)
     apply_two_qubit_gate(mps0, node, sim_params)
     mps0.normalize(decomposition="SVD")
@@ -374,7 +374,7 @@ def test_digital_tjm_strong() -> None:
     min_bond_dim = 2
     threshold = 1e-12
     observable = Observable(Z(), 0)
-    sim_params = StrongSimParams([observable], num_traj, max_bond_dim, min_bond_dim, threshold)
+    sim_params = StrongSimParams([observable], num_traj, max_bond_dim, min_bond_dim, threshold, show_progress=False)
     args = 0, mps0, None, sim_params, qc
     digital_tjm(args)
 
@@ -396,7 +396,7 @@ def test_digital_tjm_weak() -> None:
     min_bond_dim = 2
     threshold = 1e-12
     shots = 10
-    sim_params = WeakSimParams(shots, max_bond_dim, min_bond_dim, threshold)
+    sim_params = WeakSimParams(shots, max_bond_dim, min_bond_dim, threshold, show_progress=False)
     args = 0, mps0, None, sim_params, qc
     digital_tjm(args)
 
@@ -445,7 +445,7 @@ def test_noisy_digital_tjm_matches_reference() -> None:
     qc.rzz(0.5, 1, 2)
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
-    sim_params = StrongSimParams(observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=4)
+    sim_params = StrongSimParams(observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=4, show_progress=False)
     state = MPS(num_qubits, state="zeros", pad=2)
     simulator.run(state, qc, sim_params, noise_model, parallel=False)
 
@@ -510,7 +510,7 @@ def test_digital_tjm_longrange_noise() -> None:
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
     sim_params = StrongSimParams(
-        observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=num_layers - 1
+        observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=num_layers - 1, show_progress=False
     )
     state = MPS(num_qubits, state="zeros", pad=2)
     simulator.run(state, qc, sim_params, noise_model, parallel=False)
@@ -542,7 +542,7 @@ def test_no_mid_measurements_results_have_two_columns() -> None:
     qc.rzz(0.1, 1, 2)
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
-    sim_params = StrongSimParams(observables, num_traj=1, sample_layers=True)
+    sim_params = StrongSimParams(observables, num_traj=1, sample_layers=True, show_progress=False)
     state = MPS(num_qubits, state="zeros")
 
     simulator.run(state, qc, sim_params, noise_model=None, parallel=False)
@@ -576,7 +576,7 @@ def test_counts_multiple_mid_measurement_barriers() -> None:
     qc.cx(2, 3)
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
-    sim_params = StrongSimParams(observables, num_traj=1, sample_layers=True)
+    sim_params = StrongSimParams(observables, num_traj=1, sample_layers=True, show_progress=False)
     state = MPS(num_qubits, state="zeros")
 
     simulator.run(state, qc, sim_params, noise_model=None, parallel=False)
@@ -606,7 +606,7 @@ def test_ignores_non_mid_barriers_and_handles_measures() -> None:
     qc.rzz(0.2, 0, 1)
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
-    sim_params = StrongSimParams(observables, num_traj=1, sample_layers=True)
+    sim_params = StrongSimParams(observables, num_traj=1, sample_layers=True, show_progress=False)
     state = MPS(num_qubits, state="zeros")
 
     simulator.run(state, qc, sim_params, noise_model=None, parallel=False)

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -445,7 +445,9 @@ def test_noisy_digital_tjm_matches_reference() -> None:
     qc.rzz(0.5, 1, 2)
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
-    sim_params = StrongSimParams(observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=4, show_progress=False)
+    sim_params = StrongSimParams(
+        observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=4, show_progress=False
+    )
     state = MPS(num_qubits, state="zeros", pad=2)
     simulator.run(state, qc, sim_params, noise_model, parallel=False)
 
@@ -510,7 +512,11 @@ def test_digital_tjm_longrange_noise() -> None:
 
     observables = [Observable(Z(), i) for i in range(num_qubits)]
     sim_params = StrongSimParams(
-        observables=observables, num_traj=num_traj, sample_layers=True, num_mid_measurements=num_layers - 1, show_progress=False
+        observables=observables,
+        num_traj=num_traj,
+        sample_layers=True,
+        num_mid_measurements=num_layers - 1,
+        show_progress=False,
     )
     state = MPS(num_qubits, state="zeros", pad=2)
     simulator.run(state, qc, sim_params, noise_model, parallel=False)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -86,7 +86,15 @@ def test_analog_simulation() -> None:
 
     measurements = [Observable(Z(), site) for site in range(length)]
     sim_params = AnalogSimParams(
-        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps, show_progress=False
+        measurements,
+        elapsed_time,
+        dt,
+        num_traj,
+        max_bond_dim,
+        threshold,
+        order,
+        sample_timesteps=sample_timesteps,
+        show_progress=False,
     )
     gamma = 0.1
     noise_model = NoiseModel([
@@ -138,7 +146,15 @@ def test_analog_simulation_parallel_off() -> None:
 
     measurements = [Observable(Z(), [site]) for site in range(length)]
     sim_params = AnalogSimParams(
-        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps, show_progress=False
+        measurements,
+        elapsed_time,
+        dt,
+        num_traj,
+        max_bond_dim,
+        threshold,
+        order,
+        sample_timesteps=sample_timesteps,
+        show_progress=False,
     )
     gamma = 0.1
     noise_model = NoiseModel([
@@ -195,7 +211,7 @@ def test_analog_simulation_get_state() -> None:
             order,
             sample_timesteps=sample_timesteps,
             get_state=True,
-            show_progress=False
+            show_progress=False,
         )
         simulator.run(initial_state, H, sim_params)
         assert sim_params.output_state is not None
@@ -267,7 +283,9 @@ def test_strong_simulation_no_noise() -> None:
 
     state = MPS(length=num_qubits)
     measurements = [Observable(X(), num_qubits // 2)]
-    sim_params = StrongSimParams(measurements, num_traj=1, max_bond_dim=16, threshold=1e-12, get_state=True, show_progress=False)
+    sim_params = StrongSimParams(
+        measurements, num_traj=1, max_bond_dim=16, threshold=1e-12, get_state=True, show_progress=False
+    )
     simulator.run(state, circ, sim_params)
     assert sim_params.output_state is not None
     assert isinstance(sim_params.output_state, MPS)
@@ -483,7 +501,7 @@ def test_two_site_correlator_left_boundary() -> None:
         dt=dt,
         max_bond_dim=max_bond_dim,
         sample_timesteps=sample_timesteps,
-        show_progress=False
+        show_progress=False,
     )
 
     simulator.run(state, H_0, sim_params)
@@ -655,7 +673,7 @@ def test_two_site_correlator_center() -> None:
         dt=dt,
         max_bond_dim=max_bond_dim,
         sample_timesteps=sample_timesteps,
-        show_progress=False
+        show_progress=False,
     )
 
     simulator.run(state, H_0, sim_params)
@@ -823,7 +841,7 @@ def test_two_site_correlator_right_boundary() -> None:
         dt=dt,
         max_bond_dim=max_bond_dim,
         sample_timesteps=sample_timesteps,
-        show_progress=False
+        show_progress=False,
     )
 
     simulator.run(state, H_0, sim_params)
@@ -1036,7 +1054,15 @@ def test_transmon_simulation() -> None:
     measurements = [Observable(bitstring) for bitstring in ["000", "001", "010", "011", "100", "101", "110", "111"]]
 
     sim_params = AnalogSimParams(
-        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps, show_progress=False
+        measurements,
+        elapsed_time,
+        dt,
+        num_traj,
+        max_bond_dim,
+        threshold,
+        order,
+        sample_timesteps=sample_timesteps,
+        show_progress=False,
     )
     simulator.run(state, H_0, sim_params)
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -86,7 +86,7 @@ def test_analog_simulation() -> None:
 
     measurements = [Observable(Z(), site) for site in range(length)]
     sim_params = AnalogSimParams(
-        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps
+        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps, show_progress=False
     )
     gamma = 0.1
     noise_model = NoiseModel([
@@ -138,7 +138,7 @@ def test_analog_simulation_parallel_off() -> None:
 
     measurements = [Observable(Z(), [site]) for site in range(length)]
     sim_params = AnalogSimParams(
-        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps
+        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps, show_progress=False
     )
     gamma = 0.1
     noise_model = NoiseModel([
@@ -195,6 +195,7 @@ def test_analog_simulation_get_state() -> None:
             order,
             sample_timesteps=sample_timesteps,
             get_state=True,
+            show_progress=False
         )
         simulator.run(initial_state, H, sim_params)
         assert sim_params.output_state is not None
@@ -229,7 +230,7 @@ def test_strong_simulation() -> None:
     max_bond_dim = 4
 
     measurements = [Observable(Z(), site) for site in range(num_qubits)]
-    sim_params = StrongSimParams(measurements, num_traj, max_bond_dim)
+    sim_params = StrongSimParams(measurements, num_traj, max_bond_dim, show_progress=False)
     # Use a noise model that is not None so that sim_params.num_traj remains unchanged.
     gamma = 1e-3
     noise_model = NoiseModel([
@@ -266,7 +267,7 @@ def test_strong_simulation_no_noise() -> None:
 
     state = MPS(length=num_qubits)
     measurements = [Observable(X(), num_qubits // 2)]
-    sim_params = StrongSimParams(measurements, num_traj=1, max_bond_dim=16, threshold=1e-12, get_state=True)
+    sim_params = StrongSimParams(measurements, num_traj=1, max_bond_dim=16, threshold=1e-12, get_state=True, show_progress=False)
     simulator.run(state, circ, sim_params)
     assert sim_params.output_state is not None
     assert isinstance(sim_params.output_state, MPS)
@@ -295,7 +296,7 @@ def test_strong_simulation_parallel_off() -> None:
     max_bond_dim = 4
 
     measurements = [Observable(Z(), site) for site in range(num_qubits)]
-    sim_params = StrongSimParams(measurements, num_traj, max_bond_dim)
+    sim_params = StrongSimParams(measurements, num_traj, max_bond_dim, show_progress=False)
     # Use a noise model that is not None so that sim_params.num_traj remains unchanged.
     gamma = 1e-3
     noise_model = NoiseModel([
@@ -337,7 +338,7 @@ def test_weak_simulation_noise() -> None:
     circuit.measure_all()
     shots = 1024
     max_bond_dim = 4
-    sim_params = WeakSimParams(shots, max_bond_dim)
+    sim_params = WeakSimParams(shots, max_bond_dim, show_progress=False)
 
     gamma = 1e-3
     noise_model = NoiseModel([
@@ -367,7 +368,7 @@ def test_weak_simulation_no_noise() -> None:
     circuit.measure_all()
     shots = 1024
     max_bond_dim = 4
-    sim_params = WeakSimParams(shots, max_bond_dim)
+    sim_params = WeakSimParams(shots, max_bond_dim, show_progress=False)
 
     noise_model = None
 
@@ -397,7 +398,7 @@ def test_weak_simulation_get_state() -> None:
     circuit.measure_all()
     shots = 1
     max_bond_dim = 4
-    sim_params = WeakSimParams(shots, max_bond_dim, get_state=True)
+    sim_params = WeakSimParams(shots, max_bond_dim, get_state=True, show_progress=False)
 
     noise_model = None
 
@@ -424,7 +425,7 @@ def test_weak_simulation_get_state_noise() -> None:
     circuit.measure_all()
     shots = 1024
     max_bond_dim = 4
-    sim_params = WeakSimParams(shots, max_bond_dim, get_state=True)
+    sim_params = WeakSimParams(shots, max_bond_dim, get_state=True, show_progress=False)
 
     gamma = 1e-3
     noise_model = NoiseModel([
@@ -449,7 +450,7 @@ def test_mismatch() -> None:
     circuit.measure_all()
     shots = 1024
     max_bond_dim = 4
-    sim_params = WeakSimParams(shots, max_bond_dim)
+    sim_params = WeakSimParams(shots, max_bond_dim, show_progress=False)
 
     noise_model = None
 
@@ -482,6 +483,7 @@ def test_two_site_correlator_left_boundary() -> None:
         dt=dt,
         max_bond_dim=max_bond_dim,
         sample_timesteps=sample_timesteps,
+        show_progress=False
     )
 
     simulator.run(state, H_0, sim_params)
@@ -653,6 +655,7 @@ def test_two_site_correlator_center() -> None:
         dt=dt,
         max_bond_dim=max_bond_dim,
         sample_timesteps=sample_timesteps,
+        show_progress=False
     )
 
     simulator.run(state, H_0, sim_params)
@@ -820,6 +823,7 @@ def test_two_site_correlator_right_boundary() -> None:
         dt=dt,
         max_bond_dim=max_bond_dim,
         sample_timesteps=sample_timesteps,
+        show_progress=False
     )
 
     simulator.run(state, H_0, sim_params)
@@ -980,7 +984,7 @@ def test_two_site_correlator_center_circuit() -> None:
         Observable(YY(), [L // 2, L // 2 + 1]),
         Observable(ZZ(), [L // 2, L // 2 + 1]),
     ]
-    sim_params = StrongSimParams(observables=observables, max_bond_dim=max_bond_dim)
+    sim_params = StrongSimParams(observables=observables, max_bond_dim=max_bond_dim, show_progress=False)
 
     simulator.run(state, circ, sim_params)
 
@@ -1032,7 +1036,7 @@ def test_transmon_simulation() -> None:
     measurements = [Observable(bitstring) for bitstring in ["000", "001", "010", "011", "100", "101", "110", "111"]]
 
     sim_params = AnalogSimParams(
-        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps
+        measurements, elapsed_time, dt, num_traj, max_bond_dim, threshold, order, sample_timesteps=sample_timesteps, show_progress=False
     )
     simulator.run(state, H_0, sim_params)
 


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

This pull requests adds the ability for the user to turn off the progress bar from printing from each type of simulation parameters. Previously, you would need to modify YAQS's code directly to achieve this.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
