### PR TITLE
🔧 Configure `prek` priorities

### DIFF
--- a/.license-tools-config.json
+++ b/.license-tools-config.json
@@ -30,6 +30,6 @@
     "uv\\.lock",
     "py\\.typed",
     ".*build.*",
-    "LICENSE"
+    "(^|/)LICENSE$"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,43 +15,25 @@ ci:
   skip: [ty-check]
 
 repos:
-  # Priority 0: Fast validation and independent fixers
-
   ## Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
+        priority: 0
       - id: end-of-file-fixer
+        priority: 1
       - id: trailing-whitespace
-
-  ## Check the pyproject.toml file
-  - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.04.11
-    hooks:
-      - id: validate-pyproject
+        priority: 2
 
   ## Check JSON schemata
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.1
     hooks:
       - id: check-github-workflows
+        priority: 0
       - id: check-readthedocs
-
-  ## Catch common capitalization mistakes
-  - repo: local
-    hooks:
-      - id: disallow-caps
-        name: Disallow improper capitalization
-        language: pygrep
-        entry: \b(Numpy|Github|PyTest|Mqt|Tum)\b
-        exclude: ^(\.pre-commit-config\.yaml)$
-
-  ## Check for spelling
-  - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.45.0
-    hooks:
-      - id: typos
+        priority: 0
 
   ## Check best practices for scientific Python code
   - repo: https://github.com/scientific-python/cookie
@@ -59,20 +41,47 @@ repos:
     hooks:
       - id: sp-repo-review
         additional_dependencies: ["repo-review[cli]"]
+        priority: 0
 
-  ## Check for license headers
-  - repo: https://github.com/emzeat/mz-lictools
-    rev: v2.9.0
+  ## Check pyproject.toml file
+  - repo: https://github.com/henryiii/validate-pyproject-schema-store
+    rev: 2026.04.11
     hooks:
-      - id: license-tools
+      - id: validate-pyproject
+        priority: 0
 
-  ## Ensure uv lock file is up-to-date
+  ## Ensure uv.lock is up to date
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.6
     hooks:
       - id: uv-lock
+        priority: 0
 
-  ## Tidy up BibTeX files
+  ## Check for common capitalization mistakes
+  - repo: local
+    hooks:
+      - id: disallow-caps
+        name: Disallow improper capitalization
+        language: pygrep
+        entry: \b(Numpy|Github|PyTest|Mqt|Tum)\b
+        exclude: ^(\.pre-commit-config\.yaml)$
+        priority: 0
+
+  ## Check for typos
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.45.1
+    hooks:
+      - id: typos
+        priority: 3
+
+  ## Check license headers
+  - repo: https://github.com/emzeat/mz-lictools
+    rev: v2.9.0
+    hooks:
+      - id: license-tools
+        priority: 4
+
+  ## Format BibTeX files with bibtex-tidy
   - repo: https://github.com/FlamingTempura/bibtex-tidy
     rev: v1.14.0
     hooks:
@@ -89,35 +98,36 @@ repos:
             "--trailing-commas",
             "--remove-empty-fields",
           ]
-
-  # Priority 1: Second-pass fixers
+        priority: 5
 
   ## Format configuration files with prettier
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.2
+    rev: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json, json5]
+        priority: 5
 
-  ## Python linting using ruff
+  ## Format and lint Python files with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.11
     hooks:
       - id: ruff-format
         types_or: [python, pyi, jupyter, markdown]
+        priority: 6
       - id: ruff-check
         require_serial: true
+        priority: 7
 
-  # Priority 2+: Final checks and fixers
-
-  ## Static type checking using ty (needs to run after lockfile update/ruff format, and ruff lint)
+  ## Check Python types with ty
   - repo: local
     hooks:
       - id: ty-check
         name: ty check
         entry: uv run ty check
-        language: system
+        language: unsupported
         require_serial: true
         types_or: [python, pyi, jupyter]
         exclude: ^(docs/)
         pass_filenames: false
+        priority: 8


### PR DESCRIPTION
## Description

This PR adapts `.pre-commit-config.yaml` to benefit from `prek`'s priority feature.

`prek` is a drop-in replacement for `pre-commit`. Built in Rust, it is considerably more performant than `pre-commit`. In addition, `prek` provides more features than `pre-commit` (such as the priority feature that makes runs more stable). `pre-commit run -a` continues to work as before, but the command may emit warnings if unknown configuration syntax is encountered. For more information on `prek`, see https://prek.j178.dev/.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
