### PR TITLE
added accuracy presets to simulation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- added accuracy presets to simulation parameters ([#438]) ([**@aaronleesander**])
 - added linalg submodule to open a new path for optimizations and stop BLAS thread oversubscription for stability ([#429]) ([**@aaronleesander**])
 - added high-level State and Hamiltonian classes at user-facing level ([#426]) ([**@aaronleesander**])
 - added Fermionic and Jordan-Wigner MPO encodings of 1D Fermi-Hubbard model ([#220]) ([**@thilomueller**])
@@ -119,6 +120,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#438]: https://github.com/munich-quantum-toolkit/yaqs/pull/438
 [#430]: https://github.com/munich-quantum-toolkit/yaqs/pull/430
 [#429]: https://github.com/munich-quantum-toolkit/yaqs/pull/428
 [#428]: https://github.com/munich-quantum-toolkit/yaqs/pull/428

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -11,11 +11,11 @@ mystnb:
 
 YAQS separates **what you evolve** ({class}`~mqt.yaqs.core.data_structures.state.State`, circuits, Hamiltonians) from **how you truncate and sample** via parameter objects passed to {meth}`~mqt.yaqs.Simulator.run`:
 
-| Class | Use when |
-| ----- | -------- |
+| Class                                                                         | Use when                                                                                     |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | {class}`~mqt.yaqs.core.data_structures.simulation_parameters.AnalogSimParams` | Open-system or unitary time evolution (TDVP / BUG, MCWF trajectories, Lindblad-style paths). |
-| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.StrongSimParams` | Noisy **strong** digital simulation (per-trajectory MPS evolution with observables). |
-| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.WeakSimParams` | Noisy **weak** digital simulation (shot-based sampling; you set `shots` explicitly). |
+| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.StrongSimParams` | Noisy **strong** digital simulation (per-trajectory MPS evolution with observables).         |
+| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.WeakSimParams`   | Noisy **weak** digital simulation (shot-based sampling; you set `shots` explicitly).         |
 
 This page shows how to construct each class. For {class}`~mqt.yaqs.Simulator` execution options (parallelism, progress bars), see {doc}`simulator_initialization`.
 
@@ -23,11 +23,11 @@ This page shows how to construct each class. For {class}`~mqt.yaqs.Simulator` ex
 
 All three classes accept a keyword-only `accuracy` argument (default `"balanced"`) that sets truncation and, for analog/strong simulations, trajectory counts:
 
-| `accuracy` | `threshold` | `max_bond_dim` | `num_traj` (analog / strong) |
-| ---------- | ----------- | -------------- | ---------------------------- |
-| `"fast"` | `1e-3` | `16` | `64` |
-| `"balanced"` (default) | `1e-6` | `128` | `256` |
-| `"accurate"` | `1e-9` | `4096` | `1024` |
+| `accuracy`             | `threshold` | `max_bond_dim` | `num_traj` (analog / strong) |
+| ---------------------- | ----------- | -------------- | ---------------------------- |
+| `"fast"`               | `1e-3`      | `16`           | `64`                         |
+| `"balanced"` (default) | `1e-6`      | `128`          | `256`                        |
+| `"accurate"`           | `1e-9`      | `4096`         | `1024`                       |
 
 - **`"fast"`** — quick tests, examples, and CI-style runs.
 - **`"balanced"`** — default tradeoff for exploratory work.

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -1,0 +1,156 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  number_source_lines: true
+  execution_timeout: 300
+---
+
+# Configuring Simulation Parameters
+
+YAQS separates **what you evolve** ({class}`~mqt.yaqs.core.data_structures.state.State`, circuits, Hamiltonians) from **how you truncate and sample** via parameter objects passed to {meth}`~mqt.yaqs.Simulator.run`:
+
+| Class | Use when |
+| ----- | -------- |
+| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.AnalogSimParams` | Open-system or unitary time evolution (TDVP / BUG, MCWF trajectories, Lindblad-style paths). |
+| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.StrongSimParams` | Noisy **strong** digital simulation (per-trajectory MPS evolution with observables). |
+| {class}`~mqt.yaqs.core.data_structures.simulation_parameters.WeakSimParams` | Noisy **weak** digital simulation (shot-based sampling; you set `shots` explicitly). |
+
+This page shows how to construct each class. For {class}`~mqt.yaqs.Simulator` execution options (parallelism, progress bars), see {doc}`simulator_initialization`.
+
+## Accuracy presets
+
+All three classes accept a keyword-only `accuracy` argument (default `"balanced"`) that sets truncation and, for analog/strong simulations, trajectory counts:
+
+| `accuracy` | `threshold` | `max_bond_dim` | `num_traj` (analog / strong) |
+| ---------- | ----------- | -------------- | ---------------------------- |
+| `"fast"` | `1e-3` | `16` | `64` |
+| `"balanced"` (default) | `1e-6` | `128` | `256` |
+| `"accurate"` | `1e-9` | `4096` | `1024` |
+
+- **`"fast"`** — quick tests, examples, and CI-style runs.
+- **`"balanced"`** — default tradeoff for exploratory work.
+- **`"accurate"`** — strictest built-in preset (`threshold=1e-9`, `max_bond_dim=4096`, `num_traj=1024` for stochastic runs).
+- **Overrides** — pass `threshold`, `max_bond_dim`, and/or `num_traj` explicitly; any non-`None` value wins over the preset.
+
+`min_bond_dim` (default `2`) and `trunc_mode` (default `"discarded_weight"`) are unchanged across presets. The chosen preset is stored on the object as `params.accuracy`.
+
+## Recommended usage
+
+```{code-cell} ipython3
+from mqt.yaqs.core.data_structures.simulation_parameters import (
+    ACCURACY_PRESETS,
+    AnalogSimParams,
+    Observable,
+    StrongSimParams,
+    WeakSimParams,
+)
+from mqt.yaqs.core.libraries.gate_library import Z
+
+
+def _trunc_summary(params: AnalogSimParams | StrongSimParams | WeakSimParams) -> dict[str, object]:
+    """Collect accuracy-related fields for display."""
+    out: dict[str, object] = {
+        "accuracy": params.accuracy,
+        "threshold": params.threshold,
+        "max_bond_dim": params.max_bond_dim,
+    }
+    if isinstance(params, WeakSimParams):
+        out["shots"] = params.shots
+    else:
+        out["num_traj"] = params.num_traj
+    return out
+```
+
+```{code-cell} ipython3
+# Default: balanced preset
+analog_params = AnalogSimParams()
+print("default", _trunc_summary(analog_params))
+
+# Fast preset for quick tests, examples, and CI-style runs
+fast_params = AnalogSimParams(accuracy="fast")
+print("fast", _trunc_summary(fast_params))
+
+# Balanced preset for normal exploratory use
+balanced_params = StrongSimParams(accuracy="balanced")
+print("balanced", _trunc_summary(balanced_params))
+
+# Accurate preset for stricter built-in settings
+accurate_params = StrongSimParams(accuracy="accurate")
+print("accurate", _trunc_summary(accurate_params))
+```
+
+Explicit numerical values override the preset (advanced control):
+
+```{code-cell} ipython3
+custom_params = StrongSimParams(
+    accuracy="balanced",
+    threshold=1e-8,
+    max_bond_dim=512,
+    num_traj=512,
+)
+_trunc_summary(custom_params)
+```
+
+Weak simulation: `shots` remain explicit and are **not** controlled by `accuracy`:
+
+```{code-cell} ipython3
+weak_params = WeakSimParams(
+    shots=1024,
+    accuracy="fast",
+)
+_trunc_summary(weak_params)
+```
+
+## `AnalogSimParams`
+
+Besides truncation settings, you typically set the time grid (`elapsed_time`, `dt`), observables, and whether to record intermediate times (`sample_timesteps`).
+
+```{code-cell} ipython3
+L = 4
+observables = [Observable(Z(), site) for site in range(L)]
+
+analog = AnalogSimParams(
+    observables=observables,
+    elapsed_time=0.2,
+    dt=0.05,
+    accuracy="accurate",
+)
+_trunc_summary(analog)
+```
+
+Pass the resulting object to {meth}`~mqt.yaqs.Simulator.run` together with a {class}`~mqt.yaqs.core.data_structures.state.State` and {class}`~mqt.yaqs.core.data_structures.hamiltonian.Hamiltonian` (see {doc}`analog_simulation`).
+
+## `StrongSimParams`
+
+Used for noisy strong circuit simulation. Provide observables and optionally enable layer sampling (see {doc}`strong_circuit_simulation`).
+
+```{code-cell} ipython3
+strong = StrongSimParams(
+    observables=[Observable(Z(), 0)],
+    accuracy="accurate",
+)
+_trunc_summary(strong)
+```
+
+## `WeakSimParams`
+
+Used for noisy weak simulation. **`shots` is always required** and is not part of the accuracy preset.
+
+```{code-cell} ipython3
+weak_balanced = WeakSimParams(shots=1000)
+weak_accurate = WeakSimParams(shots=1000, accuracy="accurate")
+print("balanced", _trunc_summary(weak_balanced))
+print("accurate", _trunc_summary(weak_accurate))
+```
+
+See {doc}`weak_circuit_simulation` for a full example with measurement histograms.
+
+## Reference: preset table in code
+
+The built-in values are defined in {data}`~mqt.yaqs.core.data_structures.simulation_parameters.ACCURACY_PRESETS`:
+
+```{code-cell} ipython3
+ACCURACY_PRESETS
+```

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -33,12 +33,12 @@ AccuracyPreset = Literal["fast", "balanced", "accurate"]
 ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
     "fast": {"threshold": 1e-3, "max_bond_dim": 16, "num_traj": 64},
     "balanced": {"threshold": 1e-6, "max_bond_dim": 128, "num_traj": 256},
-    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1000},
+    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
 }
 
 _EXPERT_DEFAULT_THRESHOLD = 1e-9
 _EXPERT_DEFAULT_MAX_BOND_DIM = 4096
-_EXPERT_DEFAULT_NUM_TRAJ = 1000
+_EXPERT_DEFAULT_NUM_TRAJ = 1024
 
 
 def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None:

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -36,45 +36,25 @@ ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
     "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
 }
 
-_EXPERT_DEFAULT_THRESHOLD = 1e-9
-_EXPERT_DEFAULT_MAX_BOND_DIM = 4096
-_EXPERT_DEFAULT_NUM_TRAJ = 1000
 
-
-def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None:
+def _validate_accuracy(accuracy: AccuracyPreset) -> AccuracyPreset:
     """Validate ``accuracy`` preset names at runtime.
 
-    Args:
-        accuracy: Preset name or ``None`` for expert defaults.
-
     Returns:
-        The validated preset name, or ``None``.
+        The validated preset name.
 
     Raises:
         ValueError: If ``accuracy`` is not a supported preset name.
     """
-    if accuracy is None:
-        return None
     if accuracy not in ACCURACY_PRESETS:
         msg = f"accuracy must be one of {sorted(ACCURACY_PRESETS)!r}, got {accuracy!r}."
         raise ValueError(msg)
     return accuracy
 
 
-def _get_accuracy_preset(accuracy: AccuracyPreset | None) -> dict[str, float | int]:
-    """Return the preset values for ``accuracy`` or expert defaults for ``None``.
-
-    Returns:
-        Mapping with ``threshold``, ``max_bond_dim``, and ``num_traj`` keys.
-    """
-    accuracy = _validate_accuracy(accuracy)
-    if accuracy is None:
-        return {
-            "threshold": _EXPERT_DEFAULT_THRESHOLD,
-            "max_bond_dim": _EXPERT_DEFAULT_MAX_BOND_DIM,
-            "num_traj": _EXPERT_DEFAULT_NUM_TRAJ,
-        }
-    return ACCURACY_PRESETS[accuracy]
+def _get_accuracy_preset(accuracy: AccuracyPreset) -> dict[str, float | int]:
+    """Return the preset values for ``accuracy``."""
+    return ACCURACY_PRESETS[_validate_accuracy(accuracy)]
 
 
 def _validate_random_seed(random_seed: int | None) -> None:
@@ -161,8 +141,8 @@ class AnalogSimParams:
         random_seed: If set, seeds per-trajectory jump RNG and static noise sampling for reproducible runs.
         max_bond_dim: Maximum allowed bond dimension.
         accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Default is ``"balanced"``. ``"fast"`` is intended for quick tests and
+            examples, while ``"accurate"`` uses the strictest built-in settings.
             Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
         trunc_mode: Truncation mode used in TDVP (``"discarded_weight"`` or ``"relative"``).
         threshold: Truncation threshold.
@@ -185,7 +165,7 @@ class AnalogSimParams:
         threshold: float | None = None,
         order: int = 1,
         *,
-        accuracy: AccuracyPreset | None = "balanced",
+        accuracy: AccuracyPreset = "balanced",
         sample_timesteps: bool = True,
         evolution_mode: EvolutionMode = EvolutionMode.TDVP,
         get_state: bool = False,
@@ -205,8 +185,8 @@ class AnalogSimParams:
             max_bond_dim: Maximum bond dimension allowed.
             min_bond_dim: Minimum bond dimension used to improve TDVP accuracy when possible.
             accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Default is ``"balanced"``. ``"fast"`` is intended for quick tests and
+                examples, while ``"accurate"`` uses the strictest built-in settings.
                 Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Threshold for simulation accuracy.
@@ -271,8 +251,8 @@ class StrongSimParams:
             sampling for reproducible runs.
         max_bond_dim: The maximum bond dimension for the simulation.
         accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Default is ``"balanced"``. ``"fast"`` is intended for quick tests and
+            examples, while ``"accurate"`` uses the strictest built-in settings.
             Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
         min_bond_dim: The minimum bond dimension if possible which gives TDVP
             better accuracy. Default is 2.
@@ -296,7 +276,7 @@ class StrongSimParams:
         trunc_mode: str = "discarded_weight",
         threshold: float | None = None,
         *,
-        accuracy: AccuracyPreset | None = "balanced",
+        accuracy: AccuracyPreset = "balanced",
         get_state: bool = False,
         sample_layers: bool = False,
         num_mid_measurements: int = 0,
@@ -312,8 +292,8 @@ class StrongSimParams:
             max_bond_dim: Maximum bond dimension allowed in simulation.
             min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
             accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Default is ``"balanced"``. ``"fast"`` is intended for quick tests and
+                examples, while ``"accurate"`` uses the strictest built-in settings.
                 Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Threshold for simulation accuracy.
@@ -362,8 +342,8 @@ class WeakSimParams:
         shots: The number of shots for the simulation.
         max_bond_dim: The maximum bond dimension for the simulation.
         accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
-            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Default is ``"balanced"``. ``"fast"`` is intended for quick tests and
+            examples, while ``"accurate"`` uses the strictest built-in settings.
             Explicit ``threshold`` and ``max_bond_dim`` override the preset.
         min_bond_dim: The minimum bond dimension if possible which gives TDVP
             better accuracy. Default is 2.
@@ -387,7 +367,7 @@ class WeakSimParams:
         trunc_mode: str = "discarded_weight",
         threshold: float | None = None,
         *,
-        accuracy: AccuracyPreset | None = "balanced",
+        accuracy: AccuracyPreset = "balanced",
         get_state: bool = False,
         random_seed: int | None = None,
     ) -> None:
@@ -400,8 +380,8 @@ class WeakSimParams:
             max_bond_dim: Maximum bond dimension for simulation.
             min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
             accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
-                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Default is ``"balanced"``. ``"fast"`` is intended for quick tests and
+                examples, while ``"accurate"`` uses the strictest built-in settings.
                 Explicit ``threshold`` and ``max_bond_dim`` override the preset.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Accuracy threshold for truncating tensors.

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -256,72 +256,6 @@ class AnalogSimParams:
         )
 
 
-class WeakSimParams:
-    """A class to represent the parameters for a weak simulation.
-
-    Attributes:
-        dt: A placeholder property for code compatibility.
-        num_traj: A placeholder property for code compatibility.
-        shots: The number of shots for the simulation.
-        max_bond_dim: The maximum bond dimension for the simulation.
-        accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
-            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
-            Explicit ``threshold`` and ``max_bond_dim`` override the preset.
-        min_bond_dim: The minimum bond dimension if possible which gives TDVP
-            better accuracy. Default is 2.
-        trunc_mode: The type of truncation performed in TDVP. Options are
-            ``"discarded_weight"`` and ``"relative"``.
-        threshold: The threshold value for the simulation.
-        window_size: The window size for the simulation.
-        get_state: If ``True``, request the final state on the returned
-            :class:`~mqt.yaqs.Result`.
-    """
-
-    # Properties set as placeholders for code compatibility
-    dt = 1
-    num_traj = 0
-
-    def __init__(
-        self,
-        shots: int,
-        max_bond_dim: int | None = None,
-        min_bond_dim: int = 2,
-        trunc_mode: str = "discarded_weight",
-        threshold: float | None = None,
-        *,
-        accuracy: AccuracyPreset | None = "balanced",
-        get_state: bool = False,
-        random_seed: int | None = None,
-    ) -> None:
-        """Weak circuit simulation initialization.
-
-        Initializes parameters for a weak circuit simulation.
-
-        Args:
-            shots: Number of measurement shots to simulate.
-            max_bond_dim: Maximum bond dimension for simulation.
-            min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
-            accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
-                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
-                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
-                Explicit ``threshold`` and ``max_bond_dim`` override the preset.
-            trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
-            threshold: Accuracy threshold for truncating tensors.
-            get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
-            random_seed: If set, makes per-shot jump RNG reproducible.
-        """
-        _validate_random_seed(random_seed)
-        preset = _get_accuracy_preset(accuracy)
-        self.shots = shots
-        self.max_bond_dim = max_bond_dim if max_bond_dim is not None else int(preset["max_bond_dim"])
-        self.min_bond_dim = min_bond_dim
-        self.trunc_mode = trunc_mode
-        self.threshold = threshold if threshold is not None else float(preset["threshold"])
-        self.get_state = get_state
-        self.random_seed = random_seed
-
-
 class StrongSimParams:
     """Strong Circuit Simulation Parameters.
 
@@ -414,4 +348,70 @@ class StrongSimParams:
         self.get_state = get_state
         self.sample_layers = sample_layers
         self.num_mid_measurements = num_mid_measurements
+        self.random_seed = random_seed
+
+
+class WeakSimParams:
+    """A class to represent the parameters for a weak simulation.
+
+    Attributes:
+        dt: A placeholder property for code compatibility.
+        num_traj: A placeholder property for code compatibility.
+        shots: The number of shots for the simulation.
+        max_bond_dim: The maximum bond dimension for the simulation.
+        accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
+            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Explicit ``threshold`` and ``max_bond_dim`` override the preset.
+        min_bond_dim: The minimum bond dimension if possible which gives TDVP
+            better accuracy. Default is 2.
+        trunc_mode: The type of truncation performed in TDVP. Options are
+            ``"discarded_weight"`` and ``"relative"``.
+        threshold: The threshold value for the simulation.
+        window_size: The window size for the simulation.
+        get_state: If ``True``, request the final state on the returned
+            :class:`~mqt.yaqs.Result`.
+    """
+
+    # Properties set as placeholders for code compatibility
+    dt = 1
+    num_traj = 0
+
+    def __init__(
+        self,
+        shots: int,
+        max_bond_dim: int | None = None,
+        min_bond_dim: int = 2,
+        trunc_mode: str = "discarded_weight",
+        threshold: float | None = None,
+        *,
+        accuracy: AccuracyPreset | None = "balanced",
+        get_state: bool = False,
+        random_seed: int | None = None,
+    ) -> None:
+        """Weak circuit simulation initialization.
+
+        Initializes parameters for a weak circuit simulation.
+
+        Args:
+            shots: Number of measurement shots to simulate.
+            max_bond_dim: Maximum bond dimension for simulation.
+            min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
+            accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
+                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Explicit ``threshold`` and ``max_bond_dim`` override the preset.
+            trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
+            threshold: Accuracy threshold for truncating tensors.
+            get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
+            random_seed: If set, makes per-shot jump RNG reproducible.
+        """
+        _validate_random_seed(random_seed)
+        preset = _get_accuracy_preset(accuracy)
+        self.shots = shots
+        self.max_bond_dim = max_bond_dim if max_bond_dim is not None else int(preset["max_bond_dim"])
+        self.min_bond_dim = min_bond_dim
+        self.trunc_mode = trunc_mode
+        self.threshold = threshold if threshold is not None else float(preset["threshold"])
+        self.get_state = get_state
         self.random_seed = random_seed

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import copy
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -33,14 +33,12 @@ AccuracyPreset = Literal["fast", "balanced", "accurate"]
 ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
     "fast": {"threshold": 1e-3, "max_bond_dim": 16, "num_traj": 64},
     "balanced": {"threshold": 1e-6, "max_bond_dim": 128, "num_traj": 256},
-    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
+    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1000},
 }
 
 _EXPERT_DEFAULT_THRESHOLD = 1e-9
 _EXPERT_DEFAULT_MAX_BOND_DIM = 4096
 _EXPERT_DEFAULT_NUM_TRAJ = 1000
-
-_T = TypeVar("_T")
 
 
 def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None:
@@ -63,32 +61,20 @@ def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None
     return accuracy
 
 
-def _preset_bond_trunc_and_traj(
-    accuracy: AccuracyPreset | None,
-) -> tuple[int, int, float]:
-    """Return preset ``(num_traj, max_bond_dim, threshold)`` or expert defaults."""
-    if accuracy is None:
-        return _EXPERT_DEFAULT_NUM_TRAJ, _EXPERT_DEFAULT_MAX_BOND_DIM, _EXPERT_DEFAULT_THRESHOLD
-    preset = ACCURACY_PRESETS[accuracy]
-    return int(preset["num_traj"]), int(preset["max_bond_dim"]), float(preset["threshold"])
-
-
-def _resolve_accuracy_setting(
-    value: _T | None,
-    preset_value: _T,
-    fallback_value: _T,
-    accuracy: AccuracyPreset | None,
-) -> _T:
-    """Resolve a simulation parameter from explicit value, preset, or expert default.
+def _get_accuracy_preset(accuracy: AccuracyPreset | None) -> dict[str, float | int]:
+    """Return the preset values for ``accuracy`` or expert defaults for ``None``.
 
     Returns:
-        The resolved parameter value.
+        Mapping with ``threshold``, ``max_bond_dim``, and ``num_traj`` keys.
     """
-    if value is not None:
-        return value
+    accuracy = _validate_accuracy(accuracy)
     if accuracy is None:
-        return fallback_value
-    return preset_value
+        return {
+            "threshold": _EXPERT_DEFAULT_THRESHOLD,
+            "max_bond_dim": _EXPERT_DEFAULT_MAX_BOND_DIM,
+            "num_traj": _EXPERT_DEFAULT_NUM_TRAJ,
+        }
+    return ACCURACY_PRESETS[accuracy]
 
 
 def _validate_random_seed(random_seed: int | None) -> None:
@@ -174,10 +160,10 @@ class AnalogSimParams:
         num_traj: Number of trajectories (for stochastic open-system evolution).
         random_seed: If set, seeds per-trajectory jump RNG and static noise sampling for reproducible runs.
         max_bond_dim: Maximum allowed bond dimension.
-        accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-            ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
-            ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
-            Explicit numerical arguments override the preset. ``None`` selects expert defaults.
+        accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
         trunc_mode: Truncation mode used in TDVP (``"discarded_weight"`` or ``"relative"``).
         threshold: Truncation threshold.
         order: Integration order.
@@ -218,10 +204,10 @@ class AnalogSimParams:
             random_seed: If set, makes stochastic trajectories and noise-model sampling reproducible.
             max_bond_dim: Maximum bond dimension allowed.
             min_bond_dim: Minimum bond dimension used to improve TDVP accuracy when possible.
-            accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-                ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
-                ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
-                Explicit numerical arguments override the preset. ``None`` selects expert defaults.
+            accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Threshold for simulation accuracy.
             order: Order of approximation or numerical scheme.
@@ -234,8 +220,7 @@ class AnalogSimParams:
 
         """
         _validate_random_seed(random_seed)
-        accuracy = _validate_accuracy(accuracy)
-        preset_num_traj, preset_max_bond_dim, preset_threshold = _preset_bond_trunc_and_traj(accuracy)
+        preset = _get_accuracy_preset(accuracy)
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -257,13 +242,11 @@ class AnalogSimParams:
         self.dt = dt
         self.times = np.arange(0, elapsed_time + dt, dt)
         self.sample_timesteps = sample_timesteps
-        self.num_traj = _resolve_accuracy_setting(num_traj, preset_num_traj, _EXPERT_DEFAULT_NUM_TRAJ, accuracy)
-        self.max_bond_dim = _resolve_accuracy_setting(
-            max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
-        )
+        self.num_traj = num_traj if num_traj is not None else int(preset["num_traj"])
+        self.max_bond_dim = max_bond_dim if max_bond_dim is not None else int(preset["max_bond_dim"])
         self.min_bond_dim = min_bond_dim
         self.trunc_mode = trunc_mode
-        self.threshold = _resolve_accuracy_setting(threshold, preset_threshold, _EXPERT_DEFAULT_THRESHOLD, accuracy)
+        self.threshold = threshold if threshold is not None else float(preset["threshold"])
         self.order = order
         self.evolution_mode = evolution_mode
         self.get_state = get_state
@@ -281,10 +264,10 @@ class WeakSimParams:
         num_traj: A placeholder property for code compatibility.
         shots: The number of shots for the simulation.
         max_bond_dim: The maximum bond dimension for the simulation.
-        accuracy: Optional preset controlling ``threshold`` and ``max_bond_dim``.
-            ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
-            ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
-            Explicit numerical arguments override the preset. ``None`` selects expert defaults.
+        accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
+            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Explicit ``threshold`` and ``max_bond_dim`` override the preset.
         min_bond_dim: The minimum bond dimension if possible which gives TDVP
             better accuracy. Default is 2.
         trunc_mode: The type of truncation performed in TDVP. Options are
@@ -319,25 +302,22 @@ class WeakSimParams:
             shots: Number of measurement shots to simulate.
             max_bond_dim: Maximum bond dimension for simulation.
             min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
-            accuracy: Optional preset controlling ``threshold`` and ``max_bond_dim``.
-                ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
-                ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
-                Explicit numerical arguments override the preset. ``None`` selects expert defaults.
+            accuracy: Preset controlling ``threshold`` and ``max_bond_dim``.
+                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Explicit ``threshold`` and ``max_bond_dim`` override the preset.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Accuracy threshold for truncating tensors.
             get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
             random_seed: If set, makes per-shot jump RNG reproducible.
         """
         _validate_random_seed(random_seed)
-        accuracy = _validate_accuracy(accuracy)
-        _, preset_max_bond_dim, preset_threshold = _preset_bond_trunc_and_traj(accuracy)
+        preset = _get_accuracy_preset(accuracy)
         self.shots = shots
-        self.max_bond_dim = _resolve_accuracy_setting(
-            max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
-        )
+        self.max_bond_dim = max_bond_dim if max_bond_dim is not None else int(preset["max_bond_dim"])
         self.min_bond_dim = min_bond_dim
         self.trunc_mode = trunc_mode
-        self.threshold = _resolve_accuracy_setting(threshold, preset_threshold, _EXPERT_DEFAULT_THRESHOLD, accuracy)
+        self.threshold = threshold if threshold is not None else float(preset["threshold"])
         self.get_state = get_state
         self.random_seed = random_seed
 
@@ -355,10 +335,10 @@ class StrongSimParams:
         random_seed: If set, seeds per-trajectory jump RNG and static noise
             sampling for reproducible runs.
         max_bond_dim: The maximum bond dimension for the simulation.
-        accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-            ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
-            ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
-            Explicit numerical arguments override the preset. ``None`` selects expert defaults.
+        accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+            Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+            defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+            Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
         min_bond_dim: The minimum bond dimension if possible which gives TDVP
             better accuracy. Default is 2.
         trunc_mode: The type of truncation performed in TDVP. Options are
@@ -396,10 +376,10 @@ class StrongSimParams:
             num_traj: Number of trajectories to simulate.
             max_bond_dim: Maximum bond dimension allowed in simulation.
             min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
-            accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
-                ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
-                ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
-                Explicit numerical arguments override the preset. ``None`` selects expert defaults.
+            accuracy: Preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+                Default is ``"balanced"``. ``"accurate"`` matches the previous high-accuracy
+                defaults. ``accuracy=None`` selects the same expert defaults as ``"accurate"``.
+                Explicit ``threshold``, ``max_bond_dim``, and ``num_traj`` override the preset.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Threshold for simulation accuracy.
             get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
@@ -408,8 +388,7 @@ class StrongSimParams:
             random_seed: If set, makes stochastic trajectories and noise-model sampling reproducible.
         """
         _validate_random_seed(random_seed)
-        accuracy = _validate_accuracy(accuracy)
-        preset_num_traj, preset_max_bond_dim, preset_threshold = _preset_bond_trunc_and_traj(accuracy)
+        preset = _get_accuracy_preset(accuracy)
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -427,13 +406,11 @@ class StrongSimParams:
         else:
             self.sorted_observables = []
 
-        self.num_traj = _resolve_accuracy_setting(num_traj, preset_num_traj, _EXPERT_DEFAULT_NUM_TRAJ, accuracy)
-        self.max_bond_dim = _resolve_accuracy_setting(
-            max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
-        )
+        self.num_traj = num_traj if num_traj is not None else int(preset["num_traj"])
+        self.max_bond_dim = max_bond_dim if max_bond_dim is not None else int(preset["max_bond_dim"])
         self.min_bond_dim = min_bond_dim
         self.trunc_mode = trunc_mode
-        self.threshold = _resolve_accuracy_setting(threshold, preset_threshold, _EXPERT_DEFAULT_THRESHOLD, accuracy)
+        self.threshold = threshold if threshold is not None else float(preset["threshold"])
         self.get_state = get_state
         self.sample_layers = sample_layers
         self.num_mid_measurements = num_mid_measurements

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -33,12 +33,12 @@ AccuracyPreset = Literal["fast", "balanced", "accurate"]
 ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
     "fast": {"threshold": 1e-3, "max_bond_dim": 16, "num_traj": 64},
     "balanced": {"threshold": 1e-6, "max_bond_dim": 128, "num_traj": 256},
-    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
+    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1000},
 }
 
 _EXPERT_DEFAULT_THRESHOLD = 1e-9
 _EXPERT_DEFAULT_MAX_BOND_DIM = 4096
-_EXPERT_DEFAULT_NUM_TRAJ = 1024
+_EXPERT_DEFAULT_NUM_TRAJ = 1000
 
 
 def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None:
@@ -221,6 +221,7 @@ class AnalogSimParams:
         """
         _validate_random_seed(random_seed)
         preset = _get_accuracy_preset(accuracy)
+        self.accuracy = accuracy
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -323,6 +324,7 @@ class StrongSimParams:
         """
         _validate_random_seed(random_seed)
         preset = _get_accuracy_preset(accuracy)
+        self.accuracy = accuracy
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -408,6 +410,7 @@ class WeakSimParams:
         """
         _validate_random_seed(random_seed)
         preset = _get_accuracy_preset(accuracy)
+        self.accuracy = accuracy
         self.shots = shots
         self.max_bond_dim = max_bond_dim if max_bond_dim is not None else int(preset["max_bond_dim"])
         self.min_bond_dim = min_bond_dim

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import copy
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 import numpy as np
 
@@ -27,6 +27,67 @@ from mqt.yaqs.core.libraries.gate_library import GateLibrary
 
 if TYPE_CHECKING:
     from mqt.yaqs.core.libraries.gate_library import BaseGate
+
+AccuracyPreset = Literal["fast", "balanced", "accurate"]
+
+STOCHASTIC_ACCURACY_PRESETS: dict[
+    AccuracyPreset,
+    dict[str, float | int],
+] = {
+    "fast": {"threshold": 1e-3, "max_bond_dim": 16, "num_traj": 64},
+    "balanced": {"threshold": 1e-6, "max_bond_dim": 128, "num_traj": 256},
+    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
+}
+
+WEAK_ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
+    "fast": {"threshold": 1e-3, "max_bond_dim": 16},
+    "balanced": {"threshold": 1e-6, "max_bond_dim": 128},
+    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096},
+}
+
+_EXPERT_DEFAULT_THRESHOLD = 1e-9
+_EXPERT_DEFAULT_MAX_BOND_DIM = 4096
+_EXPERT_DEFAULT_NUM_TRAJ = 1000
+
+_T = TypeVar("_T")
+
+
+def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None:
+    """Validate ``accuracy`` preset names at runtime.
+
+    Args:
+        accuracy: Preset name or ``None`` for expert defaults.
+
+    Returns:
+        The validated preset name, or ``None``.
+
+    Raises:
+        ValueError: If ``accuracy`` is not a supported preset name.
+    """
+    if accuracy is None:
+        return None
+    if accuracy not in STOCHASTIC_ACCURACY_PRESETS:
+        msg = f"accuracy must be one of {sorted(STOCHASTIC_ACCURACY_PRESETS)!r}, got {accuracy!r}."
+        raise ValueError(msg)
+    return accuracy
+
+
+def _resolve_accuracy_setting(
+    value: _T | None,
+    preset_value: _T,
+    fallback_value: _T,
+    accuracy: AccuracyPreset | None,
+) -> _T:
+    """Resolve a simulation parameter from explicit value, preset, or expert default.
+
+    Returns:
+        The resolved parameter value.
+    """
+    if value is not None:
+        return value
+    if accuracy is None:
+        return fallback_value
+    return preset_value
 
 
 def _validate_random_seed(random_seed: int | None) -> None:
@@ -112,6 +173,10 @@ class AnalogSimParams:
         num_traj: Number of trajectories (for stochastic open-system evolution).
         random_seed: If set, seeds per-trajectory jump RNG and static noise sampling for reproducible runs.
         max_bond_dim: Maximum allowed bond dimension.
+        accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+            ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
+            ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
+            Explicit numerical arguments override the preset. ``None`` selects expert defaults.
         trunc_mode: Truncation mode used in TDVP (``"discarded_weight"`` or ``"relative"``).
         threshold: Truncation threshold.
         order: Integration order.
@@ -126,13 +191,14 @@ class AnalogSimParams:
         observables: list[Observable] | None = None,
         elapsed_time: float = 0.1,
         dt: float = 0.1,
-        num_traj: int = 1000,
-        max_bond_dim: int = 4096,
+        num_traj: int | None = None,
+        max_bond_dim: int | None = None,
         min_bond_dim: int = 2,
         trunc_mode: str = "discarded_weight",
-        threshold: float = 1e-9,
+        threshold: float | None = None,
         order: int = 1,
         *,
+        accuracy: AccuracyPreset | None = "balanced",
         sample_timesteps: bool = True,
         evolution_mode: EvolutionMode = EvolutionMode.TDVP,
         get_state: bool = False,
@@ -151,6 +217,10 @@ class AnalogSimParams:
             random_seed: If set, makes stochastic trajectories and noise-model sampling reproducible.
             max_bond_dim: Maximum bond dimension allowed.
             min_bond_dim: Minimum bond dimension used to improve TDVP accuracy when possible.
+            accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+                ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
+                ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
+                Explicit numerical arguments override the preset. ``None`` selects expert defaults.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Threshold for simulation accuracy.
             order: Order of approximation or numerical scheme.
@@ -163,6 +233,16 @@ class AnalogSimParams:
 
         """
         _validate_random_seed(random_seed)
+        accuracy = _validate_accuracy(accuracy)
+        if accuracy is not None:
+            stochastic_preset = STOCHASTIC_ACCURACY_PRESETS[accuracy]
+            preset_num_traj = int(stochastic_preset["num_traj"])
+            preset_max_bond_dim = int(stochastic_preset["max_bond_dim"])
+            preset_threshold = float(stochastic_preset["threshold"])
+        else:
+            preset_num_traj = _EXPERT_DEFAULT_NUM_TRAJ
+            preset_max_bond_dim = _EXPERT_DEFAULT_MAX_BOND_DIM
+            preset_threshold = _EXPERT_DEFAULT_THRESHOLD
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -184,11 +264,13 @@ class AnalogSimParams:
         self.dt = dt
         self.times = np.arange(0, elapsed_time + dt, dt)
         self.sample_timesteps = sample_timesteps
-        self.num_traj = num_traj
-        self.max_bond_dim = max_bond_dim
+        self.num_traj = _resolve_accuracy_setting(num_traj, preset_num_traj, _EXPERT_DEFAULT_NUM_TRAJ, accuracy)
+        self.max_bond_dim = _resolve_accuracy_setting(
+            max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
+        )
         self.min_bond_dim = min_bond_dim
         self.trunc_mode = trunc_mode
-        self.threshold = threshold
+        self.threshold = _resolve_accuracy_setting(threshold, preset_threshold, _EXPERT_DEFAULT_THRESHOLD, accuracy)
         self.order = order
         self.evolution_mode = evolution_mode
         self.get_state = get_state
@@ -206,6 +288,10 @@ class WeakSimParams:
         num_traj: A placeholder property for code compatibility.
         shots: The number of shots for the simulation.
         max_bond_dim: The maximum bond dimension for the simulation.
+        accuracy: Optional preset controlling ``threshold`` and ``max_bond_dim``.
+            ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
+            ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
+            Explicit numerical arguments override the preset. ``None`` selects expert defaults.
         min_bond_dim: The minimum bond dimension if possible which gives TDVP
             better accuracy. Default is 2.
         trunc_mode: The type of truncation performed in TDVP. Options are
@@ -223,11 +309,12 @@ class WeakSimParams:
     def __init__(
         self,
         shots: int,
-        max_bond_dim: int = 4096,
+        max_bond_dim: int | None = None,
         min_bond_dim: int = 2,
         trunc_mode: str = "discarded_weight",
-        threshold: float = 1e-9,
+        threshold: float | None = None,
         *,
+        accuracy: AccuracyPreset | None = "balanced",
         get_state: bool = False,
         random_seed: int | None = None,
     ) -> None:
@@ -239,17 +326,31 @@ class WeakSimParams:
             shots: Number of measurement shots to simulate.
             max_bond_dim: Maximum bond dimension for simulation.
             min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
+            accuracy: Optional preset controlling ``threshold`` and ``max_bond_dim``.
+                ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
+                ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
+                Explicit numerical arguments override the preset. ``None`` selects expert defaults.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Accuracy threshold for truncating tensors.
             get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
             random_seed: If set, makes per-shot jump RNG reproducible.
         """
         _validate_random_seed(random_seed)
+        accuracy = _validate_accuracy(accuracy)
+        if accuracy is not None:
+            weak_preset = WEAK_ACCURACY_PRESETS[accuracy]
+            preset_max_bond_dim = int(weak_preset["max_bond_dim"])
+            preset_threshold = float(weak_preset["threshold"])
+        else:
+            preset_max_bond_dim = _EXPERT_DEFAULT_MAX_BOND_DIM
+            preset_threshold = _EXPERT_DEFAULT_THRESHOLD
         self.shots = shots
-        self.max_bond_dim = max_bond_dim
+        self.max_bond_dim = _resolve_accuracy_setting(
+            max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
+        )
         self.min_bond_dim = min_bond_dim
         self.trunc_mode = trunc_mode
-        self.threshold = threshold
+        self.threshold = _resolve_accuracy_setting(threshold, preset_threshold, _EXPERT_DEFAULT_THRESHOLD, accuracy)
         self.get_state = get_state
         self.random_seed = random_seed
 
@@ -263,15 +364,19 @@ class StrongSimParams:
         dt: A placeholder property for code compatibility.
         observables: A list of observables to be tracked during the simulation.
         sorted_observables: A list of observables sorted by site and name.
-        num_traj: The number of trajectories to simulate. Default is 1000.
+        num_traj: The number of trajectories to simulate.
         random_seed: If set, seeds per-trajectory jump RNG and static noise
             sampling for reproducible runs.
-        max_bond_dim: The maximum bond dimension for the simulation. Default is 2.
+        max_bond_dim: The maximum bond dimension for the simulation.
+        accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+            ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
+            ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
+            Explicit numerical arguments override the preset. ``None`` selects expert defaults.
         min_bond_dim: The minimum bond dimension if possible which gives TDVP
             better accuracy. Default is 2.
         trunc_mode: The type of truncation performed in TDVP. Options are
             ``"discarded_weight"`` and ``"relative"``.
-        threshold: The threshold value for the simulation. Default is ``1e-6``.
+        threshold: The threshold value for the simulation.
         window_size: The size of the window for the simulation. Default is ``None``.
         get_state: If ``True``, request the final state on the returned
             :class:`~mqt.yaqs.Result`.
@@ -283,12 +388,13 @@ class StrongSimParams:
     def __init__(
         self,
         observables: list[Observable] | None = None,
-        num_traj: int = 1000,
-        max_bond_dim: int = 4096,
+        num_traj: int | None = None,
+        max_bond_dim: int | None = None,
         min_bond_dim: int = 2,
         trunc_mode: str = "discarded_weight",
-        threshold: float = 1e-9,
+        threshold: float | None = None,
         *,
+        accuracy: AccuracyPreset | None = "balanced",
         get_state: bool = False,
         sample_layers: bool = False,
         num_mid_measurements: int = 0,
@@ -303,6 +409,10 @@ class StrongSimParams:
             num_traj: Number of trajectories to simulate.
             max_bond_dim: Maximum bond dimension allowed in simulation.
             min_bond_dim: Minimum bond dimension when TDVP can use it for better accuracy.
+            accuracy: Optional preset controlling ``threshold``, ``max_bond_dim``, and ``num_traj``.
+                ``"fast"`` is for quick tests. ``"balanced"`` is the default tradeoff.
+                ``"accurate"`` corresponds approximately to the old high-accuracy defaults.
+                Explicit numerical arguments override the preset. ``None`` selects expert defaults.
             trunc_mode: TDVP truncation mode (``"discarded_weight"`` or ``"relative"``).
             threshold: Threshold for simulation accuracy.
             get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
@@ -311,6 +421,16 @@ class StrongSimParams:
             random_seed: If set, makes stochastic trajectories and noise-model sampling reproducible.
         """
         _validate_random_seed(random_seed)
+        accuracy = _validate_accuracy(accuracy)
+        if accuracy is not None:
+            stochastic_preset = STOCHASTIC_ACCURACY_PRESETS[accuracy]
+            preset_num_traj = int(stochastic_preset["num_traj"])
+            preset_max_bond_dim = int(stochastic_preset["max_bond_dim"])
+            preset_threshold = float(stochastic_preset["threshold"])
+        else:
+            preset_num_traj = _EXPERT_DEFAULT_NUM_TRAJ
+            preset_max_bond_dim = _EXPERT_DEFAULT_MAX_BOND_DIM
+            preset_threshold = _EXPERT_DEFAULT_THRESHOLD
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -328,11 +448,13 @@ class StrongSimParams:
         else:
             self.sorted_observables = []
 
-        self.num_traj = num_traj
-        self.max_bond_dim = max_bond_dim
+        self.num_traj = _resolve_accuracy_setting(num_traj, preset_num_traj, _EXPERT_DEFAULT_NUM_TRAJ, accuracy)
+        self.max_bond_dim = _resolve_accuracy_setting(
+            max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
+        )
         self.min_bond_dim = min_bond_dim
         self.trunc_mode = trunc_mode
-        self.threshold = threshold
+        self.threshold = _resolve_accuracy_setting(threshold, preset_threshold, _EXPERT_DEFAULT_THRESHOLD, accuracy)
         self.get_state = get_state
         self.sample_layers = sample_layers
         self.num_mid_measurements = num_mid_measurements

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -33,7 +33,7 @@ AccuracyPreset = Literal["fast", "balanced", "accurate"]
 ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
     "fast": {"threshold": 1e-3, "max_bond_dim": 16, "num_traj": 64},
     "balanced": {"threshold": 1e-6, "max_bond_dim": 128, "num_traj": 256},
-    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1000},
+    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
 }
 
 _EXPERT_DEFAULT_THRESHOLD = 1e-9

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -30,19 +30,10 @@ if TYPE_CHECKING:
 
 AccuracyPreset = Literal["fast", "balanced", "accurate"]
 
-STOCHASTIC_ACCURACY_PRESETS: dict[
-    AccuracyPreset,
-    dict[str, float | int],
-] = {
+ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
     "fast": {"threshold": 1e-3, "max_bond_dim": 16, "num_traj": 64},
     "balanced": {"threshold": 1e-6, "max_bond_dim": 128, "num_traj": 256},
     "accurate": {"threshold": 1e-9, "max_bond_dim": 4096, "num_traj": 1024},
-}
-
-WEAK_ACCURACY_PRESETS: dict[AccuracyPreset, dict[str, float | int]] = {
-    "fast": {"threshold": 1e-3, "max_bond_dim": 16},
-    "balanced": {"threshold": 1e-6, "max_bond_dim": 128},
-    "accurate": {"threshold": 1e-9, "max_bond_dim": 4096},
 }
 
 _EXPERT_DEFAULT_THRESHOLD = 1e-9
@@ -66,10 +57,20 @@ def _validate_accuracy(accuracy: AccuracyPreset | None) -> AccuracyPreset | None
     """
     if accuracy is None:
         return None
-    if accuracy not in STOCHASTIC_ACCURACY_PRESETS:
-        msg = f"accuracy must be one of {sorted(STOCHASTIC_ACCURACY_PRESETS)!r}, got {accuracy!r}."
+    if accuracy not in ACCURACY_PRESETS:
+        msg = f"accuracy must be one of {sorted(ACCURACY_PRESETS)!r}, got {accuracy!r}."
         raise ValueError(msg)
     return accuracy
+
+
+def _preset_bond_trunc_and_traj(
+    accuracy: AccuracyPreset | None,
+) -> tuple[int, int, float]:
+    """Return preset ``(num_traj, max_bond_dim, threshold)`` or expert defaults."""
+    if accuracy is None:
+        return _EXPERT_DEFAULT_NUM_TRAJ, _EXPERT_DEFAULT_MAX_BOND_DIM, _EXPERT_DEFAULT_THRESHOLD
+    preset = ACCURACY_PRESETS[accuracy]
+    return int(preset["num_traj"]), int(preset["max_bond_dim"]), float(preset["threshold"])
 
 
 def _resolve_accuracy_setting(
@@ -234,15 +235,7 @@ class AnalogSimParams:
         """
         _validate_random_seed(random_seed)
         accuracy = _validate_accuracy(accuracy)
-        if accuracy is not None:
-            stochastic_preset = STOCHASTIC_ACCURACY_PRESETS[accuracy]
-            preset_num_traj = int(stochastic_preset["num_traj"])
-            preset_max_bond_dim = int(stochastic_preset["max_bond_dim"])
-            preset_threshold = float(stochastic_preset["threshold"])
-        else:
-            preset_num_traj = _EXPERT_DEFAULT_NUM_TRAJ
-            preset_max_bond_dim = _EXPERT_DEFAULT_MAX_BOND_DIM
-            preset_threshold = _EXPERT_DEFAULT_THRESHOLD
+        preset_num_traj, preset_max_bond_dim, preset_threshold = _preset_bond_trunc_and_traj(accuracy)
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."
@@ -337,13 +330,7 @@ class WeakSimParams:
         """
         _validate_random_seed(random_seed)
         accuracy = _validate_accuracy(accuracy)
-        if accuracy is not None:
-            weak_preset = WEAK_ACCURACY_PRESETS[accuracy]
-            preset_max_bond_dim = int(weak_preset["max_bond_dim"])
-            preset_threshold = float(weak_preset["threshold"])
-        else:
-            preset_max_bond_dim = _EXPERT_DEFAULT_MAX_BOND_DIM
-            preset_threshold = _EXPERT_DEFAULT_THRESHOLD
+        _, preset_max_bond_dim, preset_threshold = _preset_bond_trunc_and_traj(accuracy)
         self.shots = shots
         self.max_bond_dim = _resolve_accuracy_setting(
             max_bond_dim, preset_max_bond_dim, _EXPERT_DEFAULT_MAX_BOND_DIM, accuracy
@@ -422,15 +409,7 @@ class StrongSimParams:
         """
         _validate_random_seed(random_seed)
         accuracy = _validate_accuracy(accuracy)
-        if accuracy is not None:
-            stochastic_preset = STOCHASTIC_ACCURACY_PRESETS[accuracy]
-            preset_num_traj = int(stochastic_preset["num_traj"])
-            preset_max_bond_dim = int(stochastic_preset["max_bond_dim"])
-            preset_threshold = float(stochastic_preset["threshold"])
-        else:
-            preset_num_traj = _EXPERT_DEFAULT_NUM_TRAJ
-            preset_max_bond_dim = _EXPERT_DEFAULT_MAX_BOND_DIM
-            preset_threshold = _EXPERT_DEFAULT_THRESHOLD
+        preset_num_traj, preset_max_bond_dim, preset_threshold = _preset_bond_trunc_and_traj(accuracy)
         obs_list: list[Observable] = [] if observables is None else list(observables)
         assert all(n.gate.name == "pvm" for n in obs_list) or all(n.gate.name != "pvm" for n in obs_list), (
             "We currently have not implemented mixed observable and projective-measurement simulation."

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -125,9 +125,29 @@ def test_analog_simparams_accuracy_presets(accuracy: str, expected: dict[str, fl
 def test_strong_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
     """StrongSimParams resolves threshold, max_bond_dim, and num_traj from accuracy presets."""
     params = StrongSimParams(accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.accuracy == accuracy
     assert params.threshold == pytest.approx(expected["threshold"])
     assert params.max_bond_dim == expected["max_bond_dim"]
     assert params.num_traj == expected["num_traj"]
+
+
+def test_analog_simparams_default_constructor_uses_balanced() -> None:
+    """AnalogSimParams() uses the balanced accuracy preset by default."""
+    params = AnalogSimParams()
+    balanced = ACCURACY_PRESETS["balanced"]
+    assert params.accuracy == "balanced"
+    assert params.threshold == pytest.approx(balanced["threshold"])
+    assert params.max_bond_dim == balanced["max_bond_dim"]
+    assert params.num_traj == balanced["num_traj"]
+
+
+def test_weak_simparams_default_constructor_uses_balanced() -> None:
+    """WeakSimParams(shots=...) uses the balanced accuracy preset by default."""
+    params = WeakSimParams(shots=100)
+    balanced = ACCURACY_PRESETS["balanced"]
+    assert params.accuracy == "balanced"
+    assert params.threshold == pytest.approx(balanced["threshold"])
+    assert params.max_bond_dim == balanced["max_bond_dim"]
 
 
 @pytest.mark.parametrize(
@@ -141,6 +161,7 @@ def test_strong_simparams_accuracy_presets(accuracy: str, expected: dict[str, fl
 def test_weak_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
     """WeakSimParams resolves threshold and max_bond_dim from the shared accuracy presets."""
     params = WeakSimParams(shots=100, accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.accuracy == accuracy
     assert params.shots == 100
     assert params.threshold == pytest.approx(expected["threshold"])
     assert params.max_bond_dim == expected["max_bond_dim"]
@@ -170,30 +191,16 @@ def test_weak_simparams_accuracy_explicit_overrides() -> None:
     assert params.max_bond_dim == 512
 
 
-def test_simparams_accuracy_none_expert_defaults() -> None:
-    """accuracy=None preserves the previous expert defaults."""
-    analog = AnalogSimParams(accuracy=None)
-    assert analog.accuracy is None
-    assert analog.threshold == pytest.approx(1e-9)
-    assert analog.max_bond_dim == 4096
-    assert analog.num_traj == 1024
-
-    strong = StrongSimParams(accuracy=None)
-    assert strong.accuracy is None
-    assert strong.threshold == pytest.approx(1e-9)
-    assert strong.max_bond_dim == 4096
-    assert strong.num_traj == 1024
-
-    weak = WeakSimParams(shots=100, accuracy=None)
-    assert weak.accuracy is None
-    assert weak.threshold == pytest.approx(1e-9)
-    assert weak.max_bond_dim == 4096
-
-
 def test_strong_simparams_rejects_invalid_accuracy() -> None:
     """Invalid accuracy preset names raise ValueError."""
     with pytest.raises(ValueError, match="accuracy must be one of"):
         StrongSimParams(accuracy="invalid")  # ty: ignore[invalid-argument-type]
+
+
+def test_strong_simparams_rejects_none_accuracy() -> None:
+    """accuracy=None is not supported."""
+    with pytest.raises(ValueError, match="accuracy must be one of"):
+        StrongSimParams(accuracy=None)  # ty: ignore[invalid-argument-type]
 
 
 def test_allocate_observable_buffers_with_sample_timesteps() -> None:

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -28,8 +28,7 @@ import pytest
 
 from mqt.yaqs.core.data_structures.result import Result, aggregate_trajectories, allocate_observable_buffers
 from mqt.yaqs.core.data_structures.simulation_parameters import (
-    STOCHASTIC_ACCURACY_PRESETS,
-    WEAK_ACCURACY_PRESETS,
+    ACCURACY_PRESETS,
     AnalogSimParams,
     Observable,
     StrongSimParams,
@@ -90,7 +89,7 @@ def test_analog_simparams_defaults() -> None:
     assert params.sample_timesteps is True
     # times should be np.arange(0, elapsed_time+dt, dt)
     assert np.isclose(params.times[-1], 0.1)
-    balanced = STOCHASTIC_ACCURACY_PRESETS["balanced"]
+    balanced = ACCURACY_PRESETS["balanced"]
     assert params.num_traj == balanced["num_traj"]
     assert params.max_bond_dim == balanced["max_bond_dim"]
     assert params.threshold == pytest.approx(balanced["threshold"])
@@ -100,9 +99,9 @@ def test_analog_simparams_defaults() -> None:
 @pytest.mark.parametrize(
     ("accuracy", "expected"),
     [
-        ("fast", STOCHASTIC_ACCURACY_PRESETS["fast"]),
-        ("balanced", STOCHASTIC_ACCURACY_PRESETS["balanced"]),
-        ("accurate", STOCHASTIC_ACCURACY_PRESETS["accurate"]),
+        ("fast", ACCURACY_PRESETS["fast"]),
+        ("balanced", ACCURACY_PRESETS["balanced"]),
+        ("accurate", ACCURACY_PRESETS["accurate"]),
     ],
 )
 def test_analog_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
@@ -116,9 +115,9 @@ def test_analog_simparams_accuracy_presets(accuracy: str, expected: dict[str, fl
 @pytest.mark.parametrize(
     ("accuracy", "expected"),
     [
-        ("fast", STOCHASTIC_ACCURACY_PRESETS["fast"]),
-        ("balanced", STOCHASTIC_ACCURACY_PRESETS["balanced"]),
-        ("accurate", STOCHASTIC_ACCURACY_PRESETS["accurate"]),
+        ("fast", ACCURACY_PRESETS["fast"]),
+        ("balanced", ACCURACY_PRESETS["balanced"]),
+        ("accurate", ACCURACY_PRESETS["accurate"]),
     ],
 )
 def test_strong_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
@@ -132,13 +131,13 @@ def test_strong_simparams_accuracy_presets(accuracy: str, expected: dict[str, fl
 @pytest.mark.parametrize(
     ("accuracy", "expected"),
     [
-        ("fast", WEAK_ACCURACY_PRESETS["fast"]),
-        ("balanced", WEAK_ACCURACY_PRESETS["balanced"]),
-        ("accurate", WEAK_ACCURACY_PRESETS["accurate"]),
+        ("fast", ACCURACY_PRESETS["fast"]),
+        ("balanced", ACCURACY_PRESETS["balanced"]),
+        ("accurate", ACCURACY_PRESETS["accurate"]),
     ],
 )
 def test_weak_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
-    """WeakSimParams resolves threshold and max_bond_dim from accuracy presets; shots are unchanged."""
+    """WeakSimParams resolves threshold and max_bond_dim from the shared accuracy presets."""
     params = WeakSimParams(shots=42, accuracy=accuracy)  # ty: ignore[invalid-argument-type]
     assert params.shots == 42
     assert params.threshold == pytest.approx(expected["threshold"])
@@ -148,7 +147,7 @@ def test_weak_simparams_accuracy_presets(accuracy: str, expected: dict[str, floa
 def test_strong_simparams_accuracy_explicit_overrides() -> None:
     """Explicit numerical arguments override accuracy presets."""
     params = StrongSimParams(accuracy="fast", max_bond_dim=512, num_traj=10)
-    assert params.threshold == pytest.approx(STOCHASTIC_ACCURACY_PRESETS["fast"]["threshold"])
+    assert params.threshold == pytest.approx(ACCURACY_PRESETS["fast"]["threshold"])
     assert params.max_bond_dim == 512
     assert params.num_traj == 10
 
@@ -375,7 +374,7 @@ def test_strong_params_sorting_and_fields() -> None:
     # Parameter fields are retained
     assert params.num_traj == 7
     assert params.max_bond_dim == 128
-    assert params.threshold == pytest.approx(STOCHASTIC_ACCURACY_PRESETS["balanced"]["threshold"])
+    assert params.threshold == pytest.approx(ACCURACY_PRESETS["balanced"]["threshold"])
     assert params.get_state is True
     assert params.sample_layers is True
     assert params.num_mid_measurements == 2

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -90,6 +90,7 @@ def test_analog_simparams_defaults() -> None:
     # times should be np.arange(0, elapsed_time+dt, dt)
     assert np.isclose(params.times[-1], 0.1)
     balanced = ACCURACY_PRESETS["balanced"]
+    assert params.accuracy == "balanced"
     assert params.num_traj == balanced["num_traj"]
     assert params.max_bond_dim == balanced["max_bond_dim"]
     assert params.threshold == pytest.approx(balanced["threshold"])
@@ -107,6 +108,7 @@ def test_analog_simparams_defaults() -> None:
 def test_analog_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
     """AnalogSimParams resolves threshold, max_bond_dim, and num_traj from accuracy presets."""
     params = AnalogSimParams(accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.accuracy == accuracy
     assert params.threshold == pytest.approx(expected["threshold"])
     assert params.max_bond_dim == expected["max_bond_dim"]
     assert params.num_traj == expected["num_traj"]
@@ -171,16 +173,19 @@ def test_weak_simparams_accuracy_explicit_overrides() -> None:
 def test_simparams_accuracy_none_expert_defaults() -> None:
     """accuracy=None preserves the previous expert defaults."""
     analog = AnalogSimParams(accuracy=None)
+    assert analog.accuracy is None
     assert analog.threshold == pytest.approx(1e-9)
     assert analog.max_bond_dim == 4096
     assert analog.num_traj == 1000
 
     strong = StrongSimParams(accuracy=None)
+    assert strong.accuracy is None
     assert strong.threshold == pytest.approx(1e-9)
     assert strong.max_bond_dim == 4096
     assert strong.num_traj == 1000
 
     weak = WeakSimParams(shots=100, accuracy=None)
+    assert weak.accuracy is None
     assert weak.threshold == pytest.approx(1e-9)
     assert weak.max_bond_dim == 4096
 

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -176,13 +176,13 @@ def test_simparams_accuracy_none_expert_defaults() -> None:
     assert analog.accuracy is None
     assert analog.threshold == pytest.approx(1e-9)
     assert analog.max_bond_dim == 4096
-    assert analog.num_traj == 1000
+    assert analog.num_traj == 1024
 
     strong = StrongSimParams(accuracy=None)
     assert strong.accuracy is None
     assert strong.threshold == pytest.approx(1e-9)
     assert strong.max_bond_dim == 4096
-    assert strong.num_traj == 1000
+    assert strong.num_traj == 1024
 
     weak = WeakSimParams(shots=100, accuracy=None)
     assert weak.accuracy is None

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -138,18 +138,34 @@ def test_strong_simparams_accuracy_presets(accuracy: str, expected: dict[str, fl
 )
 def test_weak_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
     """WeakSimParams resolves threshold and max_bond_dim from the shared accuracy presets."""
-    params = WeakSimParams(shots=42, accuracy=accuracy)  # ty: ignore[invalid-argument-type]
-    assert params.shots == 42
+    params = WeakSimParams(shots=100, accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.shots == 100
     assert params.threshold == pytest.approx(expected["threshold"])
     assert params.max_bond_dim == expected["max_bond_dim"]
 
 
-def test_strong_simparams_accuracy_explicit_overrides() -> None:
+def test_analog_simparams_accuracy_explicit_overrides() -> None:
     """Explicit numerical arguments override accuracy presets."""
-    params = StrongSimParams(accuracy="fast", max_bond_dim=512, num_traj=10)
-    assert params.threshold == pytest.approx(ACCURACY_PRESETS["fast"]["threshold"])
+    params = AnalogSimParams(accuracy="fast", threshold=1e-8, max_bond_dim=512, num_traj=10)
+    assert params.threshold == pytest.approx(1e-8)
     assert params.max_bond_dim == 512
     assert params.num_traj == 10
+
+
+def test_strong_simparams_accuracy_explicit_overrides() -> None:
+    """Explicit numerical arguments override accuracy presets."""
+    params = StrongSimParams(accuracy="fast", threshold=1e-8, max_bond_dim=512, num_traj=10)
+    assert params.threshold == pytest.approx(1e-8)
+    assert params.max_bond_dim == 512
+    assert params.num_traj == 10
+
+
+def test_weak_simparams_accuracy_explicit_overrides() -> None:
+    """Explicit numerical arguments override accuracy presets."""
+    params = WeakSimParams(shots=100, accuracy="fast", threshold=1e-8, max_bond_dim=512)
+    assert params.shots == 100
+    assert params.threshold == pytest.approx(1e-8)
+    assert params.max_bond_dim == 512
 
 
 def test_simparams_accuracy_none_expert_defaults() -> None:
@@ -164,24 +180,15 @@ def test_simparams_accuracy_none_expert_defaults() -> None:
     assert strong.max_bond_dim == 4096
     assert strong.num_traj == 1000
 
-    weak = WeakSimParams(shots=1, accuracy=None)
+    weak = WeakSimParams(shots=100, accuracy=None)
     assert weak.threshold == pytest.approx(1e-9)
     assert weak.max_bond_dim == 4096
 
 
-@pytest.mark.parametrize(
-    "param_cls",
-    [AnalogSimParams, StrongSimParams, WeakSimParams],
-)
-def test_simparams_rejects_invalid_accuracy(
-    param_cls: type[AnalogSimParams | StrongSimParams | WeakSimParams],
-) -> None:
+def test_strong_simparams_rejects_invalid_accuracy() -> None:
     """Invalid accuracy preset names raise ValueError."""
-    kwargs: dict[str, object] = {"accuracy": "ultra"}
-    if param_cls is WeakSimParams:
-        kwargs["shots"] = 1
     with pytest.raises(ValueError, match="accuracy must be one of"):
-        param_cls(**kwargs)  # ty: ignore[invalid-argument-type]
+        StrongSimParams(accuracy="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_allocate_observable_buffers_with_sample_timesteps() -> None:

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -28,6 +28,8 @@ import pytest
 
 from mqt.yaqs.core.data_structures.result import Result, aggregate_trajectories, allocate_observable_buffers
 from mqt.yaqs.core.data_structures.simulation_parameters import (
+    STOCHASTIC_ACCURACY_PRESETS,
+    WEAK_ACCURACY_PRESETS,
     AnalogSimParams,
     Observable,
     StrongSimParams,
@@ -88,10 +90,99 @@ def test_analog_simparams_defaults() -> None:
     assert params.sample_timesteps is True
     # times should be np.arange(0, elapsed_time+dt, dt)
     assert np.isclose(params.times[-1], 0.1)
-    assert params.num_traj == 1000
-    assert params.max_bond_dim == 4096
-    assert params.threshold == pytest.approx(1e-9)
+    balanced = STOCHASTIC_ACCURACY_PRESETS["balanced"]
+    assert params.num_traj == balanced["num_traj"]
+    assert params.max_bond_dim == balanced["max_bond_dim"]
+    assert params.threshold == pytest.approx(balanced["threshold"])
     assert params.order == 1
+
+
+@pytest.mark.parametrize(
+    ("accuracy", "expected"),
+    [
+        ("fast", STOCHASTIC_ACCURACY_PRESETS["fast"]),
+        ("balanced", STOCHASTIC_ACCURACY_PRESETS["balanced"]),
+        ("accurate", STOCHASTIC_ACCURACY_PRESETS["accurate"]),
+    ],
+)
+def test_analog_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
+    """AnalogSimParams resolves threshold, max_bond_dim, and num_traj from accuracy presets."""
+    params = AnalogSimParams(accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.threshold == pytest.approx(expected["threshold"])
+    assert params.max_bond_dim == expected["max_bond_dim"]
+    assert params.num_traj == expected["num_traj"]
+
+
+@pytest.mark.parametrize(
+    ("accuracy", "expected"),
+    [
+        ("fast", STOCHASTIC_ACCURACY_PRESETS["fast"]),
+        ("balanced", STOCHASTIC_ACCURACY_PRESETS["balanced"]),
+        ("accurate", STOCHASTIC_ACCURACY_PRESETS["accurate"]),
+    ],
+)
+def test_strong_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
+    """StrongSimParams resolves threshold, max_bond_dim, and num_traj from accuracy presets."""
+    params = StrongSimParams(accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.threshold == pytest.approx(expected["threshold"])
+    assert params.max_bond_dim == expected["max_bond_dim"]
+    assert params.num_traj == expected["num_traj"]
+
+
+@pytest.mark.parametrize(
+    ("accuracy", "expected"),
+    [
+        ("fast", WEAK_ACCURACY_PRESETS["fast"]),
+        ("balanced", WEAK_ACCURACY_PRESETS["balanced"]),
+        ("accurate", WEAK_ACCURACY_PRESETS["accurate"]),
+    ],
+)
+def test_weak_simparams_accuracy_presets(accuracy: str, expected: dict[str, float | int]) -> None:
+    """WeakSimParams resolves threshold and max_bond_dim from accuracy presets; shots are unchanged."""
+    params = WeakSimParams(shots=42, accuracy=accuracy)  # ty: ignore[invalid-argument-type]
+    assert params.shots == 42
+    assert params.threshold == pytest.approx(expected["threshold"])
+    assert params.max_bond_dim == expected["max_bond_dim"]
+
+
+def test_strong_simparams_accuracy_explicit_overrides() -> None:
+    """Explicit numerical arguments override accuracy presets."""
+    params = StrongSimParams(accuracy="fast", max_bond_dim=512, num_traj=10)
+    assert params.threshold == pytest.approx(STOCHASTIC_ACCURACY_PRESETS["fast"]["threshold"])
+    assert params.max_bond_dim == 512
+    assert params.num_traj == 10
+
+
+def test_simparams_accuracy_none_expert_defaults() -> None:
+    """accuracy=None preserves the previous expert defaults."""
+    analog = AnalogSimParams(accuracy=None)
+    assert analog.threshold == pytest.approx(1e-9)
+    assert analog.max_bond_dim == 4096
+    assert analog.num_traj == 1000
+
+    strong = StrongSimParams(accuracy=None)
+    assert strong.threshold == pytest.approx(1e-9)
+    assert strong.max_bond_dim == 4096
+    assert strong.num_traj == 1000
+
+    weak = WeakSimParams(shots=1, accuracy=None)
+    assert weak.threshold == pytest.approx(1e-9)
+    assert weak.max_bond_dim == 4096
+
+
+@pytest.mark.parametrize(
+    "param_cls",
+    [AnalogSimParams, StrongSimParams, WeakSimParams],
+)
+def test_simparams_rejects_invalid_accuracy(
+    param_cls: type[AnalogSimParams | StrongSimParams | WeakSimParams],
+) -> None:
+    """Invalid accuracy preset names raise ValueError."""
+    kwargs: dict[str, object] = {"accuracy": "ultra"}
+    if param_cls is WeakSimParams:
+        kwargs["shots"] = 1
+    with pytest.raises(ValueError, match="accuracy must be one of"):
+        param_cls(**kwargs)  # ty: ignore[invalid-argument-type]
 
 
 def test_allocate_observable_buffers_with_sample_timesteps() -> None:
@@ -284,7 +375,7 @@ def test_strong_params_sorting_and_fields() -> None:
     # Parameter fields are retained
     assert params.num_traj == 7
     assert params.max_bond_dim == 128
-    assert np.isclose(params.threshold, 1e-10)
+    assert params.threshold == pytest.approx(STOCHASTIC_ACCURACY_PRESETS["balanced"]["threshold"])
     assert params.get_state is True
     assert params.sample_layers is True
     assert params.num_mid_measurements == 2


### PR DESCRIPTION
## Description

This PR adds an abstraction for the accuracy of the simulator. Rather than explicitly needing to set the number of trajectories, SVD threshold, and maximum bond dimension, users can now enter "fast", "balanced" or "accurate" as settings. Since the methods implemented here are active research which we have built up intuition for, this is intended to make this more concrete rather than internal knowledge that needs to be conveyed to new users or researchers on these topics.

The previous usage of directly overriding these values is still possible and intended for expert (potentially most) users of YAQS.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
