### PR TITLE
🍎 Restore support for x86 macOS systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2022]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15-intel,
+            macos-14,
+            windows-2022,
+          ]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
     with:
       runs-on: ${{ matrix.runs-on }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Removed
 
 - 🔥 Drop support for Python 3.9 ([#180]) ([**@denialhaag**])
-- 🔥 Stop testing on x86 macOS systems ([#175]) ([**@denialhaag**])
 
 ## [0.3.0] - 2025-07-04
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,12 +4,6 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
-### End of support for x86 macOS systems
-
-Starting with this release, we can no longer guarantee support for x86 macOS systems.
-This comes as a result of GitHub removing the `macos-13` runners from their infrastructure.
-x86 macOS systems are no longer tested in our CI and we can no longer guarantee that MQT YAQS installs and runs correctly on them.
-
 ### End of support for Python 3.9
 
 Starting with this release, MQT YAQS no longer supports Python 3.9.


### PR DESCRIPTION
## Description

This PR reverts #175, which dropped support for x86 macOS systems. This is because GitHub Actions has introduced a `macos-15-intel` runner, enabling us to test on x86 macOS until August 2027.

Furthermore, this PR improves `nox` sessions that manipulate the lock file to ensure that any potential changes are fully undone.  

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
