### PR TITLE
changed solver to representation and updated noise-free simulation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
+- changed solver to representation and updated noise-free simulation paths ([#422]) ([**@aaronleesander**])
+
 ### Fixed
 
 - minor cleanup ([#420]) ([**@aaronleesander**])
@@ -110,6 +112,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#422]: https://github.com/munich-quantum-toolkit/yaqs/pull/422
 [#220]: https://github.com/munich-quantum-toolkit/yaqs/pull/220
 [#420]: https://github.com/munich-quantum-toolkit/yaqs/pull/420
 [#409]: https://github.com/munich-quantum-toolkit/yaqs/pull/409
@@ -144,8 +147,8 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- Contributor -->
 
-[**@denialhaag**]: https://github.com/denialhaag
 [**@aaronleesander**]: https://github.com/aaronleesander
+[**@denialhaag**]: https://github.com/denialhaag
 [**@Gauthameshwar**]: https://github.com/Gauthameshwar
 [**@thilomueller**]: https://github.com/thilomueller
 [**@lucello**]: https://github.com/lucello

--- a/docs/examples/solver_comparison.md
+++ b/docs/examples/solver_comparison.md
@@ -101,7 +101,7 @@ plt.show()
 > confidence intervals to visualize the uncertainty. The `density_matrix` representation, in contrast,
 > returns the deterministic ensemble average directly.
 
-### Noiseless cross-check
+## Noiseless cross-check
 
 With no noise, `representation="density_matrix"` evolves $\rho$ under the Hamiltonian only
 (`noise_model=None`). The same holds for `mps` and `vector` (a single deterministic trajectory).

--- a/docs/examples/solver_comparison.md
+++ b/docs/examples/solver_comparison.md
@@ -12,10 +12,11 @@ mystnb:
 %config InlineBackend.figure_formats = ['svg']
 ```
 
-# Solver Comparison
+# Representation Comparison
 
-It is often useful to compare different solvers to verify results or benchmark performance.
-In this example, we compare the Tensor Jump Method (TJM) against the dense operator-based Monte Carlo Wavefunction (MCWF) solver and the exact Lindblad master equation solver.
+It is often useful to compare different state representations to verify results or benchmark performance.
+In this example, we compare MPS-based evolution (tensor network), dense state-vector evolution, and exact
+density-matrix master-equation evolution on a small open-system benchmark.
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
@@ -43,55 +44,89 @@ obs = Observable("x", sites=[0])
 t_max = 5.0
 dt = 0.05
 
-# 3. Solver 1: Lindblad (Exact)
-print("Running Lindblad...")
-params_lindblad = AnalogSimParams(
+# 3. density_matrix (exact ensemble average)
+print("Running density_matrix...")
+params_rho = AnalogSimParams(
     observables=[obs],
     elapsed_time=t_max,
     dt=dt,
-    solver="Lindblad"
+    representation="density_matrix",
 )
-run(psi_0, H, params_lindblad, noise)
-res_lindblad = obs.results.flatten()
-times = params_lindblad.times
+run(psi_0, H, params_rho, noise)
+res_rho = obs.results.flatten()
+times = params_rho.times
 
-# 4. Solver 2: MCWF (Stochastic)
-print("Running MCWF...")
-params_mcwf = AnalogSimParams(
+# 4. vector (stochastic trajectories)
+print("Running vector...")
+params_vector = AnalogSimParams(
     observables=[obs],
     elapsed_time=t_max,
     dt=dt,
-    solver="MCWF",
-    num_traj=500
-)
-run(psi_0, H, params_mcwf, noise)
-res_mcwf = obs.results.flatten()
-
-# 5. Solver 3: TJM (Default Stochastic)
-print("Running TJM...")
-params_tjm = AnalogSimParams(
-    observables=[obs],
-    elapsed_time=t_max,
-    dt=dt,
-    solver="TJM",
+    representation="vector",
     num_traj=500,
-    max_bond_dim=16
 )
-run(psi_0, H, params_tjm, noise)
-res_tjm = obs.results.flatten()
+run(psi_0, H, params_vector, noise)
+res_vector = obs.results.flatten()
+
+# 5. mps (default, stochastic trajectories)
+print("Running mps...")
+params_mps = AnalogSimParams(
+    observables=[obs],
+    elapsed_time=t_max,
+    dt=dt,
+    representation="mps",
+    num_traj=500,
+    max_bond_dim=16,
+)
+run(psi_0, H, params_mps, noise)
+res_mps = obs.results.flatten()
 
 # 6. Plot Comparison
 plt.figure()
-plt.plot(times, res_lindblad, label="Lindblad (Exact)", linewidth=2, color="black")
-plt.plot(times, res_mcwf, label="MCWF (500 traj)", linestyle="--", linewidth=2)
-plt.plot(times, res_tjm, label="TJM (500 traj)", linestyle=":", linewidth=2)
+plt.plot(times, res_rho, label="density_matrix (exact)", linewidth=2, color="black")
+plt.plot(times, res_vector, label="vector (500 traj)", linestyle="--", linewidth=2)
+plt.plot(times, res_mps, label="mps (500 traj)", linestyle=":", linewidth=2)
 plt.xlabel("Time")
 plt.ylabel("$\\langle X_0 \\rangle$")
 plt.legend()
-plt.title("Solver Comparison")
+plt.title("Representation Comparison")
 plt.show()
 ```
 
 > **Note on Statistical Uncertainty**:
-> The results for `MCWF` and `TJM` are averaged over 500 trajectories. As these are stochastic methods, the plotted curves represent the mean value and carry statistical uncertainty (standard error $\propto 1/\sqrt{N_{traj}}$).
-> For production-quality results, we recommend increasing `num_traj` (e.g., to 1000 or more) or plotting confidence intervals to visualize the uncertainty. The exact Lindblad solution, in contrast, is deterministic.
+> The results for `vector` and `mps` are averaged over 500 trajectories. As these use stochastic
+> open-system evolution when a noise model is present, the plotted curves represent the mean value
+> and carry statistical uncertainty (standard error $\propto 1/\sqrt{N_{traj}}$).
+> For production-quality results, we recommend increasing `num_traj` (e.g., to 1000 or more) or plotting
+> confidence intervals to visualize the uncertainty. The `density_matrix` representation, in contrast,
+> returns the deterministic ensemble average directly.
+
+### Noiseless cross-check
+
+With no noise, `representation="density_matrix"` evolves $\rho$ under the Hamiltonian only
+(`noise_model=None`). The same holds for `mps` and `vector` (a single deterministic trajectory).
+
+```{code-cell} ipython3
+obs_mps = Observable("z", sites=[0])
+obs_rho = Observable("z", sites=[0])
+params_mps_unitary = AnalogSimParams(
+    observables=[obs_mps],
+    elapsed_time=1.0,
+    dt=0.1,
+    representation="mps",
+    max_bond_dim=16,
+    show_progress=False,
+)
+params_rho_unitary = AnalogSimParams(
+    observables=[obs_rho],
+    elapsed_time=1.0,
+    dt=0.1,
+    representation="density_matrix",
+    show_progress=False,
+)
+run(psi_0, H, params_mps_unitary, None)
+z_mps = obs_mps.results[-1]
+run(psi_0, H, params_rho_unitary, None)
+z_rho = obs_rho.results[-1]
+print(f"Noiseless <Z_0> at t=1: mps={z_mps:.6f}, density_matrix={z_rho:.6f}")
+```

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -5,24 +5,20 @@
 #
 # Licensed under the MIT License
 
-"""Exact Lindblad Solver.
+"""Exact master-equation evolution for the density-matrix representation.
 
-This module provides an exact Lindblad master equation solver for small quantum systems.
-It converts the Matrix Product State (MPS) and Matrix Product Operator (MPO) representations
-into dense matrices and solves the Lindblad master equation:
-    drho/dt = -i[H, rho] + sum_k (L_k rho L_k^dag - 0.5 * {L_k^dag L_k, rho})
-
-It is suitable for small systems (N <= 10).
-For larger systems or when stochastic trajectories are preferred, consider
-using the MCWF solver or the Tensor Jump Method (TJM).
+Converts MPS/MPO inputs into dense operators and integrates the Lindblad equation.
+For small Hilbert spaces, a fixed time-step Liouvillian propagator is precomputed.
 """
 
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
+import scipy.linalg
 import scipy.sparse
 from scipy.integrate import solve_ivp
 
@@ -33,8 +29,240 @@ if TYPE_CHECKING:
     from ..core.data_structures.noise_model import NoiseModel
     from ..core.data_structures.simulation_parameters import AnalogSimParams
 
-
 from .utils import _embed_observable_sparse, _embed_operator_sparse
+
+# Maximum length of vec(rho) for storing a dense Liouvillian step propagator (dim**2).
+MAX_LIOUVILLIAN_VECTOR_DIM = 4096
+
+
+@dataclass
+class LindbladContext:
+    """Pre-computed operators for density-matrix master-equation evolution."""
+
+    rho_initial: NDArray[np.complex128]
+    dim: int
+    h_mat: scipy.sparse.spmatrix
+    jump_ops: list[scipy.sparse.spmatrix]
+    l_dag_l_sum: scipy.sparse.csr_matrix
+    embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None]
+    sim_params: AnalogSimParams
+    is_unitary: bool = False
+    step_propagator: NDArray[np.complex128] | None = None
+
+
+def preprocess_lindblad(
+    initial_state: MPS,
+    hamiltonian: MPO,
+    noise_model: NoiseModel | None,
+    sim_params: AnalogSimParams,
+) -> LindbladContext:
+    """Pre-compute operators and optional fixed-step propagator for Lindblad evolution.
+
+    Args:
+        initial_state: The initial MPS state.
+        hamiltonian: The Hamiltonian MPO.
+        noise_model: The noise model.
+        sim_params: Simulation parameters.
+
+    Returns:
+        LindbladContext ready for time evolution.
+    """
+    num_sites = initial_state.length
+    dim = 2**num_sites
+
+    if num_sites > 10:
+        msg = (
+            f"System size {num_sites} exceeds the recommended limit (10) for representation='density_matrix'. "
+            "Density-matrix evolution uses dense-like scaling (2^2N elements). "
+            "Simulation may be very slow or run out of memory. "
+            "Consider using representation='mps' for larger systems."
+        )
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
+
+    psi = initial_state.to_vec()
+    rho_initial = np.outer(psi, psi.conj()).flatten()
+
+    h_mat = hamiltonian.to_sparse_matrix()
+
+    jump_ops: list[scipy.sparse.spmatrix] = []
+    if noise_model is not None:
+        for process in noise_model.processes:
+            strength = process["strength"]
+            if strength <= 0:
+                continue
+            op_full = _embed_operator_sparse(process, num_sites)
+            jump_ops.append(np.sqrt(strength) * op_full)
+
+    is_unitary = len(jump_ops) == 0
+
+    l_dag_l_sum = scipy.sparse.csr_matrix((dim, dim), dtype=np.complex128)
+    if jump_ops:
+        for op in jump_ops:
+            op_csr = cast("Any", op)
+            l_dag_l_sum += op_csr.conj().T @ op_csr
+
+    embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
+    for obs in sim_params.sorted_observables:
+        if obs.gate.name in {"runtime_cost", "max_bond", "total_bond", "entropy", "schmidt_spectrum"}:
+            embedded_observables.append(None)
+        else:
+            embedded_observables.append(_embed_observable_sparse(obs, num_sites))
+
+    step_propagator: NDArray[np.complex128] | None = None
+    vec_dim = dim * dim
+    if vec_dim <= MAX_LIOUVILLIAN_VECTOR_DIM:
+        liouvillian = _build_liouvillian_superoperator(dim, h_mat, jump_ops, l_dag_l_sum)
+        step_propagator = scipy.linalg.expm(liouvillian * sim_params.dt)
+
+    return LindbladContext(
+        rho_initial=rho_initial,
+        dim=dim,
+        h_mat=h_mat,
+        jump_ops=jump_ops,
+        l_dag_l_sum=l_dag_l_sum,
+        embedded_observables=embedded_observables,
+        sim_params=sim_params,
+        is_unitary=is_unitary,
+        step_propagator=step_propagator,
+    )
+
+
+def _lindblad_rhs_flat(
+    rho_flat: NDArray[np.complex128],
+    dim: int,
+    h_mat: scipy.sparse.spmatrix,
+    jump_ops: list[scipy.sparse.spmatrix],
+    l_dag_l_sum: scipy.sparse.csr_matrix,
+) -> NDArray[np.complex128]:
+    """Evaluate drho/dt flattened, matching the Lindblad master equation.
+
+    Returns:
+        Flattened time derivative of the density matrix.
+    """
+    rho = rho_flat.reshape((dim, dim))
+    h_any = cast("Any", h_mat)
+    drho = -1j * (h_any @ rho - rho @ h_any)
+    for l_op in jump_ops:
+        l_op_any = cast("Any", l_op)
+        l_dag = l_op_any.conj().T
+        drho += l_op_any @ rho @ l_dag
+    l_sum_any = cast("Any", l_dag_l_sum)
+    ac_term = 0.5 * (l_sum_any @ rho + rho @ l_sum_any)
+    drho -= ac_term
+    return drho.flatten()
+
+
+def _build_liouvillian_superoperator(
+    dim: int,
+    h_mat: scipy.sparse.spmatrix,
+    jump_ops: list[scipy.sparse.spmatrix],
+    l_dag_l_sum: scipy.sparse.csr_matrix,
+) -> NDArray[np.complex128]:
+    """Build dense Liouvillian L such that d vec(rho)/dt = L @ vec(rho).
+
+    Returns:
+        Dense Liouvillian superoperator of shape ``(dim**2, dim**2)``.
+    """
+    vec_dim = dim * dim
+
+    def rhs(rho_flat: NDArray[np.complex128]) -> NDArray[np.complex128]:
+        return _lindblad_rhs_flat(rho_flat, dim, h_mat, jump_ops, l_dag_l_sum)
+
+    liouvillian = np.zeros((vec_dim, vec_dim), dtype=np.complex128)
+    for k in range(vec_dim):
+        basis = np.zeros(vec_dim, dtype=np.complex128)
+        basis[k] = 1.0
+        liouvillian[:, k] = rhs(basis)
+    return liouvillian
+
+
+def _measure_rho(
+    rho_flat: NDArray[np.complex128],
+    dim: int,
+    ctx: LindbladContext,
+    obs_results: NDArray[np.float64],
+    t_idx: int,
+) -> None:
+    """Record observable expectations at one time index."""
+    rho_t = rho_flat.reshape((dim, dim))
+    for i, op_mat in enumerate(ctx.embedded_observables):
+        if op_mat is not None:
+            op_any = cast("Any", op_mat)
+            val = np.trace(op_any @ rho_t)
+            obs_results[i, t_idx] = val.real
+        else:
+            obs_results[i, t_idx] = 0.0
+
+
+def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
+    """Fixed-dt evolution using a precomputed Liouvillian step propagator.
+
+    Returns:
+        Observable expectation values at each sampled time.
+    """
+    sim_params = ctx.sim_params
+    dim = ctx.dim
+    assert ctx.step_propagator is not None
+
+    num_obs = len(sim_params.sorted_observables)
+    num_steps = len(sim_params.times)
+    obs_results = np.zeros((num_obs, num_steps), dtype=np.float64)
+
+    rho_vec = ctx.rho_initial.copy()
+    if sim_params.sample_timesteps:
+        _measure_rho(rho_vec, dim, ctx, obs_results, 0)
+
+    for t_idx in range(1, num_steps):
+        rho_vec = ctx.step_propagator @ rho_vec
+        if sim_params.sample_timesteps or t_idx == num_steps - 1:
+            _measure_rho(rho_vec, dim, ctx, obs_results, t_idx)
+
+    return obs_results
+
+
+def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
+    """Adaptive RK45 integration when the Liouvillian propagator is not stored.
+
+    Returns:
+        Observable expectation values at each sampled time.
+
+    Raises:
+        RuntimeError: If the ODE integration fails.
+    """
+    sim_params = ctx.sim_params
+    dim = ctx.dim
+
+    t_end = max(sim_params.elapsed_time, sim_params.times[-1] + 1e-9)
+    t_span = (0.0, t_end)
+    t_eval = sim_params.times
+
+    def lindblad_rhs(_t: float, rho_flat: NDArray[np.complex128]) -> NDArray[np.complex128]:
+        return _lindblad_rhs_flat(rho_flat, dim, ctx.h_mat, ctx.jump_ops, ctx.l_dag_l_sum)
+
+    result = solve_ivp(
+        lindblad_rhs,
+        t_span,
+        ctx.rho_initial,
+        t_eval=t_eval,
+        method="RK45",
+        rtol=sim_params.threshold,
+        atol=sim_params.threshold * 1e-2,
+    )
+
+    if not result.success:
+        msg = (
+            f"Lindblad integration failed: {result.message} "
+            f"(rtol={sim_params.threshold}, atol={sim_params.threshold * 1e-2}, t_span={t_span})"
+        )
+        raise RuntimeError(msg)
+
+    num_obs = len(sim_params.sorted_observables)
+    obs_results = np.zeros((num_obs, len(result.t)), dtype=np.float64)
+
+    for t_idx, rho_flat_t in enumerate(result.y.T):
+        _measure_rho(rho_flat_t, dim, ctx, obs_results, t_idx)
+
+    return obs_results
 
 
 def lindblad(
@@ -52,124 +280,10 @@ def lindblad(
 
     Returns:
         An array of expectation values for each observable over time.
-
-    Raises:
-        RuntimeError: If the integration fails.
     """
     _i, initial_state, noise_model, sim_params, hamiltonian = args
+    ctx = preprocess_lindblad(initial_state, hamiltonian, noise_model, sim_params)
 
-    # Check dimensions
-    num_sites = initial_state.length
-    dim = 2**num_sites
-
-    # Limit system size to avoid OOM
-    if num_sites > 10:
-        msg = (
-            f"System size {num_sites} exceeds the recommended limit (10) for representation='density_matrix'. "
-            "Density-matrix evolution uses dense-like scaling (2^2N elements). "
-            "Simulation may be very slow or run out of memory. "
-            "Consider using representation='mps' for larger systems."
-        )
-        warnings.warn(msg, RuntimeWarning, stacklevel=2)
-
-    # 1. Initial State to Rho
-    psi = initial_state.to_vec()
-    rho_initial = np.outer(psi, psi.conj())
-
-    # 2. Convert Hamiltonian MPO to sparse matrix
-    h_mat = hamiltonian.to_sparse_matrix()
-
-    # 3. Prepare Jump Operators
-    jump_ops = []
-    if noise_model is not None:
-        for process in noise_model.processes:
-            strength = process["strength"]
-            if strength <= 0:
-                continue
-
-            # Convert local operator to full-space sparse operator
-            op_full = _embed_operator_sparse(process, num_sites)
-
-            # Scale by sqrt(gamma)
-            jump_ops.append(np.sqrt(strength) * op_full)
-
-    # 4. Define Lindblad Superoperator for ODE solver
-    # drho/dt = -i[H, rho] + sum( L rho L+ - 0.5 {L+ L, rho} )
-
-    # Preconstruct L_dag + L sum for efficiency (dissipator anti-commutator part)
-    l_dag_l_sum = scipy.sparse.csr_matrix((dim, dim), dtype=complex)
-    for l_op in jump_ops:
-        l_dag_l_sum += l_op.conj().T @ l_op
-
-    # 5. Integrate
-    # Ensure t_span covers t_eval (sim_params.times) even if floats drift slightly
-    t_end = max(sim_params.elapsed_time, sim_params.times[-1] + 1e-9)
-    t_span = (0, t_end)
-    t_eval = sim_params.times
-
-    def lindblad_rhs(_t: float, rho_flat: NDArray[np.complex128]) -> NDArray[np.complex128]:
-        rho = rho_flat.reshape((dim, dim))
-
-        # Unitary part: -i [H, rho]
-        # Commutator [H, rho] = H rho - rho H
-        drho = -1j * (h_mat @ rho - rho @ h_mat)
-
-        # Dissipative part
-        # 1. Accumulate sum( L rho L+ )
-        for l_op in jump_ops:
-            l_dag = l_op.conj().T
-            drho += l_op @ rho @ l_dag
-
-        # 2. Subtract anti-commutator term once: - 0.5 { sum(L+ L), rho }
-        # Note: l_dag_l_sum = sum( L+ L ) was precomputed outside
-        ac_term = 0.5 * (l_dag_l_sum @ rho + rho @ l_dag_l_sum)
-        drho -= ac_term
-
-        return drho.flatten()
-
-    result = solve_ivp(
-        lindblad_rhs,
-        t_span,
-        rho_initial.flatten(),
-        t_eval=t_eval,
-        method="RK45",
-        rtol=sim_params.threshold,
-        atol=sim_params.threshold * 1e-2,
-    )
-
-    if not result.success:
-        msg = (
-            f"Lindblad integration failed: {result.message} "
-            f"(rtol={sim_params.threshold}, atol={sim_params.threshold * 1e-2}, t_span={t_span})"
-        )
-        raise RuntimeError(msg)
-
-    # 6. Compute Observables
-    # result.y has shape (dim^2, num_time_points)
-    num_obs = len(sim_params.sorted_observables)
-    obs_results = np.zeros((num_obs, len(result.t)), dtype=np.float64)
-
-    # Pre-embed observable operators to full space
-    embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
-    for obs in sim_params.sorted_observables:
-        if obs.gate.name in {"runtime_cost", "max_bond", "total_bond", "entropy", "schmidt_spectrum"}:
-            # These are structural/diagnostic metrics not straightforwardly defined on rho
-            embedded_observables.append(None)
-        else:
-            op = _embed_observable_sparse(obs, num_sites)
-            embedded_observables.append(op)
-
-    for t_idx, rho_flat_t in enumerate(result.y.T):
-        rho_t = rho_flat_t.reshape((dim, dim))
-
-        for i, _obs in enumerate(sim_params.sorted_observables):
-            op_mat = embedded_observables[i]
-            if op_mat is not None:
-                # Expectation <O> = Tr(O rho)
-                val = np.trace(op_mat @ rho_t)
-                obs_results[i, t_idx] = val.real
-            else:
-                # Handle special observables if needed, or leave as 0/NaN
-                obs_results[i, t_idx] = 0.0
-
-    return obs_results
+    if ctx.step_propagator is not None:
+        return _evolve_with_propagator(ctx)
+    return _evolve_with_ode(ctx)

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -5,10 +5,21 @@
 #
 # Licensed under the MIT License
 
-"""Exact master-equation evolution for the density-matrix representation.
+"""Exact Lindblad master-equation evolution for ``representation='density_matrix'``.
 
-Converts MPS/MPO inputs into dense operators and integrates the Lindblad equation.
-For small Hilbert spaces, a fixed time-step Liouvillian propagator is precomputed.
+This module integrates the ensemble-averaged master equation (deterministic in rho):
+
+    drho/dt = -i[H, rho] + sum_k ( L_k rho L_k^dag - 0.5 {L_k^dag L_k, rho} )
+
+MPS/MPO specify the initial pure state and Hamiltonian; the state is carried as a
+dense ``dim x dim`` matrix with ``dim = 2^N``. With ``noise_model=None`` (or zero
+strengths), the dissipator vanishes and evolution is unitary on rho.
+
+Because ``H`` and the jump operators are time-independent, the generator is fixed.
+For small systems we precompute ``exp(L dt)`` where ``L`` is the Liouvillian
+superoperator (``d vec(rho)/dt = L @ vec(rho)``). Larger systems fall back to
+adaptive RK45 on the same RHS. Suitable for ``N <= 10``; use ``representation='mps'``
+or ``'vector'`` for larger lattices.
 """
 
 from __future__ import annotations
@@ -31,22 +42,25 @@ if TYPE_CHECKING:
 
 from .utils import _embed_observable_sparse, _embed_operator_sparse
 
-# Maximum length of vec(rho) for storing a dense Liouvillian step propagator (dim**2).
+# Maximum length of vec(rho) = dim**2 for storing dense exp(L * dt).
+# vec_dim=4096 corresponds to N=6 qubits (propagator ~256 MB); N=7+ uses ODE fallback.
 MAX_LIOUVILLIAN_VECTOR_DIM = 4096
 
 
 @dataclass
 class LindbladContext:
-    """Pre-computed operators for density-matrix master-equation evolution."""
+    """Pre-computed operators for one density-matrix evolution run."""
 
     rho_initial: NDArray[np.complex128]
     dim: int
     h_mat: scipy.sparse.spmatrix
     jump_ops: list[scipy.sparse.spmatrix]
+    # sum_k L_k^dag L_k, used in the anti-commutator term -0.5 {sum_k L_k^dag L_k, rho}.
     l_dag_l_sum: scipy.sparse.csr_matrix
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None]
     sim_params: AnalogSimParams
     is_unitary: bool = False
+    # exp(L * dt) with L the Liouvillian superoperator, if vec(rho) is small enough.
     step_propagator: NDArray[np.complex128] | None = None
 
 
@@ -59,7 +73,7 @@ def preprocess_lindblad(
     """Pre-compute operators and optional fixed-step propagator for Lindblad evolution.
 
     Args:
-        initial_state: The initial MPS state.
+        initial_state: The initial MPS state (converted to rho = |psi><psi|).
         hamiltonian: The Hamiltonian MPO.
         noise_model: The noise model.
         sim_params: Simulation parameters.
@@ -79,11 +93,14 @@ def preprocess_lindblad(
         )
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
+    # 1. Initial state: pure |psi><psi| from MPS (flattened column-major vec(rho)).
     psi = initial_state.to_vec()
     rho_initial = np.outer(psi, psi.conj()).flatten()
 
+    # 2. Hamiltonian as sparse matrix on the full Hilbert space.
     h_mat = hamiltonian.to_sparse_matrix()
 
+    # 3. Jump operators L_k = sqrt(gamma) * op on the full space.
     jump_ops: list[scipy.sparse.spmatrix] = []
     if noise_model is not None:
         for process in noise_model.processes:
@@ -95,12 +112,14 @@ def preprocess_lindblad(
 
     is_unitary = len(jump_ops) == 0
 
+    # 4. Precompute sum_k L_k^dag L_k for the dissipator anti-commutator (skipped if noiseless).
     l_dag_l_sum = scipy.sparse.csr_matrix((dim, dim), dtype=np.complex128)
     if jump_ops:
         for op in jump_ops:
             op_csr = cast("Any", op)
             l_dag_l_sum += op_csr.conj().T @ op_csr
 
+    # 5. Embed observables; MPS-only diagnostics are not traced on rho.
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
     for obs in sim_params.sorted_observables:
         if obs.gate.name in {"runtime_cost", "max_bond", "total_bond", "entropy", "schmidt_spectrum"}:
@@ -108,6 +127,7 @@ def preprocess_lindblad(
         else:
             embedded_observables.append(_embed_observable_sparse(obs, num_sites))
 
+    # 6. Fixed-step propagator exp(L dt) when vec(rho) fits in memory (time-independent generator).
     step_propagator: NDArray[np.complex128] | None = None
     vec_dim = dim * dim
     if vec_dim <= MAX_LIOUVILLIAN_VECTOR_DIM:
@@ -136,12 +156,18 @@ def _lindblad_rhs_flat(
 ) -> NDArray[np.complex128]:
     """Evaluate drho/dt flattened, matching the Lindblad master equation.
 
+    Used both by the ODE integrator and when building the Liouvillian column-wise.
+
     Returns:
         Flattened time derivative of the density matrix.
     """
     rho = rho_flat.reshape((dim, dim))
     h_any = cast("Any", h_mat)
+
+    # Unitary part: -i [H, rho] = -i (H rho - rho H).
     drho = -1j * (h_any @ rho - rho @ h_any)
+
+    # Dissipative part: sum_k L_k rho L_k^dag - 0.5 {sum_k L_k^dag L_k, rho}.
     for l_op in jump_ops:
         l_op_any = cast("Any", l_op)
         l_dag = l_op_any.conj().T
@@ -149,6 +175,7 @@ def _lindblad_rhs_flat(
     l_sum_any = cast("Any", l_dag_l_sum)
     ac_term = 0.5 * (l_sum_any @ rho + rho @ l_sum_any)
     drho -= ac_term
+
     return drho.flatten()
 
 
@@ -159,6 +186,9 @@ def _build_liouvillian_superoperator(
     l_dag_l_sum: scipy.sparse.csr_matrix,
 ) -> NDArray[np.complex128]:
     """Build dense Liouvillian L such that d vec(rho)/dt = L @ vec(rho).
+
+    Columns are obtained by applying ``_lindblad_rhs_flat`` to basis vectors, so the
+    superoperator matches the ODE RHS exactly without hand-derived Kronecker formulas.
 
     Returns:
         Dense Liouvillian superoperator of shape ``(dim**2, dim**2)``.
@@ -183,7 +213,7 @@ def _measure_rho(
     obs_results: NDArray[np.float64],
     t_idx: int,
 ) -> None:
-    """Record observable expectations at one time index."""
+    """Record <O> = Tr(O rho) for each observable at time index ``t_idx``."""
     rho_t = rho_flat.reshape((dim, dim))
     for i, op_mat in enumerate(ctx.embedded_observables):
         if op_mat is not None:
@@ -195,7 +225,10 @@ def _measure_rho(
 
 
 def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
-    """Fixed-dt evolution using a precomputed Liouvillian step propagator.
+    """Evolve rho on the fixed grid ``sim_params.times`` via vec(rho) <- exp(L dt) vec(rho).
+
+    Matches the user ``dt`` step used elsewhere in YAQS (not adaptive substeps).
+    Noiseless runs use the same map but without separate dissipator terms in L.
 
     Returns:
         Observable expectation values at each sampled time.
@@ -221,7 +254,10 @@ def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
 
 
 def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
-    """Adaptive RK45 integration when the Liouvillian propagator is not stored.
+    """Adaptive RK45 integration when ``vec(rho)`` is too large to store ``exp(L dt)``.
+
+    Uses the same ``_lindblad_rhs_flat`` as the propagator path; tolerances come from
+    ``sim_params.threshold``.
 
     Returns:
         Observable expectation values at each sampled time.
@@ -232,11 +268,13 @@ def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
     sim_params = ctx.sim_params
     dim = ctx.dim
 
+    # Ensure t_span covers t_eval (sim_params.times) even if floats drift slightly.
     t_end = max(sim_params.elapsed_time, sim_params.times[-1] + 1e-9)
     t_span = (0.0, t_end)
     t_eval = sim_params.times
 
     def lindblad_rhs(_t: float, rho_flat: NDArray[np.complex128]) -> NDArray[np.complex128]:
+        # Time argument unused: generator is autonomous (time-independent H and jumps).
         return _lindblad_rhs_flat(rho_flat, dim, ctx.h_mat, ctx.jump_ops, ctx.l_dag_l_sum)
 
     result = solve_ivp(
@@ -256,6 +294,7 @@ def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
         )
         raise RuntimeError(msg)
 
+    # result.y has shape (dim^2, num_time_points).
     num_obs = len(sim_params.sorted_observables)
     obs_results = np.zeros((num_obs, len(result.t)), dtype=np.float64)
 
@@ -268,11 +307,11 @@ def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
 def lindblad(
     args: tuple[int, MPS, NoiseModel | None, AnalogSimParams, MPO],
 ) -> NDArray[np.float64]:
-    """Run an exact Lindblad master equation simulation.
+    """Run an exact Lindblad master-equation simulation.
 
     Args:
         args: A tuple containing:
-            - int: Trajectory identifier (unused).
+            - int: Trajectory identifier (unused; evolution is deterministic in rho).
             - MPS: The initial state.
             - NoiseModel | None: The noise model.
             - AnalogSimParams: Simulation parameters.

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -65,10 +65,10 @@ def lindblad(
     # Limit system size to avoid OOM
     if num_sites > 10:
         msg = (
-            f"System size {num_sites} exceeds the recommended limit (10) for the exact Lindblad solver. "
-            "Lindblad uses dense-like scaling for the density matrix (2^2N elements). "
+            f"System size {num_sites} exceeds the recommended limit (10) for representation='density_matrix'. "
+            "Density-matrix evolution uses dense-like scaling (2^2N elements). "
             "Simulation may be very slow or run out of memory. "
-            "Consider using the TJM solver for larger systems."
+            "Consider using representation='mps' for larger systems."
         )
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -242,13 +242,11 @@ def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
     obs_results = np.zeros((num_obs, num_steps), dtype=np.float64)
 
     rho_vec = ctx.rho_initial.copy()
-    if sim_params.sample_timesteps:
-        _measure_rho(rho_vec, dim, ctx, obs_results, 0)
+    _measure_rho(rho_vec, dim, ctx, obs_results, 0)
 
     for t_idx in range(1, num_steps):
         rho_vec = ctx.step_propagator @ rho_vec
-        if sim_params.sample_timesteps or t_idx == num_steps - 1:
-            _measure_rho(rho_vec, dim, ctx, obs_results, t_idx)
+        _measure_rho(rho_vec, dim, ctx, obs_results, t_idx)
 
     return obs_results
 

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -61,8 +61,8 @@ class MCWFContext:
     sim_params: AnalogSimParams
     # True when there is no dissipative part (no jump operators); skips jump/RNG logic.
     is_unitary: bool = False
-    # exp(-i H_eff dt) as sparse matrix, if dim <= MAX_PRECOMPUTE_DIM; else None.
-    step_propagator: scipy.sparse.csr_matrix | None = None
+    # exp(-i H_eff dt) as dense matrix, if dim <= MAX_PRECOMPUTE_DIM; else None.
+    step_propagator: NDArray[np.complex128] | None = None
     output_state: NDArray[np.complex128] | None = None
 
 
@@ -126,10 +126,9 @@ def preprocess_mcwf(
         heff -= 0.5j * sum_ldag_l
 
     # 5. Fixed-step propagator U_step = exp(-i H_eff dt) (time-independent H in YAQS).
-    step_propagator: scipy.sparse.csr_matrix | None = None
+    step_propagator: NDArray[np.complex128] | None = None
     if dim <= MAX_PRECOMPUTE_DIM:
-        u_dense = scipy.linalg.expm(-1j * sim_params.dt * heff.toarray())
-        step_propagator = scipy.sparse.csr_matrix(u_dense)
+        step_propagator = scipy.linalg.expm(-1j * sim_params.dt * heff.toarray())
 
     # 6. Observables embedded on the full space; diagnostics are not defined on |psi>.
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
@@ -206,12 +205,12 @@ def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
     Returns:
         An array of expectation values for each observable over time.
     """
-    _traj_idx, ctx = args
+    traj_idx, ctx = args
     sim_params = ctx.sim_params
     dt = sim_params.dt
 
     psi = ctx.psi_initial.copy()
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(int(traj_idx))
 
     num_obs = len(sim_params.sorted_observables)
     num_steps = len(sim_params.times)

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -5,11 +5,23 @@
 #
 # Licensed under the MIT License
 
-"""Monte Carlo Wavefunction (MCWF) evolution for the vector representation.
+"""Monte Carlo wavefunction (MCWF) evolution for ``representation='vector'``.
 
-Converts MPS/MPO inputs into dense operators and evolves the state vector under
-an effective non-Hermitian Hamiltonian (with optional quantum jumps). For noiseless
-runs, evolution is unitary; for larger systems prefer ``representation='mps'``.
+This module implements a stochastic unraveling of the Lindblad master equation for
+small systems. MPS/MPO inputs are contracted to a dense state vector and sparse
+operators; the trajectory is evolved in Hilbert space (not in a tensor network).
+
+Effective non-Hermitian dynamics between jumps:
+
+    H_eff = H - (i/2) sum_k L_k^dag L_k
+
+with a state vector updated by ``exp(-i H_eff dt)`` and occasional quantum jumps
+``L_k``. When there is no noise, ``H_eff = H`` and evolution is unitary.
+
+Hamiltonians are time-independent in YAQS today, so for fixed ``dt`` the map
+``U_step = exp(-i H_eff dt)`` can be precomputed once (see ``MAX_PRECOMPUTE_DIM``).
+Per-step Arnoldi is only used when the Hilbert-space dimension is too large to
+store ``U_step``. For larger lattices use ``representation='mps'`` instead.
 """
 
 from __future__ import annotations
@@ -33,20 +45,23 @@ if TYPE_CHECKING:
 
 from .utils import _embed_observable_sparse, _embed_operator_sparse
 
-# Maximum Hilbert-space dimension for storing a dense time-step propagator U_step.
+# Maximum Hilbert-space dimension dim = 2^N for storing dense U_step (dim x dim).
+# N=12 -> dim=4096 (~256 MB per propagator); N=14 falls back to per-step Krylov.
 MAX_PRECOMPUTE_DIM = 4096
 
 
 @dataclass
 class MCWFContext:
-    """Context for MCWF simulation containing pre-computed sparse operators."""
+    """Pre-computed data for one MCWF trajectory (shared across parallel workers via preprocess)."""
 
     psi_initial: NDArray[np.complex128]
     heff: scipy.sparse.spmatrix
     jump_ops: list[scipy.sparse.spmatrix]
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None]
     sim_params: AnalogSimParams
+    # True when there is no dissipative part (no jump operators); skips jump/RNG logic.
     is_unitary: bool = False
+    # exp(-i H_eff dt) as sparse matrix, if dim <= MAX_PRECOMPUTE_DIM; else None.
     step_propagator: scipy.sparse.csr_matrix | None = None
     output_state: NDArray[np.complex128] | None = None
 
@@ -59,6 +74,9 @@ def preprocess_mcwf(
 ) -> MCWFContext:
     """Pre-compute dense operators and initial state for MCWF simulation.
 
+    Called once per ``simulator.run`` before trajectory workers start (see
+    ``preprocess_mcwf`` in ``simulator.py``).
+
     Args:
         initial_state: The initial MPS state.
         hamiltonian: The Hamiltonian MPO.
@@ -68,11 +86,9 @@ def preprocess_mcwf(
     Returns:
         MCWFContext containing dense arrays ready for trajectory simulation.
     """
-    # Check dimensions
     num_sites = initial_state.length
     dim = 2**num_sites
 
-    # Limit system size to avoid OOM
     if num_sites > 14:
         msg = (
             f"System size {num_sites} is too large for representation='vector' even with sparse matrices. "
@@ -81,14 +97,14 @@ def preprocess_mcwf(
         )
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
-    # 1. Initial State to Vector
+    # 1. Initial state |psi> as dense vector (MPS is only the user-facing specification).
     psi = initial_state.to_vec()
     psi /= np.linalg.norm(psi)
 
-    # 2. Convert Hamiltonian MPO to sparse matrix
+    # 2. Hamiltonian as sparse matrix on the full Hilbert space.
     h_mat = hamiltonian.to_sparse_matrix()
 
-    # 3. Prepare Jump Operators
+    # 3. Jump operators L_k = sqrt(gamma) * op embedded on the full space.
     jump_ops: list[scipy.sparse.spmatrix] = []
     if noise_model is not None:
         for process in noise_model.processes:
@@ -100,7 +116,7 @@ def preprocess_mcwf(
 
     is_unitary = len(jump_ops) == 0
 
-    # 4. Construct Effective Hamiltonian
+    # 4. Effective Hamiltonian for the no-jump evolution between stochastic events.
     heff = h_mat.copy()
     if jump_ops:
         sum_ldag_l = scipy.sparse.csr_matrix((dim, dim), dtype=complex)
@@ -109,13 +125,13 @@ def preprocess_mcwf(
             sum_ldag_l += op_csr.conj().T @ op_csr
         heff -= 0.5j * sum_ldag_l
 
-    # 5. Precompute time-step propagator U_step = exp(-i * H_eff * dt) when affordable
+    # 5. Fixed-step propagator U_step = exp(-i H_eff dt) (time-independent H in YAQS).
     step_propagator: scipy.sparse.csr_matrix | None = None
     if dim <= MAX_PRECOMPUTE_DIM:
         u_dense = scipy.linalg.expm(-1j * sim_params.dt * heff.toarray())
         step_propagator = scipy.sparse.csr_matrix(u_dense)
 
-    # 6. Prepare Observables
+    # 6. Observables embedded on the full space; diagnostics are not defined on |psi>.
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
     for obs in sim_params.sorted_observables:
         if obs.gate.name in {"runtime_cost", "max_bond", "total_bond", "entropy", "schmidt_spectrum"}:
@@ -141,17 +157,22 @@ def _apply_noisy_step(
     ctx: MCWFContext,
     rng: np.random.Generator,
 ) -> NDArray[np.complex128]:
-    """Apply norm check, optional quantum jump, and renormalization for one MCWF step.
+    """MCWF no-jump / jump decision and renormalization for one time step.
+
+    ``psi_next`` is the result of non-unitary evolution ``exp(-i H_eff dt) |psi>``
+    (not yet normalized). Norm loss ``1 - ||psi_next||^2`` is the jump probability.
 
     Returns:
-        Normalized state vector after the non-unitary step (with or without jump).
+        Normalized state vector after the step (with or without jump).
     """
     norm_sq = np.vdot(psi_next, psi_next).real
     p_jump = 1.0 - norm_sq
 
     if rng.random() >= p_jump:
+        # No jump: renormalize the evolved state.
         return psi_next / np.sqrt(norm_sq)
 
+    # Jump occurred: choose channel k with probability proportional to ||L_k |psi>||^2.
     param_psi = psi
     normalization_sum = 0.0
     weights: list[float] = []
@@ -163,6 +184,7 @@ def _apply_noisy_step(
         normalization_sum += w
 
     if normalization_sum < 1e-15:
+        # Degenerate case: fall back to no-jump renormalization.
         return psi_next / np.sqrt(norm_sq)
 
     weights_arr = np.array(weights, dtype=np.float64)
@@ -174,12 +196,12 @@ def _apply_noisy_step(
 
 
 def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
-    """Run a single Monte Carlo Wavefunction trajectory using pre-computed context.
+    """Run a single Monte Carlo wavefunction trajectory.
 
     Args:
         args: A tuple containing:
-            - int: Trajectory identifier.
-            - MCWFContext: Pre-computed simulation context.
+            - int: Trajectory identifier (used for RNG seeding in parallel runs).
+            - MCWFContext: Pre-computed simulation context from ``preprocess_mcwf``.
 
     Returns:
         An array of expectation values for each observable over time.
@@ -213,6 +235,7 @@ def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
 
     for t_idx in range(1, num_steps):
         if ctx.step_propagator is not None:
+            # Fast path: one application of precomputed U_step = exp(-i H_eff dt).
             if ctx.is_unitary:
                 psi = ctx.step_propagator @ psi
             else:
@@ -220,8 +243,10 @@ def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
                 psi_next = ctx.step_propagator @ psi_before
                 psi = _apply_noisy_step(psi_before, psi_next, ctx, rng)
         elif ctx.is_unitary:
+            # Noiseless but Hilbert space too large to store U_step: Hermitian Lanczos per step.
             psi = expm_krylov(lambda v: ctx.heff @ v, psi, dt)
         else:
+            # Noisy and no stored U_step: general non-Hermitian Arnoldi per step.
             psi_next = expm_arnoldi(lambda v: ctx.heff @ v, psi, dt)
             psi = _apply_noisy_step(psi, psi_next, ctx, rng)
 

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -5,28 +5,24 @@
 #
 # Licensed under the MIT License
 
-"""Monte Carlo Wavefunction (MCWF) Solver.
+"""Monte Carlo Wavefunction (MCWF) evolution for the vector representation.
 
-This module provides a Monte Carlo Wavefunction (or Quantum Jump) solver for small quantum systems.
-It converts the Matrix Product State (MPS) and Matrix Product Operator (MPO) representations
-into dense vectors and matrices, and evolves the wavefunction under an effective non-Hermitian Hamiltonian:
-    H_eff = H - 0.5 * i * sum_k (L_k^dag L_k)
-stochastically applying quantum jumps.
-
-This solver scales exponentially. It is suitable for small systems (N <= 14).
-For larger systems, consider using the Tensor Jump Method (TJM) which uses
-Matrix Product States (MPS).
+Converts MPS/MPO inputs into dense operators and evolves the state vector under
+an effective non-Hermitian Hamiltonian (with optional quantum jumps). For noiseless
+runs, evolution is unitary; for larger systems prefer ``representation='mps'``.
 """
 
 from __future__ import annotations
 
 import warnings
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
+import scipy.linalg
 import scipy.sparse
 
-from ..core.methods.matrix_exponential import expm_arnoldi
+from ..core.methods.matrix_exponential import expm_arnoldi, expm_krylov
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -35,10 +31,10 @@ if TYPE_CHECKING:
     from ..core.data_structures.noise_model import NoiseModel
     from ..core.data_structures.simulation_parameters import AnalogSimParams
 
-
-from dataclasses import dataclass
-
 from .utils import _embed_observable_sparse, _embed_operator_sparse
+
+# Maximum Hilbert-space dimension for storing a dense time-step propagator U_step.
+MAX_PRECOMPUTE_DIM = 4096
 
 
 @dataclass
@@ -50,6 +46,8 @@ class MCWFContext:
     jump_ops: list[scipy.sparse.spmatrix]
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None]
     sim_params: AnalogSimParams
+    is_unitary: bool = False
+    step_propagator: scipy.sparse.csr_matrix | None = None
     output_state: NDArray[np.complex128] | None = None
 
 
@@ -91,7 +89,7 @@ def preprocess_mcwf(
     h_mat = hamiltonian.to_sparse_matrix()
 
     # 3. Prepare Jump Operators
-    jump_ops = []
+    jump_ops: list[scipy.sparse.spmatrix] = []
     if noise_model is not None:
         for process in noise_model.processes:
             strength = process["strength"]
@@ -100,15 +98,24 @@ def preprocess_mcwf(
             op_full = _embed_operator_sparse(process, num_sites)
             jump_ops.append(np.sqrt(strength) * op_full)
 
+    is_unitary = len(jump_ops) == 0
+
     # 4. Construct Effective Hamiltonian
     heff = h_mat.copy()
     if jump_ops:
         sum_ldag_l = scipy.sparse.csr_matrix((dim, dim), dtype=complex)
         for op in jump_ops:
-            sum_ldag_l += op.conj().T @ op
+            op_csr = cast("Any", op)
+            sum_ldag_l += op_csr.conj().T @ op_csr
         heff -= 0.5j * sum_ldag_l
 
-    # 5. Prepare Observables
+    # 5. Precompute time-step propagator U_step = exp(-i * H_eff * dt) when affordable
+    step_propagator: scipy.sparse.csr_matrix | None = None
+    if dim <= MAX_PRECOMPUTE_DIM:
+        u_dense = scipy.linalg.expm(-1j * sim_params.dt * heff.toarray())
+        step_propagator = scipy.sparse.csr_matrix(u_dense)
+
+    # 6. Prepare Observables
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
     for obs in sim_params.sorted_observables:
         if obs.gate.name in {"runtime_cost", "max_bond", "total_bond", "entropy", "schmidt_spectrum"}:
@@ -123,7 +130,47 @@ def preprocess_mcwf(
         jump_ops=jump_ops,
         embedded_observables=embedded_observables,
         sim_params=sim_params,
+        is_unitary=is_unitary,
+        step_propagator=step_propagator,
     )
+
+
+def _apply_noisy_step(
+    psi: NDArray[np.complex128],
+    psi_next: NDArray[np.complex128],
+    ctx: MCWFContext,
+    rng: np.random.Generator,
+) -> NDArray[np.complex128]:
+    """Apply norm check, optional quantum jump, and renormalization for one MCWF step.
+
+    Returns:
+        Normalized state vector after the non-unitary step (with or without jump).
+    """
+    norm_sq = np.vdot(psi_next, psi_next).real
+    p_jump = 1.0 - norm_sq
+
+    if rng.random() >= p_jump:
+        return psi_next / np.sqrt(norm_sq)
+
+    param_psi = psi
+    normalization_sum = 0.0
+    weights: list[float] = []
+    for op in ctx.jump_ops:
+        op_sparse = cast("Any", op)
+        l_psi = op_sparse.dot(param_psi)
+        w = np.vdot(l_psi, l_psi).real
+        weights.append(w)
+        normalization_sum += w
+
+    if normalization_sum < 1e-15:
+        return psi_next / np.sqrt(norm_sq)
+
+    weights_arr = np.array(weights, dtype=np.float64)
+    weights_arr /= normalization_sum
+    k_idx = rng.choice(len(ctx.jump_ops), p=weights_arr)
+    jump_op = cast("Any", ctx.jump_ops[k_idx])
+    jumped = jump_op.dot(param_psi)
+    return jumped / np.linalg.norm(jumped)
 
 
 def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
@@ -139,18 +186,15 @@ def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
     """
     _traj_idx, ctx = args
     sim_params = ctx.sim_params
+    dt = sim_params.dt
 
-    # Copy initial state for this trajectory
     psi = ctx.psi_initial.copy()
-
     rng = np.random.default_rng()
 
-    # Storage for results
     num_obs = len(sim_params.sorted_observables)
     num_steps = len(sim_params.times)
     results = np.zeros((num_obs, num_steps), dtype=np.float64)
 
-    # Helper to measure
     def measure(current_psi: NDArray[np.complex128], t_idx: int) -> None:
         for i, op_mat in enumerate(ctx.embedded_observables):
             if op_mat is not None:
@@ -164,52 +208,22 @@ def mcwf(args: tuple[int, MCWFContext]) -> NDArray[np.float64]:
             else:
                 results[i, t_idx] = 0.0
 
-    # Initial measurement
     if sim_params.sample_timesteps:
         measure(psi, 0)
 
-    # Time evolution loop
     for t_idx in range(1, num_steps):
-        # 1. Evolve with H_eff
-        # Arnoldi approximation: exp(-i * heff * dt) * psi
-        psi_next = expm_arnoldi(
-            lambda v: ctx.heff @ v,
-            psi,
-            sim_params.dt,
-        )
-
-        # 2. Norm check
-        norm_sq = np.vdot(psi_next, psi_next).real
-        p_jump = 1.0 - norm_sq
-
-        # 3. Random number for jump
-        r = rng.random()
-
-        if r < p_jump:
-            # Jump occurs
-            weights = []
-            param_psi = psi  # Use state at start of step
-
-            normalization_sum = 0.0
-            for op in ctx.jump_ops:
-                l_psi = op @ param_psi
-                w = np.vdot(l_psi, l_psi).real
-                weights.append(w)
-                normalization_sum += w
-
-            if normalization_sum < 1e-15:
-                psi = psi_next / np.sqrt(norm_sq)
+        if ctx.step_propagator is not None:
+            if ctx.is_unitary:
+                psi = ctx.step_propagator @ psi
             else:
-                weights = np.array(weights)
-                weights /= normalization_sum
-
-                k_idx = rng.choice(len(ctx.jump_ops), p=weights)
-
-                psi = ctx.jump_ops[k_idx] @ param_psi
-                psi /= np.linalg.norm(psi)
+                psi_before = psi
+                psi_next = ctx.step_propagator @ psi_before
+                psi = _apply_noisy_step(psi_before, psi_next, ctx, rng)
+        elif ctx.is_unitary:
+            psi = expm_krylov(lambda v: ctx.heff @ v, psi, dt)
         else:
-            # No jump
-            psi = psi_next / np.sqrt(norm_sq)
+            psi_next = expm_arnoldi(lambda v: ctx.heff @ v, psi, dt)
+            psi = _apply_noisy_step(psi, psi_next, ctx, rng)
 
         if sim_params.sample_timesteps or t_idx == num_steps - 1:
             measure(psi, t_idx)

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -77,9 +77,9 @@ def preprocess_mcwf(
     # Limit system size to avoid OOM
     if num_sites > 14:
         msg = (
-            f"System size {num_sites} is too large for MCWF solver even with sparse matrices. "
+            f"System size {num_sites} is too large for representation='vector' even with sparse matrices. "
             "Simulation may be very slow or run out of memory. "
-            "Consider using the TJM solver for larger systems."
+            "Consider using representation='mps' for larger systems."
         )
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 

--- a/src/mqt/yaqs/characterization/tomography/tomography.py
+++ b/src/mqt/yaqs/characterization/tomography/tomography.py
@@ -238,10 +238,10 @@ def _tomography_sequence_worker(job_idx: int) -> tuple[int, int, list[NDArray[np
     alpha_seq = worker_sequences[seq_idx]
 
     # 3. Initialize state to |0...0>
-    is_mcwf = sim_params.solver == "MCWF"
+    is_vector = sim_params.representation == "vector"
     current_state: MPS | NDArray[np.complex128]
 
-    if is_mcwf:
+    if is_vector:
         num_sites = operator.length
         current_state = np.array([1.0], dtype=np.complex128)
         for _ in range(num_sites):
@@ -276,7 +276,7 @@ def _tomography_sequence_worker(job_idx: int) -> tuple[int, int, list[NDArray[np
         _, psi_next, _ = basis_set[p_t]
         _, psi_proj, _ = basis_set[m_t]
 
-        if is_mcwf:
+        if is_vector:
             assert isinstance(current_state, np.ndarray)
             current_state, step_prob = _reprepare_site_zero_vector_forced(
                 cast("NDArray[np.complex128]", current_state), psi_proj, psi_next
@@ -302,7 +302,7 @@ def _tomography_sequence_worker(job_idx: int) -> tuple[int, int, list[NDArray[np
         n_steps = int(np.round(duration / step_params.dt))
         step_params.times = np.linspace(0, n_steps * step_params.dt, n_steps + 1)
 
-        if is_mcwf:
+        if is_vector:
             static_ctx = WORKER_CTX["mcwf_static_ctx"]
             dynamic_ctx = copy.copy(static_ctx)
             dynamic_ctx.psi_initial = current_state
@@ -388,7 +388,7 @@ def run(
         num_trajectories = 1
 
     mcwf_static_ctx = None
-    if sim_params.solver == "MCWF":
+    if sim_params.representation == "vector":
         dummy_mps = MPS(length=operator.length, state="zeros")
         mcwf_static_ctx = preprocess_mcwf(dummy_mps, operator, noise_model, sim_params)
 

--- a/src/mqt/yaqs/characterization/tomography/tomography.py
+++ b/src/mqt/yaqs/characterization/tomography/tomography.py
@@ -389,6 +389,8 @@ def run(
 
     mcwf_static_ctx = None
     if sim_params.representation == "vector":
+        # Shape-only placeholder: preprocess_mcwf uses length and static operators only.
+        # Workers override dynamic_ctx.psi_initial with the real state vector each step.
         dummy_mps = MPS(length=operator.length, state="zeros")
         mcwf_static_ctx = preprocess_mcwf(dummy_mps, operator, noise_model, sim_params)
 

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import copy
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -150,7 +150,9 @@ class AnalogSimParams:
         dt: Simulation time step.
         times: Array of sampled times from ``0`` to ``elapsed_time`` with spacing ``dt``.
         sample_timesteps: If ``True``, record values at all sampled timesteps.
-        num_traj: Number of trajectories (for stochastic solvers).
+        num_traj: Number of trajectories (for stochastic open-system evolution).
+        representation: State representation used during analog simulation
+            (``"mps"``, ``"vector"``, or ``"density_matrix"``).
         max_bond_dim: Maximum allowed bond dimension.
         trunc_mode: Truncation mode used in TDVP (``"discarded_weight"`` or ``"relative"``).
         threshold: Truncation threshold.
@@ -184,7 +186,7 @@ class AnalogSimParams:
         get_state: bool = False,
         show_progress: bool = True,
         num_threads: int = 1,
-        solver: str = "TJM",
+        representation: Literal["mps", "vector", "density_matrix"] = "mps",
         multi_time_observables: list[tuple[Observable, Observable]] | None = None,
     ) -> None:
         """Physics simulation parameters initialization.
@@ -206,19 +208,22 @@ class AnalogSimParams:
             get_state: If ``True``, output MPS is returned.
             show_progress: If ``True``, print a progress bar as trajectories finish.
             num_threads: Number of threads for single-trajectory simulations (BLAS/LAPACK).
-            solver: Solver method, one of ``"TJM"``, ``"Lindblad"``, or ``"MCWF"``.
+            representation: State representation for the run: ``"mps"`` (tensor network),
+                ``"vector"`` (dense state vector), or ``"density_matrix"`` (exact master equation).
+                With ``noise_model=None`` or zero strengths, ``"density_matrix"`` evolves the
+                density matrix unitarily; ``"mps"`` and ``"vector"`` reduce to Hamiltonian evolution.
             multi_time_observables: For ``list[MPS]`` unitary ensemble runs only, list of ``(A, B)``
                 pairs evaluated as ``<psi(t)|A U(t) B|psi(0)>``. Autocorrelation is the special
                 case ``(O, O)``.
 
         Raises:
-            ValueError: If the solver is not "TJM", "Lindblad", or "MCWF".
+            ValueError: If ``representation`` is not ``"mps"``, ``"vector"``, or ``"density_matrix"``.
         """
         self.noise_model: NoiseModel | None = None
-        if solver not in {"TJM", "Lindblad", "MCWF"}:
-            msg = f"Invalid solver '{solver}'. Allowed values are 'TJM', 'Lindblad', or 'MCWF'."
+        if representation not in {"mps", "vector", "density_matrix"}:
+            msg = f"Invalid representation '{representation}'. Allowed values are 'mps', 'vector', or 'density_matrix'."
             raise ValueError(msg)
-        self.solver = solver
+        self.representation = representation
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -915,6 +915,9 @@ def _run_analog(
         sim_params: Simulation parameters for analog simulation, including time step and evolution order.
         noise_model: The noise model applied during simulation.
         parallel: Flag indicating whether to run trajectories in parallel.
+
+    Raises:
+        ValueError: If ``get_state=True`` with ``representation='density_matrix'``.
     """
     # Deterministic unitary ensemble mode
     if isinstance(initial_state, list):
@@ -938,6 +941,10 @@ def _run_analog(
         backend = analog_tjm_1
     else:
         backend = analog_tjm_2
+
+    if sim_params.representation == "density_matrix" and sim_params.get_state:
+        msg = "get_state=True is not supported for representation='density_matrix'."
+        raise ValueError(msg)
 
     # If no noise, determinism implies a single trajectory suffices
     if (

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -999,7 +999,7 @@ def _run_analog(
         if sim_params.representation == "vector":
             # For vector serial, we still use the pre-computed ctx
             # ctx is already in local scope from above if block
-            args = [(i, ctx) for i in range(sim_params.num_traj)]
+            args = [(i, copy.copy(ctx)) for i in range(sim_params.num_traj)]
         else:
             args = [(i, initial_state, noise_model, sim_params, operator) for i in range(sim_params.num_traj)]
 

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -805,7 +805,7 @@ def _run_ensemble(
         parallel: If True and more than one member, uses :func:`run_backend_parallel`.
 
     Raises:
-        ValueError: If noisy simulation is requested with a list of states, if ``solver`` is
+        ValueError: If noisy simulation is requested with a list of states, if ``representation`` is
             unsupported in list mode, if the list is empty, or if state lengths do not match the MPO.
     """
     if noise_model is not None and any(proc["strength"] > 0 for proc in noise_model.processes):
@@ -814,9 +814,9 @@ def _run_ensemble(
             "Use list[MPS] with no noise for unitary ensembles, or use a single MPS for noisy simulation."
         )
         raise ValueError(msg)
-    # Will later add support for MCWF if needed
-    if sim_params.solver != "TJM":
-        msg = "list[MPS] analog ensemble currently supports only solver='TJM'."
+    # Will later add support for vector representation if needed
+    if sim_params.representation != "mps":
+        msg = "list[MPS] analog ensemble currently supports only representation='mps'."
         raise ValueError(msg)
 
     if not initial_states:
@@ -930,9 +930,9 @@ def _run_analog(
     # Choose integrator order (1 or 2) for the analog TJM backend
 
     backend: Callable[[Any], NDArray[np.float64]]
-    if sim_params.solver == "Lindblad":
+    if sim_params.representation == "density_matrix":
         backend = lindblad
-    elif sim_params.solver == "MCWF":
+    elif sim_params.representation == "vector":
         backend = mcwf
     elif sim_params.order == 1:
         backend = analog_tjm_1
@@ -943,7 +943,7 @@ def _run_analog(
     if (
         noise_model is None
         or all(proc["strength"] == 0 for proc in noise_model.processes)
-        or sim_params.solver == "Lindblad"
+        or sim_params.representation == "density_matrix"
     ):
         sim_params.num_traj = 1
     else:
@@ -957,13 +957,13 @@ def _run_analog(
     payload: dict[str, Any]
     worker_fn: Callable[[int], Any]
 
-    if sim_params.solver == "MCWF":
+    if sim_params.representation == "vector":
         # Optimization: Pre-compute dense operators once
         ctx = preprocess_mcwf(initial_state, operator, noise_model, sim_params)
         payload = {"ctx": ctx}
         worker_fn = _mcwf_worker
     else:
-        # Standard TJM/Lindblad arguments
+        # Standard mps / density_matrix arguments
         payload = {
             "initial_state": initial_state,
             "noise_model": noise_model,
@@ -996,8 +996,8 @@ def _run_analog(
 
         # Reconstruct args locally for serial execution
         args: list[Any]
-        if sim_params.solver == "MCWF":
-            # For MCWF serial, we still use the pre-computed ctx
+        if sim_params.representation == "vector":
+            # For vector serial, we still use the pre-computed ctx
             # ctx is already in local scope from above if block
             args = [(i, ctx) for i in range(sim_params.num_traj)]
         else:

--- a/tests/analog/test_ensemble.py
+++ b/tests/analog/test_ensemble.py
@@ -160,8 +160,8 @@ def test_unitary_ensemble_clears_multi_time_outputs_when_feature_disabled() -> N
     assert sim_params_off.multi_time_observables_times is None
 
 
-def test_list_mps_analog_ensemble_rejects_non_tjm_solver() -> None:
-    """List-of-MPS analog ensemble only supports the TJM solver path."""
+def test_list_mps_analog_ensemble_rejects_non_mps_representation() -> None:
+    """List-of-MPS analog ensemble only supports the mps representation path."""
     length = 2
     hamiltonian = MPO.ising(length, J=0.2, g=0.1)
     states = [MPS(length, state="zeros"), MPS(length, state="ones")]
@@ -170,9 +170,9 @@ def test_list_mps_analog_ensemble_rejects_non_tjm_solver() -> None:
         elapsed_time=0.1,
         dt=0.1,
         show_progress=False,
-        solver="Lindblad",
+        representation="density_matrix",
     )
-    with pytest.raises(ValueError, match=r"list\[MPS\] analog ensemble currently supports only solver='TJM'\."):
+    with pytest.raises(ValueError, match=r"list\[MPS\] analog ensemble currently supports only representation='mps'\."):
         simulator.run(states, hamiltonian, sim_params, noise_model=None, parallel=False)
 
 

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -298,6 +298,34 @@ def test_noiseless_mps_matches_density_matrix() -> None:
     assert np.isclose(z_mps, z_rho, atol=1e-4), f"mps={z_mps}, density_matrix={z_rho}"
 
 
+def test_lindblad_propagator_records_all_timepoints() -> None:
+    """Propagator path records observables at every entry in sim_params.times."""
+    n_sites = 1
+    psi = MPS(n_sites, state="ones")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    noise = NoiseModel(processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": sigma_minus}])
+    obs = Observable("z", sites=[0])
+    sim_params = AnalogSimParams(
+        observables=[obs],
+        elapsed_time=0.2,
+        dt=0.05,
+        representation="density_matrix",
+        sample_timesteps=False,
+    )
+    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    assert ctx.step_propagator is not None
+
+    res = lindblad((0, psi, noise, sim_params, h))
+    assert res.shape == (1, len(sim_params.times))
+    assert np.all(np.isfinite(res))
+    assert not np.allclose(res[0, 0], res[0, -1])
+
+
 def test_lindblad_ode_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """When vec(rho) is too large to store exp(L dt), evolution uses RK45 ODE integration."""
     monkeypatch.setattr(lindblad_mod, "MAX_LIOUVILLIAN_VECTOR_DIM", 4)

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -9,7 +9,7 @@
 
 import numpy as np
 
-from mqt.yaqs.analog.lindblad import lindblad
+from mqt.yaqs.analog.lindblad import MAX_LIOUVILLIAN_VECTOR_DIM, lindblad, preprocess_lindblad
 from mqt.yaqs.core.data_structures.networks import MPO, MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams, Observable
@@ -176,9 +176,15 @@ def test_lindblad_zero_strength_noise() -> None:
     obs = Observable("z", sites=[0])
     sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, representation="density_matrix", observables=[obs])
 
-    args = (0, psi, noise, sim_params, h)
-    # Should run without error
-    lindblad(args)
+    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    assert len(ctx.jump_ops) == 0
+    assert ctx.is_unitary
+    dim = 2**n_sites
+    assert dim * dim <= MAX_LIOUVILLIAN_VECTOR_DIM
+    assert ctx.step_propagator is not None
+    assert ctx.step_propagator.shape == (dim * dim, dim * dim)
+
+    lindblad((0, psi, noise, sim_params, h))
 
 
 def test_lindblad_diagnostic_observables() -> None:
@@ -210,6 +216,40 @@ def test_lindblad_diagnostic_observables() -> None:
     assert diag_idx != -1
     # Result for diagnostic should be 0.0
     assert np.allclose(res_lindblad[diag_idx, :], 0.0)
+
+
+def test_preprocess_lindblad_sets_propagator_small_system() -> None:
+    """Small systems precompute a fixed Liouvillian step propagator."""
+    n_sites = 3
+    psi = MPS(n_sites, state="zeros")
+    h = MPO.ising(n_sites, J=1.0, g=0.5)
+    sim_params = AnalogSimParams(
+        dt=0.05,
+        elapsed_time=0.1,
+        representation="density_matrix",
+        observables=[Observable("z", sites=[0])],
+    )
+    ctx = preprocess_lindblad(psi, h, None, sim_params)
+    vec_dim = (2**n_sites) ** 2
+    assert vec_dim <= MAX_LIOUVILLIAN_VECTOR_DIM
+    assert ctx.step_propagator is not None
+    assert ctx.step_propagator.shape == (vec_dim, vec_dim)
+    assert ctx.is_unitary
+
+
+def test_lindblad_noisy_small_system_has_propagator() -> None:
+    """Open-system runs on small Hilbert spaces also use the precomputed propagator."""
+    n_sites = 2
+    psi = MPS(n_sites, state="x+")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    noise = NoiseModel(processes=[{"name": "pauli_z", "sites": [0], "strength": 0.2}])
+    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, representation="density_matrix", observables=[])
+    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    assert not ctx.is_unitary
+    assert ctx.step_propagator is not None
 
 
 def test_noiseless_mps_matches_density_matrix() -> None:

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -7,13 +7,21 @@
 
 """Tests for the Exact Lindblad Solver."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 
+import mqt.yaqs.analog.lindblad as lindblad_mod
 from mqt.yaqs.analog.lindblad import MAX_LIOUVILLIAN_VECTOR_DIM, lindblad, preprocess_lindblad
 from mqt.yaqs.core.data_structures.networks import MPO, MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams, Observable
 from mqt.yaqs.simulator import run
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_lindblad_amplitude_damping() -> None:
@@ -288,3 +296,33 @@ def test_noiseless_mps_matches_density_matrix() -> None:
     assert z_mps is not None
     assert z_rho is not None
     assert np.isclose(z_mps, z_rho, atol=1e-4), f"mps={z_mps}, density_matrix={z_rho}"
+
+
+def test_lindblad_ode_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When vec(rho) is too large to store exp(L dt), evolution uses RK45 ODE integration."""
+    monkeypatch.setattr(lindblad_mod, "MAX_LIOUVILLIAN_VECTOR_DIM", 4)
+    n_sites = 2
+    psi = MPS(n_sites, state="ones")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    gamma = 1.0
+    noise = NoiseModel(processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": sigma_minus}])
+    obs = Observable("z", sites=[0])
+    sim_params = AnalogSimParams(
+        observables=[obs],
+        elapsed_time=0.2,
+        dt=0.05,
+        representation="density_matrix",
+        sample_timesteps=True,
+    )
+
+    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    assert ctx.step_propagator is None
+
+    res = lindblad((0, psi, noise, sim_params, h))
+    assert res.shape == (1, len(sim_params.times))
+    assert np.all(np.isfinite(res))

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -39,7 +39,7 @@ def test_lindblad_amplitude_damping() -> None:
         observables=[obs],
         elapsed_time=t_max,
         dt=dt,
-        solver="Lindblad",
+        representation="density_matrix",
         num_traj=1,  # Deterministic
     )
 
@@ -68,7 +68,7 @@ def test_lindblad_unitary_rabi() -> None:
     dt = 0.05
     obs = Observable("z", sites=[0])
 
-    sim_params = AnalogSimParams(observables=[obs], elapsed_time=t_max, dt=dt, solver="Lindblad")
+    sim_params = AnalogSimParams(observables=[obs], elapsed_time=t_max, dt=dt, representation="density_matrix")
 
     run(initial_state, hamiltonian, sim_params, None)
 
@@ -103,7 +103,7 @@ def test_lindblad_dephasing() -> None:
     obs0 = Observable("x", sites=[0])
     obs1 = Observable("x", sites=[1])
 
-    sim_params = AnalogSimParams(observables=[obs0, obs1], elapsed_time=t_max, dt=dt, solver="Lindblad")
+    sim_params = AnalogSimParams(observables=[obs0, obs1], elapsed_time=t_max, dt=dt, representation="density_matrix")
 
     run(initial_state, hamiltonian, sim_params, noise_model)
 
@@ -149,7 +149,7 @@ def test_lindblad_dephasing_both_qubits() -> None:
     obs0 = Observable("x", sites=[0])
     obs1 = Observable("x", sites=[1])
 
-    sim_params = AnalogSimParams(observables=[obs0, obs1], elapsed_time=t_max, dt=dt, solver="Lindblad")
+    sim_params = AnalogSimParams(observables=[obs0, obs1], elapsed_time=t_max, dt=dt, representation="density_matrix")
 
     run(initial_state, hamiltonian, sim_params, noise_model)
 
@@ -174,7 +174,7 @@ def test_lindblad_zero_strength_noise() -> None:
     noise = NoiseModel(processes=[{"name": "lowering", "sites": [0], "strength": 0.0}])
 
     obs = Observable("z", sites=[0])
-    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, solver="Lindblad", observables=[obs])
+    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, representation="density_matrix", observables=[obs])
 
     args = (0, psi, noise, sim_params, h)
     # Should run without error
@@ -192,7 +192,9 @@ def test_lindblad_diagnostic_observables() -> None:
     # Also add a real observable to verify mixing
     obs_real = Observable("z", sites=[0])
 
-    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, solver="Lindblad", observables=[obs_diag, obs_real])
+    sim_params = AnalogSimParams(
+        dt=0.1, elapsed_time=0.1, representation="density_matrix", observables=[obs_diag, obs_real]
+    )
 
     # Lindblad args: (traj_idx, psi, noise_model, sim_params, hamiltonian)
     args = (0, psi, None, sim_params, h)
@@ -208,3 +210,41 @@ def test_lindblad_diagnostic_observables() -> None:
     assert diag_idx != -1
     # Result for diagnostic should be 0.0
     assert np.allclose(res_lindblad[diag_idx, :], 0.0)
+
+
+def test_noiseless_mps_matches_density_matrix() -> None:
+    """Noiseless Hamiltonian evolution agrees between mps and density_matrix representations."""
+    n_sites = 3
+    psi = MPS(n_sites, state="zeros")
+    h = MPO.ising(n_sites, J=1.0, g=0.5)
+    obs = Observable("z", sites=[0])
+    t_max = 0.5
+    dt = 0.1
+
+    params_mps = AnalogSimParams(
+        observables=[obs],
+        elapsed_time=t_max,
+        dt=dt,
+        representation="mps",
+        max_bond_dim=32,
+        show_progress=False,
+    )
+    run(psi, h, params_mps, None)
+    assert obs.results is not None
+    z_mps = obs.results[-1]
+
+    obs_rho = Observable("z", sites=[0])
+    params_rho = AnalogSimParams(
+        observables=[obs_rho],
+        elapsed_time=t_max,
+        dt=dt,
+        representation="density_matrix",
+        show_progress=False,
+    )
+    run(psi, h, params_rho, None)
+    assert obs_rho.results is not None
+    z_rho = obs_rho.results[-1]
+
+    assert z_mps is not None
+    assert z_rho is not None
+    assert np.isclose(z_mps, z_rho, atol=1e-4), f"mps={z_mps}, density_matrix={z_rho}"

--- a/tests/analog/test_mcwf.py
+++ b/tests/analog/test_mcwf.py
@@ -7,13 +7,21 @@
 
 """Tests for the Monte Carlo Wavefunction (MCWF) Solver."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 
+import mqt.yaqs.analog.mcwf as mcwf_mod
 from mqt.yaqs.analog.mcwf import MAX_PRECOMPUTE_DIM, mcwf, preprocess_mcwf
 from mqt.yaqs.core.data_structures.networks import MPO, MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams, Observable
 from mqt.yaqs.simulator import run
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_mcwf_amplitude_damping() -> None:
@@ -237,3 +245,109 @@ def test_mcwf_diagnostic_observables() -> None:
     res_mcwf = mcwf((0, ctx))
     # Result for diagnostic should be 0.0
     assert np.allclose(res_mcwf[diag_idx, :], 0.0)
+
+
+def test_mcwf_trajectory_rng_seeding() -> None:
+    """Same traj_idx yields identical MCWF trajectories; different indices differ."""
+    n_sites = 1
+    psi = MPS(n_sites, state="x+")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    sigma_z = np.array([[1, 0], [0, -1]], dtype=complex)
+    noise = NoiseModel(
+        processes=[{"name": "dephasing", "sites": [0], "strength": 2.0, "matrix": sigma_z}]
+    )
+    obs = Observable("x", sites=[0])
+    sim_params = AnalogSimParams(
+        dt=0.02,
+        elapsed_time=1.0,
+        representation="vector",
+        observables=[obs],
+        sample_timesteps=True,
+    )
+    ctx = preprocess_mcwf(psi, h, noise, sim_params)
+
+    res_a = mcwf((3, ctx))
+    res_b = mcwf((3, ctx))
+    res_c = mcwf((7, ctx))
+
+    assert np.allclose(res_a, res_b)
+    assert not np.allclose(res_a, res_c)
+
+
+def test_mcwf_noisy_evolution_with_propagator() -> None:
+    """Noisy open-system evolution uses the precomputed step propagator path."""
+    n_sites = 2
+    psi = MPS(n_sites, state="x+")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    noise = NoiseModel(processes=[{"name": "pauli_z", "sites": [0], "strength": 0.3}])
+    obs = Observable("z", sites=[0])
+    sim_params = AnalogSimParams(
+        dt=0.05,
+        elapsed_time=0.15,
+        representation="vector",
+        observables=[obs],
+        sample_timesteps=True,
+    )
+    ctx = preprocess_mcwf(psi, h, noise, sim_params)
+    assert ctx.step_propagator is not None
+    assert not ctx.is_unitary
+
+    res = mcwf((0, ctx))
+    assert res.shape == (1, len(sim_params.times))
+    assert np.all(np.isfinite(res))
+
+
+def test_mcwf_unitary_krylov_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When U_step is not stored, unitary evolution uses expm_krylov per step."""
+    monkeypatch.setattr(mcwf_mod, "MAX_PRECOMPUTE_DIM", 4)
+    n_sites = 3
+    psi = MPS(n_sites, state="zeros")
+    h = MPO.ising(n_sites, J=1.0, g=0.5)
+    obs = Observable("z", sites=[0])
+    sim_params = AnalogSimParams(
+        dt=0.05,
+        elapsed_time=0.1,
+        representation="vector",
+        observables=[obs],
+        sample_timesteps=True,
+    )
+    ctx = preprocess_mcwf(psi, h, None, sim_params)
+    assert ctx.step_propagator is None
+    assert ctx.is_unitary
+
+    res = mcwf((0, ctx))
+    assert res.shape == (1, len(sim_params.times))
+    assert np.all(np.isfinite(res))
+
+
+def test_mcwf_noisy_arnoldi_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When U_step is not stored, noisy evolution uses expm_arnoldi per step."""
+    monkeypatch.setattr(mcwf_mod, "MAX_PRECOMPUTE_DIM", 4)
+    n_sites = 3
+    psi = MPS(n_sites, state="x+")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    noise = NoiseModel(processes=[{"name": "pauli_z", "sites": [0], "strength": 0.2}])
+    obs = Observable("z", sites=[0])
+    sim_params = AnalogSimParams(
+        dt=0.05,
+        elapsed_time=0.1,
+        representation="vector",
+        observables=[obs],
+        sample_timesteps=True,
+    )
+    ctx = preprocess_mcwf(psi, h, noise, sim_params)
+    assert ctx.step_propagator is None
+    assert not ctx.is_unitary
+
+    res = mcwf((0, ctx))
+    assert res.shape == (1, len(sim_params.times))
+    assert np.all(np.isfinite(res))

--- a/tests/analog/test_mcwf.py
+++ b/tests/analog/test_mcwf.py
@@ -9,7 +9,7 @@
 
 import numpy as np
 
-from mqt.yaqs.analog.mcwf import mcwf, preprocess_mcwf
+from mqt.yaqs.analog.mcwf import MAX_PRECOMPUTE_DIM, mcwf, preprocess_mcwf
 from mqt.yaqs.core.data_structures.networks import MPO, MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams, Observable
@@ -162,9 +162,46 @@ def test_mcwf_zero_strength_noise() -> None:
         dt=0.1, elapsed_time=0.1, representation="vector", observables=[Observable("z", sites=[0])]
     )
 
-    # Preprocess should not add any jump ops
     ctx = preprocess_mcwf(psi, h, noise, sim_params)
     assert len(ctx.jump_ops) == 0
+    assert ctx.is_unitary
+    dim = 2**n_sites
+    assert ctx.step_propagator is not None
+    assert ctx.step_propagator.shape == (dim, dim)
+
+
+def test_preprocess_mcwf_sets_propagator_small_system() -> None:
+    """Small systems precompute a fixed time-step propagator."""
+    n_sites = 3
+    psi = MPS(n_sites, state="zeros")
+    h = MPO.ising(n_sites, J=1.0, g=0.5)
+    sim_params = AnalogSimParams(
+        dt=0.05,
+        elapsed_time=0.1,
+        representation="vector",
+        observables=[Observable("z", sites=[0])],
+    )
+    ctx = preprocess_mcwf(psi, h, None, sim_params)
+    dim = 2**n_sites
+    assert dim <= MAX_PRECOMPUTE_DIM
+    assert ctx.step_propagator is not None
+    assert ctx.step_propagator.shape == (dim, dim)
+    assert ctx.is_unitary
+
+
+def test_mcwf_noisy_system_has_propagator() -> None:
+    """Open-system runs on small Hilbert spaces also use the precomputed propagator."""
+    n_sites = 2
+    psi = MPS(n_sites, state="x+")
+    h = MPO()
+    h.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    noise = NoiseModel(processes=[{"name": "pauli_z", "sites": [0], "strength": 0.2}])
+    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, representation="vector", observables=[])
+    ctx = preprocess_mcwf(psi, h, noise, sim_params)
+    assert not ctx.is_unitary
+    assert ctx.step_propagator is not None
 
 
 def test_mcwf_diagnostic_observables() -> None:

--- a/tests/analog/test_mcwf.py
+++ b/tests/analog/test_mcwf.py
@@ -41,7 +41,7 @@ def test_mcwf_amplitude_damping() -> None:
     # We need enough trajectories to converge reasonably well
     num_traj = 200
     sim_params = AnalogSimParams(
-        observables=[obs], elapsed_time=t_max, dt=dt, solver="MCWF", num_traj=num_traj, show_progress=False
+        observables=[obs], elapsed_time=t_max, dt=dt, representation="vector", num_traj=num_traj, show_progress=False
     )
 
     run(initial_state, hamiltonian, sim_params, noise_model, parallel=False)
@@ -81,7 +81,7 @@ def test_mcwf_unitary_rabi() -> None:
         observables=[obs],
         elapsed_time=t_max,
         dt=dt,
-        solver="MCWF",
+        representation="vector",
         num_traj=1,  # Deterministic
     )
 
@@ -121,7 +121,12 @@ def test_mcwf_dephasing() -> None:
 
     num_traj = 200
     sim_params = AnalogSimParams(
-        observables=[obs0, obs1], elapsed_time=t_max, dt=dt, solver="MCWF", num_traj=num_traj, show_progress=False
+        observables=[obs0, obs1],
+        elapsed_time=t_max,
+        dt=dt,
+        representation="vector",
+        num_traj=num_traj,
+        show_progress=False,
     )
 
     # Use parallel=True to verify infrastructure
@@ -153,7 +158,9 @@ def test_mcwf_zero_strength_noise() -> None:
     # Define noise with 0 strength
     noise = NoiseModel(processes=[{"name": "lowering", "sites": [0], "strength": 0.0}])
 
-    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, solver="MCWF", observables=[Observable("z", sites=[0])])
+    sim_params = AnalogSimParams(
+        dt=0.1, elapsed_time=0.1, representation="vector", observables=[Observable("z", sites=[0])]
+    )
 
     # Preprocess should not add any jump ops
     ctx = preprocess_mcwf(psi, h, noise, sim_params)
@@ -171,7 +178,7 @@ def test_mcwf_diagnostic_observables() -> None:
     # Also add a real observable to verify mixing
     obs_real = Observable("z", sites=[0])
 
-    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, solver="MCWF", observables=[obs_diag, obs_real])
+    sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, representation="vector", observables=[obs_diag, obs_real])
 
     # MCWF Preprocess
     ctx = preprocess_mcwf(psi, h, None, sim_params)

--- a/tests/analog/test_mcwf.py
+++ b/tests/analog/test_mcwf.py
@@ -256,9 +256,7 @@ def test_mcwf_trajectory_rng_seeding() -> None:
     for i in range(len(h.tensors)):
         h.tensors[i] *= 0.0
     sigma_z = np.array([[1, 0], [0, -1]], dtype=complex)
-    noise = NoiseModel(
-        processes=[{"name": "dephasing", "sites": [0], "strength": 2.0, "matrix": sigma_z}]
-    )
+    noise = NoiseModel(processes=[{"name": "dephasing", "sites": [0], "strength": 2.0, "matrix": sigma_z}])
     obs = Observable("x", sites=[0])
     sim_params = AnalogSimParams(
         dt=0.02,

--- a/tests/characterization/tomography/test_tomography.py
+++ b/tests/characterization/tomography/test_tomography.py
@@ -104,9 +104,9 @@ def test_tomography_run_defaults() -> None:
 
 
 def test_tomography_mcwf_multistep() -> None:
-    """Test multi-step process tomography with MCWF solver."""
+    """Test multi-step process tomography with vector representation."""
     op = MPO.ising(length=2, J=1.0, g=0.5)
-    params = AnalogSimParams(dt=0.1, solver="MCWF", num_traj=10)
+    params = AnalogSimParams(dt=0.1, representation="vector", num_traj=10)
     pt = run(op, params, timesteps=[0.1, 0.1])
     assert pt.tensor.shape == (4, 16, 16)
 

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -21,6 +21,8 @@ quantum simulation. It verifies that:
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import numpy as np
 import pytest
 
@@ -90,7 +92,7 @@ def test_analog_simparams_defaults() -> None:
 def test_analog_simparams_invalid_representation() -> None:
     """Test that AnalogSimParams rejects unknown representation values."""
     with pytest.raises(ValueError, match=r"Invalid representation 'tjm'"):
-        AnalogSimParams(representation="tjm")  # ty: ignore[invalid-argument-type]
+        AnalogSimParams(representation=cast("Any", "tjm"))
 
 
 def test_observable_initialize_with_sample_timesteps() -> None:

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -84,6 +84,13 @@ def test_analog_simparams_defaults() -> None:
     assert params.max_bond_dim == 4096
     assert params.threshold == pytest.approx(1e-9)
     assert params.order == 1
+    assert params.representation == "mps"
+
+
+def test_analog_simparams_invalid_representation() -> None:
+    """Test that AnalogSimParams rejects unknown representation values."""
+    with pytest.raises(ValueError, match=r"Invalid representation 'tjm'"):
+        AnalogSimParams(representation="tjm")  # ty: ignore[invalid-argument-type]
 
 
 def test_observable_initialize_with_sample_timesteps() -> None:

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -92,7 +92,7 @@ def test_analog_simparams_defaults() -> None:
 def test_analog_simparams_invalid_representation() -> None:
     """Test that AnalogSimParams rejects unknown representation values."""
     with pytest.raises(ValueError, match=r"Invalid representation 'tjm'"):
-        AnalogSimParams(representation=cast("Any", "tjm"))
+        AnalogSimParams(representation=cast(Any, "tjm"))  # noqa: TC006
 
 
 def test_observable_initialize_with_sample_timesteps() -> None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -256,6 +256,20 @@ def test_analog_simulation_get_state() -> None:
         np.testing.assert_allclose(1, fidelity)
 
 
+def test_density_matrix_get_state_rejected() -> None:
+    """density_matrix evolution does not support returning an output state."""
+    psi = MPS(2, state="zeros")
+    h = MPO.ising(2, J=1.0, g=0.5)
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        representation="density_matrix",
+        get_state=True,
+        show_progress=False,
+    )
+    with pytest.raises(ValueError, match=r"get_state=True is not supported for representation='density_matrix'"):
+        simulator.run(psi, h, sim_params, None)
+
+
 def test_strong_simulation() -> None:
     """Test the circuit-based simulation branch using StrongSimParams.
 


### PR DESCRIPTION
## Description

This PR is intended to promote the noise-free simulation ability of YAQS. In particular, the noise-free paths of the TJM, MCWF, and Lindblad have been updated for performance. Finally, the solver setting in AnalogSimParams has been changed to representation. Rather than set TJM, MCWF, Lindbladian, it is now MPS, vector, density_matrix respectively.


## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
