### PR TITLE
added tests to ensure qubit ordering matches Qiskit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Removed
 
 ### Fixed
-
+- added tests to ensure qubit ordering matches Qiskit ([#446]) ([**@aaronleesander**])
 - minor cleanup ([#420]) ([**@aaronleesander**])
 
 ## [0.5.0] - 2026-05-12
@@ -123,6 +123,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#446]: https://github.com/munich-quantum-toolkit/yaqs/pull/446
 [#445]: https://github.com/munich-quantum-toolkit/yaqs/pull/445
 [#441]: https://github.com/munich-quantum-toolkit/yaqs/pull/441
 [#439]: https://github.com/munich-quantum-toolkit/yaqs/pull/439

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Removed
 
 ### Fixed
+
 - added tests to ensure qubit ordering matches Qiskit ([#446]) ([**@aaronleesander**])
 - minor cleanup ([#420]) ([**@aaronleesander**])
 

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -177,7 +177,7 @@ Used for noisy strong circuit simulation. Provide observables and optionally ena
 
 Digital circuit simulation on an MPS uses a **hybrid** two-qubit update by default (`gate_mode="hybrid"`):
 
-- **Nearest-neighbor** gates (adjacent in the internal MPS site order after bit reversal) use a direct **TEBD/SVD** update.
+- **Nearest-neighbor** gates (adjacent in the internal MPS site order) use a direct **TEBD/SVD** update.
 - **Long-range** gates keep the existing **generator MPO + two-site TDVP** path.
 
 Set `gate_mode="tdvp"` to apply TDVP to every two-qubit gate. Set `gate_mode="tebd"` to use TEBD/SVD for all two-qubit gates; long-range gates are implemented by adjacent SWAP insertion before and after the update.
@@ -193,6 +193,8 @@ _trunc_summary(strong)
 ## `WeakSimParams`
 
 Used for noisy weak simulation. **`shots` is always required** and is not part of the preset.
+
+YAQS stores weak-simulation measurement histograms in `Result.counts` as a `dict[int, int]`. The integer key encodes the measured bitstring with **site 0 as the least-significant bit** (little-endian). This matches Qiskit’s default convention if you interpret Qiskit bitstrings (`c_{n-1}...c_0`) via `int(bitstring, 2)`.
 
 ```{code-cell} ipython3
 weak_balanced = WeakSimParams(shots=1000)

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -1257,9 +1257,8 @@ class Simulator:
 
         Requires :attr:`~mqt.yaqs.core.data_structures.state.State.representation` ``"mps"``,
         materializes the state, validates that the number of qubits in the quantum circuit
-        matches the MPS length, reverses the bit order of the circuit, and dispatches the
-        simulation to the appropriate backend based on whether the simulation parameters
-        indicate strong or weak simulation.
+        matches the MPS length, and dispatches the simulation to the appropriate backend
+        based on whether the simulation parameters indicate strong or weak simulation.
 
         Args:
             initial_state: The initial system state (must use MPS representation).
@@ -1283,7 +1282,6 @@ class Simulator:
         if mps.length != operator.num_qubits:
             msg = "State and circuit qubit counts do not match."
             raise ValueError(msg)
-        operator = copy.deepcopy(operator.reverse_bits())
 
         if isinstance(sim_params, StrongSimParams):
             self._run_strong_sim(mps, operator, sim_params, noise_model, result)

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -31,7 +31,7 @@ import numpy as np
 import pytest
 from qiskit.circuit import QuantumCircuit
 from qiskit.converters import circuit_to_dag
-from qiskit.quantum_info import Statevector
+from qiskit.quantum_info import Pauli, Statevector
 
 from mqt.yaqs import Simulator
 from mqt.yaqs.core.data_structures.mps import MPS
@@ -43,7 +43,7 @@ from mqt.yaqs.core.data_structures.simulation_parameters import (
 )
 from mqt.yaqs.core.data_structures.state import State
 from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
-from mqt.yaqs.core.libraries.gate_library import GateLibrary, X, Z
+from mqt.yaqs.core.libraries.gate_library import GateLibrary, X, Y, Z
 from mqt.yaqs.digital.digital_tjm import (
     apply_single_qubit_gate,
     apply_two_qubit_gate,
@@ -756,8 +756,7 @@ def test_mixed_circuit_tebd_matches_tdvp() -> None:
 def test_statevector_matches_qiskit_on_nonsymmetric_probes() -> None:
     """Lock down YAQS dense-vector convention against Qiskit on non-symmetric circuits.
 
-    The simulator reverses qubit order internally; this test ensures the resulting MPS dense
-    vector remains consistent with a single documented Qiskit reference convention.
+    This guards qubit ordering conventions in YAQS' digital backend against Qiskit.
     """
     n = 3
     circuits: list[QuantumCircuit] = []
@@ -789,6 +788,46 @@ def test_statevector_matches_qiskit_on_nonsymmetric_probes() -> None:
         assert isinstance(vec, np.ndarray)
         ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
         assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+def test_observables_match_qiskit_statevector_qubit_ordering() -> None:
+    """Digital observable expectations match Qiskit (guards qubit ordering)."""
+
+    def qiskit_single_pauli_expectation(qc: QuantumCircuit, site: int, op: str) -> float:
+        n = qc.num_qubits
+        label = ["I"] * n
+        # Qiskit Pauli labels are ordered as q_{n-1} ... q_0.
+        label[n - 1 - site] = op
+        psi = Statevector(qc)
+        exp = psi.expectation_value(Pauli("".join(label)))
+        return float(np.real(exp))
+
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.cx(0, 2)
+    qc.ry(0.51, 1)
+    qc.rz(0.23, 2)
+    qc.cx(2, 1)
+
+    requested = [
+        Observable(Z(), 2),
+        Observable(X(), 0),
+        Observable(Y(), 1),
+        Observable(Z(), 0),
+        Observable(X(), 2),
+    ]
+    sim_params = StrongSimParams(observables=requested, gate_mode="hybrid", preset="exact")
+    state = State(3, initial="zeros")
+    result = Simulator(parallel=False, show_progress=False).run(state, qc, sim_params, None)
+
+    for i, obs in enumerate(result.observables):
+        site = obs.sites[0] if isinstance(obs.sites, list) else obs.sites
+        assert isinstance(site, int)
+        op = obs.gate.name.upper()
+        assert op in {"X", "Y", "Z"}
+        expected = qiskit_single_pauli_expectation(qc, site, op)
+        got = float(np.real(result.expectation_values[i][0]))
+        assert got == pytest.approx(expected, abs=1e-10)
 
 
 def test_expectation_values_align_with_result_observables_order() -> None:

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -830,6 +830,49 @@ def test_observables_match_qiskit_statevector_qubit_ordering() -> None:
         assert got == pytest.approx(expected, abs=1e-10)
 
 
+def test_statevector_observables_match_qiskit_paulis() -> None:
+    """Observables computed from YAQS dense vector match Qiskit Pauli placement."""
+
+    def qiskit_single_pauli_expectation_from_vec(vec: np.ndarray, site: int, op: str) -> float:
+        n = int(np.log2(vec.size))
+        label = ["I"] * n
+        # Qiskit Pauli labels are ordered as q_{n-1} ... q_0.
+        label[n - 1 - site] = op
+        psi = Statevector(vec)
+        exp = psi.expectation_value(Pauli("".join(label)))
+        return float(np.real(exp))
+
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.cx(0, 2)
+    qc.ry(0.51, 1)
+    qc.rz(0.23, 2)
+    qc.cx(2, 1)
+
+    requested = [
+        Observable(Z(), 2),
+        Observable(X(), 0),
+        Observable(Y(), 1),
+        Observable(Z(), 0),
+        Observable(X(), 2),
+    ]
+    sim_params = StrongSimParams(observables=requested, gate_mode="hybrid", preset="exact", get_state=True)
+    state = State(3, initial="zeros")
+    result = Simulator(parallel=False, show_progress=False).run(state, qc, sim_params, None)
+
+    assert result.output_state is not None
+    yaqs_vec = result.output_state.mps.to_vec()
+
+    for i, obs in enumerate(result.observables):
+        site = obs.sites[0] if isinstance(obs.sites, list) else obs.sites
+        assert isinstance(site, int)
+        op = obs.gate.name.upper()
+        assert op in {"X", "Y", "Z"}
+        expected = qiskit_single_pauli_expectation_from_vec(yaqs_vec, site, op)
+        got = float(np.real(result.expectation_values[i][0]))
+        assert got == pytest.approx(expected, abs=1e-10)
+
+
 def test_expectation_values_align_with_result_observables_order() -> None:
     """Ensure expectation_values[i] corresponds to result.observables[i] (sorted order)."""
     qc = QuantumCircuit(3)
@@ -912,6 +955,40 @@ def test_weak_simulation_nearest_neighbor_counts() -> None:
     result = Simulator(parallel=False, show_progress=False).run(state, qc, sim_params, None)
     assert result.counts is not None
     assert sum(result.counts.values()) == 32
+
+
+@pytest.mark.parametrize(
+    ("num_qubits", "ones"),
+    [
+        (3, (0,)),
+        (3, (1,)),
+        (3, (2,)),
+        (4, (0, 2)),
+        (4, (1, 3)),
+        (5, (0, 1, 4)),
+    ],
+)
+def test_weak_counts_match_qiskit_qubit_ordering_deterministic(num_qubits: int, ones: tuple[int, ...]) -> None:
+    """Weak counts match Qiskit (bitstring->int) for deterministic basis states."""
+    qc = QuantumCircuit(num_qubits, num_qubits)
+    for q in ones:
+        qc.x(q)
+    qc.measure_all()
+
+    shots = 32
+    sim_params = WeakSimParams(shots=shots, gate_mode="hybrid", preset="exact")
+    state = State(num_qubits, initial="zeros")
+    result = Simulator(parallel=False, show_progress=False).run(state, qc, sim_params, None)
+    assert result.counts is not None
+
+    # Qiskit gives bitstrings ordered c_{n-1}..c_0; YAQS uses int keys.
+    qc_nom = qc.remove_final_measurements(inplace=False)
+    assert qc_nom is not None
+    probs = Statevector(qc_nom).probabilities_dict()
+    qiskit_counts_int = {int(bitstring, 2): round(p * shots) for bitstring, p in probs.items() if p > 0}
+    # Deterministic circuits should produce exactly one outcome with probability 1.
+    assert sum(qiskit_counts_int.values()) == shots
+    assert result.counts == qiskit_counts_int
 
 
 def test_noisy_nearest_neighbor_smoke() -> None:


### PR DESCRIPTION
## Description

This PR adds tests to ensure the qubit ordering matches qiskit. It also removes an unneeded reverse_bits() on the quantum circuit.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
