### PR TITLE
changed default to TEBD in digital circuit simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
+- changed default digital circuit simulator `gate_mode` to `tebd` (from `hybrid`)
 - refactored public API to use Simulator, Result, and EquivalenceChecker classes ([#430]) ([**@aaronleesander**])
 - sped up and stabilized test suite ([#428]) ([**@aaronleesander**])
 - changed `simulator.run` to accept `State | list[State]` and `Hamiltonian` for analog simulations instead of `MPS` / `MPO` ([#422]) ([**@aaronleesander**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
-- changed default digital circuit simulator `gate_mode` to `tebd` (from `hybrid`)
+- changed default to TEBD in digital circuit simulation ([#445]) ([**@aaronleesander**])
 - refactored public API to use Simulator, Result, and EquivalenceChecker classes ([#430]) ([**@aaronleesander**])
 - sped up and stabilized test suite ([#428]) ([**@aaronleesander**])
 - changed `simulator.run` to accept `State | list[State]` and `Hamiltonian` for analog simulations instead of `MPS` / `MPO` ([#422]) ([**@aaronleesander**])
@@ -123,6 +123,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#445]: https://github.com/munich-quantum-toolkit/yaqs/pull/445
 [#441]: https://github.com/munich-quantum-toolkit/yaqs/pull/441
 [#439]: https://github.com/munich-quantum-toolkit/yaqs/pull/439
 [#438]: https://github.com/munich-quantum-toolkit/yaqs/pull/438

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -175,10 +175,9 @@ Used for noisy strong circuit simulation. Provide observables and optionally ena
 
 ### Two-qubit gate mode (`gate_mode`)
 
-Digital circuit simulation on an MPS uses a **hybrid** two-qubit update by default (`gate_mode="hybrid"`):
+Digital circuit simulation on an MPS uses a **TEBD/SVD** two-qubit update by default (`gate_mode="tebd"`).
 
-- **Nearest-neighbor** gates (adjacent in the internal MPS site order after bit reversal) use a direct **TEBD/SVD** update.
-- **Long-range** gates keep the existing **generator MPO + two-site TDVP** path.
+You can also set `gate_mode="hybrid"` to use TEBD/SVD for **nearest-neighbor** gates (adjacent in the internal MPS site order after bit reversal) while keeping the existing **generator MPO + two-site TDVP** path for **long-range** gates.
 
 Set `gate_mode="tdvp"` to apply TDVP to every two-qubit gate. Set `gate_mode="tebd"` to use TEBD/SVD for all two-qubit gates; long-range gates are implemented by adjacent SWAP insertion before and after the update.
 

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -375,7 +375,7 @@ class StrongSimParams:
         get_state: If ``True``, request the final state on the returned
             :class:`~mqt.yaqs.Result`.
         gate_mode: Two-qubit gate update mode on the MPS digital backend
-            (``"hybrid"``, ``"tdvp"``, or ``"tebd"``).
+            (``"tebd"``, ``"hybrid"``, or ``"tdvp"``).
     """
 
     # Properties set as placeholders for code compatibility
@@ -396,7 +396,7 @@ class StrongSimParams:
         sample_layers: bool = False,
         num_mid_measurements: int = 0,
         random_seed: int | None = None,
-        gate_mode: GateMode = "hybrid",
+        gate_mode: GateMode = "tebd",
     ) -> None:
         """Strong circuit simulation parameters initialization.
 
@@ -422,7 +422,7 @@ class StrongSimParams:
             sample_layers: If ``True``, record observables at sampled circuit layers.
             num_mid_measurements: Number of mid-circuit measurement barriers when sampling layers.
             random_seed: If set, makes stochastic trajectories and noise-model sampling reproducible.
-            gate_mode: Two-qubit gate update mode (default ``"hybrid"``).
+            gate_mode: Two-qubit gate update mode (default ``"tebd"``).
         """
         _validate_random_seed(random_seed)
         preset_values = SIMULATION_PRESETS[_validate_preset(preset)]
@@ -485,7 +485,7 @@ class WeakSimParams:
         get_state: If ``True``, request the final state on the returned
             :class:`~mqt.yaqs.Result`.
         gate_mode: Two-qubit gate update mode on the MPS digital backend
-            (``"hybrid"``, ``"tdvp"``, or ``"tebd"``).
+            (``"tebd"``, ``"hybrid"``, or ``"tdvp"``).
     """
 
     # Properties set as placeholders for code compatibility
@@ -504,7 +504,7 @@ class WeakSimParams:
         preset: SimulationPreset = "balanced",
         get_state: bool = False,
         random_seed: int | None = None,
-        gate_mode: GateMode = "hybrid",
+        gate_mode: GateMode = "tebd",
     ) -> None:
         """Weak circuit simulation initialization.
 
@@ -527,7 +527,7 @@ class WeakSimParams:
             svd_threshold: SVD truncation threshold for bond dimension control.
             get_state: If ``True``, request the final state on the returned :class:`~mqt.yaqs.Result`.
             random_seed: If set, makes per-shot jump RNG reproducible.
-            gate_mode: Two-qubit gate update mode (default ``"hybrid"``).
+            gate_mode: Two-qubit gate update mode (default ``"tebd"``).
         """
         _validate_random_seed(random_seed)
         preset_values = SIMULATION_PRESETS[_validate_preset(preset)]

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -161,13 +161,13 @@ def test_weak_simparams_default_constructor_uses_balanced() -> None:
     assert params.svd_threshold == pytest.approx(balanced["svd_threshold"])
     assert params.max_bond_dim == balanced["max_bond_dim"]
     assert params.krylov_tol == pytest.approx(balanced["krylov_tol"])
-    assert params.gate_mode == "hybrid"
+    assert params.gate_mode == "tebd"
 
 
 def test_gate_mode_defaults_and_validation() -> None:
-    """Strong and weak digital params default to hybrid and validate gate_mode names."""
-    assert StrongSimParams().gate_mode == "hybrid"
-    assert WeakSimParams(shots=1).gate_mode == "hybrid"
+    """Strong and weak digital params default to TEBD and validate gate_mode names."""
+    assert StrongSimParams().gate_mode == "tebd"
+    assert WeakSimParams(shots=1).gate_mode == "tebd"
     assert StrongSimParams(gate_mode="tdvp").gate_mode == "tdvp"
     with pytest.raises(ValueError, match="gate_mode"):
         StrongSimParams(gate_mode=cast("GateMode", "invalid"))


### PR DESCRIPTION
## Description

This PR sets the default digital circuit simulation method to TEBD.

This is intended to be temporary while the TDVP circuit simulation method is tested more thoroughly.
We noticed instabilities in some cases which need to be investigated before this is re-set to the default.
For now, it is left as a setting.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
