### PR TITLE
feat: add Haar random MPS initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
-- added `MPS(..., state="haar-random")` initializer using Haar-random isometries with optional bond-dimension cap via `pad`
+- added `MPS(..., state="haar-random")` initializer using Haar-random isometries with optional bond-dimension cap via `pad` ([#400]) ([**@Gauthameshwar**])
 - added process tomography for non-Markovian noise ([#344]) ([**@aaronleesander**])
 - added ability to measure in X or Y basis ([#339]) ([**@aaronleesander**])
 - added Arnoldi iteration as alternative to Lanczos method ([#338]) ([**@aaronleesander**])
@@ -97,6 +97,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 <!-- PR links -->
 
 [#344]: https://github.com/munich-quantum-toolkit/yaqs/pull/344
+[#400]: https://github.com/munich-quantum-toolkit/yaqs/pull/400
 [#339]: https://github.com/munich-quantum-toolkit/yaqs/pull/339
 [#338]: https://github.com/munich-quantum-toolkit/yaqs/pull/338
 [#337]: https://github.com/munich-quantum-toolkit/yaqs/pull/337
@@ -128,6 +129,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 [**@denialhaag**]: https://github.com/denialhaag
 [**@aaronleesander**]: https://github.com/aaronleesander
+[**@Gauthameshwar**]: https://github.com/Gauthameshwar
 [**@thilomueller**]: https://github.com/thilomueller
 [**@lucello**]: https://github.com/lucello
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- added `MPS(..., state="haar-random")` initializer using Haar-random isometries with optional bond-dimension cap via `pad`
 - added process tomography for non-Markovian noise ([#344]) ([**@aaronleesander**])
 - added ability to measure in X or Y basis ([#339]) ([**@aaronleesander**])
 - added Arnoldi iteration as alternative to Lanczos method ([#338]) ([**@aaronleesander**])

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,12 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
+### New `state="haar-random"` MPS initializer
+
+An additional MPS initializer is available: `MPS(..., state="haar-random")`.
+It constructs an entangled MPS from Haar-random isometries and uses `pad` as a bond-dimension cap for this mode.
+If `pad` is not provided, it defaults to bond dimension 1.
+
 ### End of support for x86 macOS systems
 
 Starting with this release, we can no longer guarantee support for x86 macOS systems.

--- a/docs/examples/analog_simulation.md
+++ b/docs/examples/analog_simulation.md
@@ -60,6 +60,8 @@ Define the initial state
 from mqt.yaqs.core.data_structures.networks import MPS
 
 state = MPS(L, state="zeros")
+# Alternative: initialize an entangled random state with capped bond dimension.
+# state = MPS(L, state="haar-random", pad=4)
 ```
 
 Define the noise model

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -229,6 +229,11 @@ class MPS:
 
         # Create d-level |0> state
         if not tensors:
+            haar_bond_cache: dict[str, list[int] | None] | None = None
+            haar_rng_cache: dict[str, np.random.Generator | None] | None = None
+            if state == "haar-random":
+                haar_bond_cache = {"dims": None}
+                haar_rng_cache = {"rng": None}
             for i, d in enumerate(self.physical_dimensions):
                 vector = np.zeros(d, dtype=complex)
                 if state == "zeros":
@@ -271,7 +276,13 @@ class MPS:
                     vector[1] = 1 - vector[0]
                 elif state == "haar-random":
                     target_dim = 1 if pad is None else pad
-                    tensor = _haar_random_tensor_core(i, d, target_dim)
+                    tensor = _haar_random_tensor_core(
+                        i,
+                        d,
+                        target_dim,
+                        _bond_cache=haar_bond_cache,
+                        _rng_cache=haar_rng_cache,
+                    )
                     self.tensors.append(tensor)
                     continue
                 elif state == "basis":

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -102,9 +102,12 @@ class MPS:
                 - "Neel": Alternating pattern |0101...⟩.
                 - "wall": Domain wall at given site |000111>
                 - "random": Initializes each qubit randomly.
+                - "haar-random": Initializes an entangled MPS via Haar-random isometries.
                 - "basis": Initializes a qubit in an input computational basis.
                 Default is "zeros".
             pad: Pads the state with extra zeros to increase bond dimension. Can increase numerical stability.
+                For ``state="haar-random"``, this value is interpreted as the target maximum internal
+                bond dimension χ_max. If omitted, χ_max defaults to 1.
             basis_string: String used to initialize the state in a specific computational basis.
                 This should generally be in the form of 0s and 1s, e.g., "0101" for a 4-qubit state.
                 For mixed-dimensional systems, this can be increased to 2, 3, ... etc.
@@ -131,6 +134,98 @@ class MPS:
         else:
             self.physical_dimensions = physical_dimensions
         assert len(self.physical_dimensions) == length
+
+        def _bond_caps(target_dim: int) -> list[int]:
+            """Compute feasible MPS bond dimensions for a target maximum.
+
+            Args:
+                target_dim: Target maximum internal bond dimension.
+
+            Returns:
+                List of length ``self.length + 1`` with bond dimensions
+                ``[chi_0, ..., chi_L]`` where boundaries satisfy
+                ``chi_0 = chi_L = 1``.
+
+            Raises:
+                ValueError: If ``target_dim < 1``.
+            """
+            if target_dim < 1:
+                msg = "Target bond dimension must be at least 1."
+                raise ValueError(msg)
+            caps = [0] * (self.length + 1)
+            caps[0] = 1
+            caps[self.length] = 1
+
+            # Left-to-right representability cap
+            left_cap = 1
+            for i in range(1, self.length):
+                left_cap *= self.physical_dimensions[i - 1]
+                caps[i] = left_cap
+
+            # Right-to-left representability cap
+            right_cap = 1
+            for i in range(self.length - 1, 0, -1):
+                right_cap *= self.physical_dimensions[i]
+                caps[i] = min(caps[i], right_cap)
+
+            # Apply target cap on internal bonds
+            for i in range(1, self.length):
+                caps[i] = min(caps[i], target_dim)
+
+            return caps
+
+        def _haar_random_tensor_core(
+            site: int,
+            local_dim: int,
+            target_dim: int,
+            *,
+            _bond_cache: dict[str, list[int] | None] | None = None,
+            _rng_cache: dict[str, np.random.Generator | None] | None = None,
+        ) -> NDArray[np.complex128]:
+            """Construct one Haar-random isometric MPS tensor core lazily.
+
+            Args:
+                site: Site index of the tensor core.
+                local_dim: Physical dimension at the site.
+                target_dim: Target maximum internal bond dimension.
+                _bond_cache: Optional cache for lazily computed bond dimensions.
+                _rng_cache: Optional cache for lazily initialized RNG.
+
+            Returns:
+                Tensor core with shape ``(local_dim, chi_l, chi_r)``.
+            """
+            if _rng_cache is None:
+                _rng_cache = {"rng": None}
+            if _bond_cache is None:
+                _bond_cache = {"dims": None}
+            if _bond_cache["dims"] is None:
+                _bond_cache["dims"] = _bond_caps(target_dim)
+            if _rng_cache["rng"] is None:
+                _rng_cache["rng"] = np.random.default_rng()
+
+            bond_dims = _bond_cache["dims"]
+            rng = _rng_cache["rng"]
+            assert bond_dims is not None
+            assert rng is not None
+
+            chi_l = bond_dims[site]
+            chi_r = bond_dims[site + 1]
+            assert chi_r <= local_dim * chi_l, "Invalid bond schedule for Haar-random initialization."
+
+            x_mat = rng.standard_normal((local_dim * chi_l, chi_r)) + 1j * rng.standard_normal((
+                local_dim * chi_l,
+                chi_r,
+            ))
+            q_mat, r_mat = np.linalg.qr(x_mat, mode="reduced")
+
+            # Fix arbitrary QR phases for a well-defined Haar isometry sample.
+            diag = np.diag(r_mat)
+            phases = np.ones_like(diag, dtype=np.complex128)
+            non_zero = np.abs(diag) > 0
+            phases[non_zero] = diag[non_zero] / np.abs(diag[non_zero])
+            q_mat /= phases[np.newaxis, :]
+
+            return q_mat.reshape(local_dim, chi_l, chi_r).astype(np.complex128)
 
         # Create d-level |0> state
         if not tensors:
@@ -174,6 +269,11 @@ class MPS:
                     rng = np.random.default_rng()
                     vector[0] = rng.random()
                     vector[1] = 1 - vector[0]
+                elif state == "haar-random":
+                    target_dim = 1 if pad is None else pad
+                    tensor = _haar_random_tensor_core(i, d, target_dim)
+                    self.tensors.append(tensor)
+                    continue
                 elif state == "basis":
                     assert basis_string is not None, "basis_string must be provided for 'basis' state initialization."
                     self.init_mps_from_basis(basis_string, self.physical_dimensions)
@@ -189,7 +289,7 @@ class MPS:
 
             if state == "random":
                 self.normalize()
-        if pad is not None:
+        if pad is not None and state != "haar-random":
             self.pad_bond_dimension(pad)
 
     def init_mps_from_basis(self, basis_string: str, physical_dimensions: list[int]) -> None:

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -248,6 +248,22 @@ def random_mps(shapes: list[tuple[int, int, int]], *, normalize: bool = True) ->
     return mps
 
 
+def _expected_uniform_clipped_bonds(length: int, chi_max: int) -> list[int]:
+    """Expected qubit bond-dimension schedule for the Haar-random initializer.
+
+    Args:
+        length: Number of sites.
+        chi_max: Maximum internal bond dimension.
+
+    Returns:
+        A list of bond dimensions ``[chi_0, ..., chi_L]`` with open boundaries.
+    """
+    bonds = [1]
+    bonds.extend(min(chi_max, 2 ** min(i, length - i)) for i in range(1, length))
+    bonds.append(1)
+    return bonds
+
+
 rng = np.random.default_rng()
 
 ##############################################################################
@@ -1138,6 +1154,65 @@ def test_pad_raises_on_shrink() -> None:
 
     with pytest.raises(ValueError, match="Target bond dim must be at least current bond dim"):
         mps.pad_bond_dimension(2)  # would shrink - must fail
+
+
+def test_haar_random_shapes_and_isometries() -> None:
+    """Haar-random initializer should produce feasible bonds and site-wise isometries."""
+    length = 8
+    chi_max = 4
+    mps = MPS(length=length, state="haar-random", pad=chi_max)
+    expected = _expected_uniform_clipped_bonds(length, chi_max)
+
+    for i, tensor in enumerate(mps.tensors):
+        d, chi_l, chi_r = tensor.shape
+        assert d == 2
+        assert chi_l == expected[i]
+        assert chi_r == expected[i + 1]
+
+        q_mat = tensor.reshape(d * chi_l, chi_r)
+        ident = np.eye(chi_r, dtype=np.complex128)
+        np.testing.assert_allclose(q_mat.conj().T @ q_mat, ident, atol=1e-12)
+
+    assert np.isclose(mps.norm(), 1.0, atol=1e-12)
+
+
+def test_haar_random_default_pad_is_product_state() -> None:
+    """Without pad, Haar-random defaults to χ_max=1 and should be a product state."""
+    mps = MPS(length=6, state="haar-random")
+    for tensor in mps.tensors:
+        assert tensor.shape[1] == 1
+        assert tensor.shape[2] == 1
+
+    assert np.isclose(mps.get_entropy([2, 3]), 0.0, atol=1e-12)
+
+
+def test_haar_random_entropy_statistics_vs_random_mps() -> None:
+    """Haar-random MPS should show higher mean entropy and lower variance than random tensors."""
+    length = 8
+    chi_max = 4
+    cut = length // 2 - 1
+    num_samples = 120
+
+    bonds = _expected_uniform_clipped_bonds(length, chi_max)
+    shapes = [(2, bonds[i], bonds[i + 1]) for i in range(length)]
+    local_rng = np.random.default_rng(1234)
+
+    rand_entropies = np.empty(num_samples, dtype=np.float64)
+    haar_entropies = np.empty(num_samples, dtype=np.float64)
+
+    for idx in range(num_samples):
+        tensors = [crandn(shape, seed=local_rng) for shape in shapes]
+        rand_state = MPS(length=length, tensors=tensors, physical_dimensions=2)
+        rand_state.normalize()
+        rand_state.set_canonical_form(cut)
+        rand_entropies[idx] = rand_state.get_entropy([cut, cut + 1])
+
+        haar_state = MPS(length=length, state="haar-random", pad=chi_max)
+        haar_state.set_canonical_form(cut)
+        haar_entropies[idx] = haar_state.get_entropy([cut, cut + 1])
+
+    assert float(np.mean(haar_entropies)) > float(np.mean(rand_entropies))
+    assert float(np.std(haar_entropies)) < float(np.std(rand_entropies))
 
 
 @pytest.mark.parametrize("center", [0, 1, 2, 3])

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -1186,6 +1186,12 @@ def test_haar_random_default_pad_is_product_state() -> None:
     assert np.isclose(mps.get_entropy([2, 3]), 0.0, atol=1e-12)
 
 
+def test_haar_random_invalid_pad_raises() -> None:
+    """Haar-random initializer should reject non-positive target bond dimensions."""
+    with pytest.raises(ValueError, match="Target bond dimension must be at least 1"):
+        _ = MPS(length=6, state="haar-random", pad=0)
+
+
 def test_haar_random_entropy_statistics_vs_random_mps() -> None:
     """Haar-random MPS should show higher mean entropy and lower variance than random tensors."""
     length = 8


### PR DESCRIPTION
## Summary
This PR adds a new MPS initialization mode: `state="haar-random"`.
It constructs site-wise Haar-random isometric tensor cores (Ginibre + reduced QR + phase fix), with `pad` interpreted as the bond-dimension cap (`chi_max`) for this mode. The resulting Haar-random MPS shows higher entanglement and tighter concentration than the random-tensor baseline in our finite-χ benchmark. 

> `pad` argument interpreted as the bond dimension cap for this mode. For example, `MPS(L, state="haar-random", pad=4)` will give a Haar-random vector with random isometries of bond dim 4 at each MPS site, and hence, will have entanglement in it. This is not the same as creating a product state and padding zeros to the other bond dimension indices of the MPS. 

## Motivation
We commonly use a Haar-random as the initial state for typicality-style studies. This is distinct from existing product-like random initializations. This will be used for studying unitary trajectories that lead to relaxation dynamics in non-integrable systems.

No dependencies needed for this merge.

## Changes
- `src/mqt/yaqs/core/data_structures/networks.py`
  - Added `state="haar-random"` branch in `MPS.__init__`
  - Added helper for per-site Haar-random core construction
- `tests/core/data_structures/test_networks.py`
  - Added tests for isometry, bond-shape schedule, default behavior, and entropy-statistics comparison
- `docs/examples/analog_simulation.md`
  - Added usage snippet for `state="haar-random"` (just a commented line in the code block)
- `CHANGELOG.md`, `UPGRADING.md`
  - Added user-facing notes

## Reproducible benchmark analysis

```
import numpy as np

from mqt.yaqs.core.data_structures.networks import MPS
from tests.core.data_structures.test_networks import crandn

# ---- Benchmark config ----
L = 8                # number of qubits/sites
bond_dim = 4         # requested bond-dimension cap
num_samples = 300    # decent sample size
cut = L // 2 - 1     # entropy across bond (cut, cut+1)
seed = 20260430
rng = np.random.default_rng(seed)


def expected_uniform_clipped_bonds(length: int, chi_max: int) -> list[int]:
    bonds = [1]
    bonds.extend(min(chi_max, 2 ** min(i, length - i)) for i in range(1, length))
    bonds.append(1)
    return bonds


def random_tensor_mps_entropy() -> float:
    bonds = expected_uniform_clipped_bonds(L, bond_dim)
    shapes = [(2, bonds[i], bonds[i + 1]) for i in range(L)]

    # random complex tensor cores, then normalize to represent a valid state
    tensors = [crandn(shape, seed=rng) for shape in shapes]
    state = MPS(length=L, tensors=tensors, physical_dimensions=2)
    state.normalize()
    state.set_canonical_form(cut)
    return float(state.get_entropy([cut, cut + 1]))


def haar_random_mps_entropy() -> float:
    state = MPS(length=L, state="haar-random", pad=bond_dim)
    state.set_canonical_form(cut)
    return float(state.get_entropy([cut, cut + 1]))


random_vals = np.array([random_tensor_mps_entropy() for _ in range(num_samples)], dtype=np.float64)
haar_vals = np.array([haar_random_mps_entropy() for _ in range(num_samples)], dtype=np.float64)

ln2 = np.log(2.0)

rows = [
    (
        "Random tensor MPS (manual cores)",
        random_vals.mean(),
        random_vals.std(),
        np.median(random_vals),
    ),
    (
        "Haar-random isometry MPS",
        haar_vals.mean(),
        haar_vals.std(),
        np.median(haar_vals),
    ),
]

print(f"L={L}, bond_dim={bond_dim}, cut=({cut},{cut+1}), samples={num_samples}")
print("| Ensemble | Mean entropy (nats) | Std (nats) | Median (nats) | Mean entropy (bits) |")
print("|---|---:|---:|---:|---:|")
for name, mean_nats, std_nats, med_nats in rows:
    print(
        f"| {name} | {mean_nats:.6f} | {std_nats:.6f} | {med_nats:.6f} | {mean_nats/ln2:.6f} |"
    )
```
For `L=8`, `bond_dim=4`, `cut (3,4)`, `samples=300`:

| Ensemble                          | Mean entropy (nats) | Std (nats) | Median (nats) | Mean entropy (bits) |
|-----------------------------------|---------------------:|-----------:|---------------:|--------------------:|
| Random tensor MPS (manual cores)  | 0.722509             | 0.168419   | 0.732455       | 1.042360            |
| Haar-random isometry MPS          | 1.064273             | 0.106144   | 1.074726       | 1.535421            |

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
