### PR TITLE
refactored observable handling in simulator to preserve user order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Removed
 
 ### Fixed
+
 - refactored observable handling in simulator to preserve user order ([#447]) ([**@aaronleesander**])
 - added tests to ensure qubit ordering matches Qiskit ([#446]) ([**@aaronleesander**])
 - minor cleanup ([#420]) ([**@aaronleesander**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Removed
 
 ### Fixed
-
+- refactored observable handling in simulator to preserve user order ([#447]) ([**@aaronleesander**])
 - added tests to ensure qubit ordering matches Qiskit ([#446]) ([**@aaronleesander**])
 - minor cleanup ([#420]) ([**@aaronleesander**])
 
@@ -124,6 +124,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#447]: https://github.com/munich-quantum-toolkit/yaqs/pull/447
 [#446]: https://github.com/munich-quantum-toolkit/yaqs/pull/446
 [#445]: https://github.com/munich-quantum-toolkit/yaqs/pull/445
 [#441]: https://github.com/munich-quantum-toolkit/yaqs/pull/441

--- a/src/mqt/yaqs/core/data_structures/result.py
+++ b/src/mqt/yaqs/core/data_structures/result.py
@@ -159,8 +159,9 @@ class Result:
     """Result of a :meth:`~mqt.yaqs.Simulator.run` call.
 
     Holds all simulation outputs. :attr:`sim_params` is the read-only configuration
-    object the user passed in. :attr:`observables` lists measurement metadata
-    (deep-copied from the configuration); :attr:`expectation_values` and
+    object the user passed in. :attr:`observables` preserves the user-supplied
+    ordering from ``sim_params.observables`` (deep-copied from the configuration);
+    :attr:`expectation_values` and
     :attr:`trajectories` hold the corresponding data in lock-step by index.
     For MPS-backed analog and strong-digital runs, :attr:`runtime_cost`,
     :attr:`max_bond`, and :attr:`total_bond` are populated automatically.

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -258,16 +258,35 @@ def _prepare_observable_ordering(observables: list[Observable]) -> tuple[list[Ob
     return sorted_observables, tuple(user_to_sorted)
 
 
-class AnalogSimParams:
+class _ObservableOrderingMixin:
+    """Computed observable ordering from the current ``observables`` list."""
+
+    observables: list[Observable]
+
+    @property
+    def sorted_observables(self) -> list[Observable]:
+        """Observables sorted by site for efficient MPS evaluation."""
+        sorted_obs, _indices = _prepare_observable_ordering(self.observables)
+        return sorted_obs
+
+    @property
+    def observable_sorted_indices(self) -> tuple[int, ...]:
+        """Maps each user-list index to the corresponding sorted worker-buffer row."""
+        _sorted_obs, indices = _prepare_observable_ordering(self.observables)
+        return indices
+
+
+class AnalogSimParams(_ObservableOrderingMixin):
     """Analog Simulation Parameters.
 
     A class to represent the parameters for an analog simulation.
 
     Attributes:
         observables: List of observables tracked during the simulation.
-        sorted_observables: Observables sorted by site for efficient MPS evaluation.
+        sorted_observables: Observables sorted by site for efficient MPS evaluation (computed
+            from the current :attr:`observables` list).
         observable_sorted_indices: Maps each user-list index to the corresponding row in
-            sorted worker buffers (``observable_sorted_indices[user_i]``).
+            sorted worker buffers (computed from the current :attr:`observables` list).
         elapsed_time: Total simulation time.
         dt: Simulation time step.
         times: Array of sampled times from ``0`` to ``elapsed_time`` with spacing ``dt``.
@@ -353,7 +372,6 @@ class AnalogSimParams:
             "We currently have not implemented mixed observable and projective-measurement simulation."
         )
         self.observables = obs_list
-        self.sorted_observables, self.observable_sorted_indices = _prepare_observable_ordering(obs_list)
 
         self.elapsed_time = elapsed_time
         self.dt = dt
@@ -376,7 +394,7 @@ class AnalogSimParams:
         )
 
 
-class StrongSimParams:
+class StrongSimParams(_ObservableOrderingMixin):
     """Strong Circuit Simulation Parameters.
 
     A class to represent the parameters for a strong simulation.
@@ -384,9 +402,10 @@ class StrongSimParams:
     Attributes:
         dt: A placeholder property for code compatibility.
         observables: A list of observables to be tracked during the simulation.
-        sorted_observables: Observables sorted by site for efficient MPS evaluation.
+        sorted_observables: Observables sorted by site for efficient MPS evaluation (computed
+            from the current :attr:`observables` list).
         observable_sorted_indices: Maps each user-list index to the corresponding row in
-            sorted worker buffers (``observable_sorted_indices[user_i]``).
+            sorted worker buffers (computed from the current :attr:`observables` list).
         num_traj: The number of trajectories to simulate.
         random_seed: If set, seeds per-trajectory jump RNG and static noise
             sampling for reproducible runs.
@@ -466,7 +485,6 @@ class StrongSimParams:
             "We currently have not implemented mixed observable and projective-measurement simulation."
         )
         self.observables = obs_list
-        self.sorted_observables, self.observable_sorted_indices = _prepare_observable_ordering(obs_list)
 
         self.num_traj = num_traj if num_traj is not None else preset_values["num_traj"]
         self.max_bond_dim = _resolve_max_bond_dim(max_bond_dim, preset_values["max_bond_dim"])

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -218,6 +218,46 @@ class Observable:
             self.gate.set_sites(self.sites)
 
 
+def _prepare_observable_ordering(observables: list[Observable]) -> tuple[list[Observable], tuple[int, ...]]:
+    """Prepare a sorted evaluation order and a user-index to sorted-row mapping.
+
+    Non-PVM observables are evaluated in ascending site order to reduce the number of
+    orthogonality-center shifts in MPS-based backends. The sorting is *stable* for
+    ties (observables on the same site keep their original list order). PVM
+    observables are appended in their original relative order.
+
+    Args:
+        observables: Observables in the order supplied by the user.
+
+    Returns:
+        ``(sorted_observables, observable_sorted_indices)`` where
+        ``observable_sorted_indices[user_i]`` is the corresponding row index in the
+        sorted worker buffers for ``observables[user_i]``.
+    """
+    if not observables:
+        return [], ()
+
+    indexed = list(enumerate(observables))
+    sortable = [(i, obs) for i, obs in indexed if obs.gate.name != "pvm"]
+    pvm_pairs = [(i, obs) for i, obs in indexed if obs.gate.name == "pvm"]
+
+    def _site_sort_key(pair: tuple[int, Observable]) -> tuple[int, int]:
+        user_i, obs = pair
+        sites = obs.sites
+        site = sites[0] if isinstance(sites, list) else sites
+        assert isinstance(site, int)
+        return (site, user_i)
+
+    sorted_pairs = sorted(sortable, key=_site_sort_key) + pvm_pairs
+    sorted_observables = [obs for _user_i, obs in sorted_pairs]
+
+    user_to_sorted: list[int] = [0] * len(observables)
+    for sorted_i, (user_i, _obs) in enumerate(sorted_pairs):
+        user_to_sorted[user_i] = sorted_i
+
+    return sorted_observables, tuple(user_to_sorted)
+
+
 class AnalogSimParams:
     """Analog Simulation Parameters.
 
@@ -225,7 +265,9 @@ class AnalogSimParams:
 
     Attributes:
         observables: List of observables tracked during the simulation.
-        sorted_observables: Observables sorted by site and name.
+        sorted_observables: Observables sorted by site for efficient MPS evaluation.
+        observable_sorted_indices: Maps each user-list index to the corresponding row in
+            sorted worker buffers (``observable_sorted_indices[user_i]``).
         elapsed_time: Total simulation time.
         dt: Simulation time step.
         times: Array of sampled times from ``0`` to ``elapsed_time`` with spacing ``dt``.
@@ -311,17 +353,7 @@ class AnalogSimParams:
             "We currently have not implemented mixed observable and projective-measurement simulation."
         )
         self.observables = obs_list
-
-        if self.observables:
-            sortable = [obs for obs in self.observables if obs.gate.name != "pvm"]
-            unsorted = [obs for obs in self.observables if obs.gate.name == "pvm"]
-            sorted_obs = sorted(
-                sortable,
-                key=lambda obs: obs.sites[0] if isinstance(obs.sites, list) else obs.sites,
-            )
-            self.sorted_observables = sorted_obs + unsorted
-        else:
-            self.sorted_observables = []
+        self.sorted_observables, self.observable_sorted_indices = _prepare_observable_ordering(obs_list)
 
         self.elapsed_time = elapsed_time
         self.dt = dt
@@ -352,7 +384,9 @@ class StrongSimParams:
     Attributes:
         dt: A placeholder property for code compatibility.
         observables: A list of observables to be tracked during the simulation.
-        sorted_observables: A list of observables sorted by site and name.
+        sorted_observables: Observables sorted by site for efficient MPS evaluation.
+        observable_sorted_indices: Maps each user-list index to the corresponding row in
+            sorted worker buffers (``observable_sorted_indices[user_i]``).
         num_traj: The number of trajectories to simulate.
         random_seed: If set, seeds per-trajectory jump RNG and static noise
             sampling for reproducible runs.
@@ -432,17 +466,7 @@ class StrongSimParams:
             "We currently have not implemented mixed observable and projective-measurement simulation."
         )
         self.observables = obs_list
-
-        if self.observables:
-            sortable = [obs for obs in self.observables if obs.gate.name != "pvm"]
-            unsorted = [obs for obs in self.observables if obs.gate.name == "pvm"]
-            sorted_obs = sorted(
-                sortable,
-                key=lambda obs: obs.sites[0] if isinstance(obs.sites, list) else obs.sites,
-            )
-            self.sorted_observables = sorted_obs + unsorted
-        else:
-            self.sorted_observables = []
+        self.sorted_observables, self.observable_sorted_indices = _prepare_observable_ordering(obs_list)
 
         self.num_traj = num_traj if num_traj is not None else preset_values["num_traj"]
         self.max_bond_dim = _resolve_max_bond_dim(max_bond_dim, preset_values["max_bond_dim"])

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -488,8 +488,8 @@ def _prepare_result_observables(
     num_traj: int,
     num_mid_measurements: int | None = None,
 ) -> None:
-    """Deep-copy sorted observables onto ``result`` and allocate output buffers."""
-    result.observables = [copy.deepcopy(obs) for obs in sim_params.sorted_observables]
+    """Deep-copy user-ordered observables onto ``result`` and allocate output buffers."""
+    result.observables = [copy.deepcopy(obs) for obs in sim_params.observables]
     trajectories, expectation_values, times = allocate_observable_buffers(
         sim_params,
         len(result.observables),
@@ -503,17 +503,29 @@ def _prepare_result_observables(
 
 def _worker_sim_params(
     sim_params: AnalogSimParams | StrongSimParams,
-    result: Result,
 ) -> AnalogSimParams | StrongSimParams:
-    """Build worker-visible params that reference ``result.observables`` for measurement.
+    """Build worker-visible params that expose sorted observables for measurement.
 
     Returns:
-        A deep copy of ``sim_params`` whose observable lists alias ``result.observables``.
+        A deep copy of ``sim_params`` whose observable lists are ordered for worker evaluation.
     """
     worker_params = copy.deepcopy(sim_params)
-    worker_params.observables = result.observables
-    worker_params.sorted_observables = result.observables
+    # Workers evaluate in sorted order for efficiency; Result retains user order.
+    worker_params.sorted_observables = [copy.deepcopy(obs) for obs in sim_params.sorted_observables]
+    worker_params.observables = worker_params.sorted_observables
     return worker_params
+
+
+def _store_observable_trajectory(
+    result: Result,
+    sim_params: AnalogSimParams | StrongSimParams,
+    *,
+    traj_index: int,
+    sorted_traj_data: NDArray[np.float64] | NDArray[np.complex128],
+) -> None:
+    """Store one trajectory's observable data into result buffers in user order."""
+    for user_i, sorted_i in enumerate(sim_params.observable_sorted_indices):
+        result.trajectories[user_i][traj_index] = sorted_traj_data[sorted_i]
 
 
 def _store_final_mps(result: Result, final_mps: MPS | None) -> None:
@@ -922,7 +934,7 @@ class Simulator:
             effective_num_traj = sim_params.num_traj
 
         _prepare_result_observables(result, sim_params, num_traj=effective_num_traj)
-        worker_params = cast("AnalogSimParams", _worker_sim_params(sim_params, result))
+        worker_params = cast("AnalogSimParams", _worker_sim_params(sim_params))
 
         diag_per_traj: NDArray[np.float64] | None = None
         if state_rep == "mps":
@@ -983,8 +995,7 @@ class Simulator:
                 mp_context=self.mp_context,
             ):
                 traj_data, traj_diag, traj_final = traj_payload
-                for obs_index in range(len(result.observables)):
-                    result.trajectories[obs_index][i] = traj_data[obs_index]
+                _store_observable_trajectory(result, sim_params, traj_index=i, sorted_traj_data=traj_data)
                 if traj_diag is not None and diag_per_traj is not None:
                     diag_per_traj[:, i, :] = traj_diag
                 if traj_final is not None:
@@ -1007,8 +1018,7 @@ class Simulator:
 
             for i, arg in enumerate(iterator):
                 traj_data, traj_diag, traj_final = _call_backend(backend, arg, n_threads=n_threads)
-                for obs_index in range(len(result.observables)):
-                    result.trajectories[obs_index][i] = traj_data[obs_index]
+                _store_observable_trajectory(result, sim_params, traj_index=i, sorted_traj_data=traj_data)
                 if traj_diag is not None and diag_per_traj is not None:
                     diag_per_traj[:, i, :] = traj_diag
                 if traj_final is not None:
@@ -1081,7 +1091,7 @@ class Simulator:
             num_traj=effective_num_traj,
             num_mid_measurements=effective_num_mid_measurements,
         )
-        worker_params = cast("StrongSimParams", _worker_sim_params(sim_params, result))
+        worker_params = cast("StrongSimParams", _worker_sim_params(sim_params))
         if sim_params.sample_layers:
             worker_params.num_mid_measurements = effective_num_mid_measurements
 
@@ -1113,8 +1123,8 @@ class Simulator:
                 mp_context=self.mp_context,
             ):
                 traj_data, traj_diag, traj_final = traj_payload
-                for obs_index in range(len(result.observables)):
-                    result.trajectories[obs_index][i] = traj_data[obs_index]
+                traj_data = cast("NDArray[np.float64] | NDArray[np.complex128]", traj_data)
+                _store_observable_trajectory(result, sim_params, traj_index=i, sorted_traj_data=traj_data)
                 if traj_diag is not None:
                     diag_per_traj[:, i, :] = traj_diag
                 if traj_final is not None:
@@ -1130,8 +1140,8 @@ class Simulator:
 
             for i, arg in enumerate(iterator):
                 traj_data, traj_diag, traj_final = _call_backend(backend, arg, n_threads=n_threads)
-                for obs_index in range(len(result.observables)):
-                    result.trajectories[obs_index][i] = traj_data[obs_index]
+                traj_data = cast("NDArray[np.float64] | NDArray[np.complex128]", traj_data)
+                _store_observable_trajectory(result, sim_params, traj_index=i, sorted_traj_data=traj_data)
                 if traj_diag is not None:
                     diag_per_traj[:, i, :] = traj_diag
                 if traj_final is not None:
@@ -1337,7 +1347,7 @@ class Simulator:
         effective_num_traj = len(initial_states)
 
         _prepare_result_observables(result, sim_params, num_traj=effective_num_traj)
-        worker_params = cast("AnalogSimParams", _worker_sim_params(sim_params, result))
+        worker_params = cast("AnalogSimParams", _worker_sim_params(sim_params))
         diag_per_traj, _ = allocate_diagnostic_buffers(sim_params, num_traj=effective_num_traj)
 
         n_pairs = len(sim_params.multi_time_observables)
@@ -1369,8 +1379,7 @@ class Simulator:
                 retry_exceptions=self.retry_exceptions,
                 mp_context=self.mp_context,
             ):
-                for obs_index in range(len(result.observables)):
-                    result.trajectories[obs_index][i] = obs_result[obs_index]
+                _store_observable_trajectory(result, sim_params, traj_index=i, sorted_traj_data=obs_result)
                 diag_per_traj[:, i, :] = traj_diag
                 if multi_time_matrix is not None:
                     assert multi_time_result is not None
@@ -1383,8 +1392,7 @@ class Simulator:
                 obs_result, traj_diag, multi_time_result = _call_backend(
                     ensemble_member_worker, arg, n_threads=n_threads
                 )
-                for obs_index in range(len(result.observables)):
-                    result.trajectories[obs_index][i] = obs_result[obs_index]
+                _store_observable_trajectory(result, sim_params, traj_index=i, sorted_traj_data=obs_result)
                 diag_per_traj[:, i, :] = traj_diag
                 if multi_time_matrix is not None:
                     assert multi_time_result is not None

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -116,7 +116,12 @@ from .core.data_structures.result import (
     allocate_diagnostic_buffers,
     allocate_observable_buffers,
 )
-from .core.data_structures.simulation_parameters import AnalogSimParams, StrongSimParams, WeakSimParams
+from .core.data_structures.simulation_parameters import (
+    AnalogSimParams,
+    StrongSimParams,
+    WeakSimParams,
+    _prepare_observable_ordering,
+)
 from .core.data_structures.state import State
 
 if TYPE_CHECKING:
@@ -511,8 +516,8 @@ def _worker_sim_params(
     """
     worker_params = copy.deepcopy(sim_params)
     # Workers evaluate in sorted order for efficiency; Result retains user order.
-    worker_params.sorted_observables = [copy.deepcopy(obs) for obs in sim_params.sorted_observables]
-    worker_params.observables = worker_params.sorted_observables
+    sorted_obs, _ = _prepare_observable_ordering(sim_params.observables)
+    worker_params.observables = [copy.deepcopy(obs) for obs in sorted_obs]
     return worker_params
 
 
@@ -524,7 +529,8 @@ def _store_observable_trajectory(
     sorted_traj_data: NDArray[np.float64] | NDArray[np.complex128],
 ) -> None:
     """Store one trajectory's observable data into result buffers in user order."""
-    for user_i, sorted_i in enumerate(sim_params.observable_sorted_indices):
+    _, observable_sorted_indices = _prepare_observable_ordering(sim_params.observables)
+    for user_i, sorted_i in enumerate(observable_sorted_indices):
         result.trajectories[user_i][traj_index] = sorted_traj_data[sorted_i]
 
 

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -487,6 +487,11 @@ def test_strong_params_sorting_and_fields() -> None:
     # Mapping from user order -> sorted worker row indices
     assert params.observable_sorted_indices == (3, 2, 0, 1)
 
+    # Ordering is derived from the current observables list, not cached at construction.
+    params.observables.append(Observable(GateLibrary.z(), sites=0))
+    assert len(params.sorted_observables) == 5
+    assert params.observable_sorted_indices == (4, 3, 1, 2, 0)
+
     # Parameter fields are retained
     assert params.num_traj == 7
     assert params.max_bond_dim == 128

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -484,6 +484,9 @@ def test_strong_params_sorting_and_fields() -> None:
     assert params.sorted_observables[2] is obs_x2
     assert params.sorted_observables[3] is obs_z3
 
+    # Mapping from user order -> sorted worker row indices
+    assert params.observable_sorted_indices == (3, 2, 0, 1)
+
     # Parameter fields are retained
     assert params.num_traj == 7
     assert params.max_bond_dim == 128

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -874,24 +874,33 @@ def test_statevector_observables_match_qiskit_paulis() -> None:
 
 
 def test_expectation_values_align_with_result_observables_order() -> None:
-    """Ensure expectation_values[i] corresponds to result.observables[i] (sorted order)."""
+    """Ensure expectation_values[i] corresponds to result.observables[i] (user order)."""
     qc = QuantumCircuit(3)
     qc.rx(0.37, 0)
     qc.cx(0, 2)
     qc.ry(0.51, 1)
 
-    # Intentionally not sorted by site to ensure sorting doesn't break interpretation.
+    # Intentionally not sorted by site: Result order should still match this list.
     requested = [Observable(Z(), 2), Observable(X(), 0), Observable(Z(), 0)]
     sim_params = StrongSimParams(observables=requested, gate_mode="hybrid", preset="exact", get_state=True)
     state = State(3, initial="zeros")
     result = Simulator(parallel=False, show_progress=False).run(state, qc, sim_params, None)
 
     assert result.output_state is not None
-    mps = result.output_state.mps
+    vec = result.output_state.mps.to_vec()
 
-    # result.observables defines the canonical order for expectation_values.
-    expected_vals = _expect_mps_like_evaluate_observables(mps, result.observables)
-    for i, expected in enumerate(expected_vals):
+    assert len(result.observables) == len(requested)
+    for i, (got_obs, req_obs) in enumerate(zip(result.observables, requested, strict=True)):
+        assert got_obs.gate.name == req_obs.gate.name
+        assert got_obs.sites == req_obs.sites
+
+        # Verify the expectation value matches the observable at the same index.
+        n = int(np.log2(vec.size))
+        label = ["I"] * n
+        site = got_obs.sites[0] if isinstance(got_obs.sites, list) else got_obs.sites
+        assert isinstance(site, int)
+        label[n - 1 - site] = got_obs.gate.name.upper()
+        expected = float(np.real(Statevector(vec).expectation_value(Pauli("".join(label)))))
         got = float(np.real(result.expectation_values[i][-1]))
         assert got == pytest.approx(expected, abs=1e-10)
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -28,6 +28,7 @@ import numba
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit
+from qiskit.quantum_info import Pauli, Statevector
 
 from mqt.yaqs import Result, Simulator, simulator
 from mqt.yaqs.core.data_structures.hamiltonian import Hamiltonian
@@ -1085,6 +1086,41 @@ def test_transmon_simulation() -> None:
 
     # finally check total leakage
     np.testing.assert_array_less(leakage, 5e-2)
+
+
+def test_analog_result_observables_preserve_user_order() -> None:
+    """Analog runs must preserve user observable order on Result."""
+    state = State(2, initial="zeros")
+    H = Hamiltonian.ising(2, J=1.0, g=0.7)
+    requested = [Observable(Z(), 1), Observable(X(), 0), Observable(Z(), 0)]
+    sim_params = AnalogSimParams(
+        observables=requested,
+        elapsed_time=0.1,
+        dt=0.1,
+        num_traj=1,
+        get_state=True,
+        sample_timesteps=False,
+        preset="exact",
+    )
+
+    result = Simulator(parallel=False, show_progress=False).run(state, H, sim_params)
+
+    assert result.output_state is not None
+    vec = result.output_state.mps.to_vec()
+    n = int(np.log2(vec.size))
+
+    assert len(result.observables) == len(requested)
+    for i, (got_obs, req_obs) in enumerate(zip(result.observables, requested, strict=True)):
+        assert got_obs.gate.name == req_obs.gate.name
+        assert got_obs.sites == req_obs.sites
+
+        label = ["I"] * n
+        site = got_obs.sites[0] if isinstance(got_obs.sites, list) else got_obs.sites
+        assert isinstance(site, int)
+        label[n - 1 - site] = got_obs.gate.name.upper()
+        expected = float(np.real(Statevector(vec).expectation_value(Pauli("".join(label)))))
+        got = float(np.real(result.expectation_values[i][-1]))
+        assert got == pytest.approx(expected, abs=1e-10)
 
 
 def test_scheduled_jump_single_site() -> None:


### PR DESCRIPTION
## Description

This PR fixes a bug where the observable order input by the user is not the order that comes out. This is due to them being sorted for efficient calculation within the code. Now the re-ordering happens during initialization of the simulation parameters and is purely internal rather than user facing.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
