### PR TITLE
improved Qiskit gate compatibility with matrix fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
-improved Qiskit gate compatibility with matrix fallback ([#464]) ([**@aaronleesander**])
+- improved Qiskit gate compatibility with matrix fallback ([#464]) ([**@aaronleesander**])
 
 - added MPO zip-up as default long-range gate application method ([#449]) ([**@aaronleesander**])
 - parallelized MPO equivalence checker ([#448]) ([**@aaronleesander**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+improved Qiskit gate compatibility with matrix fallback ([#464]) ([**@aaronleesander**])
 - added MPO zip-up as default long-range gate application method ([#449]) ([**@aaronleesander**])
 - parallelized MPO equivalence checker ([#448]) ([**@aaronleesander**])
 - added tebd/hybrid/tdvp options for circuit simulation ([#441]) ([**@aaronleesander**])
@@ -133,6 +134,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#464]: https://github.com/munich-quantum-toolkit/yaqs/pull/464
 [#458]: https://github.com/munich-quantum-toolkit/yaqs/pull/458
 [#457]: https://github.com/munich-quantum-toolkit/yaqs/pull/457
 [#449]: https://github.com/munich-quantum-toolkit/yaqs/pull/449

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Added
 
 improved Qiskit gate compatibility with matrix fallback ([#464]) ([**@aaronleesander**])
+
 - added MPO zip-up as default long-range gate application method ([#449]) ([**@aaronleesander**])
 - parallelized MPO equivalence checker ([#448]) ([**@aaronleesander**])
 - added tebd/hybrid/tdvp options for circuit simulation ([#441]) ([**@aaronleesander**])

--- a/docs/examples/custom_gates.md
+++ b/docs/examples/custom_gates.md
@@ -89,7 +89,7 @@ objects raise `ValueError`.
   comparison; mid-circuit measurements raise `ValueError`.
 
 Plain `barrier` instructions are dropped in simulation except barriers labelled
-`SAMPLE_OBSERVABLES` (used for weak-simulation sampling).
+`SAMPLE_OBSERVABLES` (used for strong-simulation layer sampling).
 
 ### Equivalence checking
 

--- a/docs/examples/custom_gates.md
+++ b/docs/examples/custom_gates.md
@@ -1,0 +1,294 @@
+# Custom and Qiskit Gates in YAQS
+
+YAQS represents every digital gate as a {class}`~mqt.yaqs.core.libraries.gate_library.BaseGate`
+instance from {class}`~mqt.yaqs.core.libraries.gate_library.GateLibrary`. Circuits enter YAQS as
+Qiskit {class}`qiskit.circuit.QuantumCircuit` objects; the library converts each DAG operation
+into an internal gate, then applies that gate during **circuit simulation** or **equivalence
+checking**.
+
+This page explains that pipeline, how built-in and custom gates are translated, and how to
+supply an analytic **generator** when you want long-range two-qubit gates to use the TDVP
+window path.
+
+## How YAQS handles gates end-to-end
+
+```mermaid
+flowchart TD
+  qc[QuantumCircuit] --> dag[DAGCircuit]
+  dag --> convert[convert_dag_to_tensor_algorithm]
+  convert --> hardcoded[GateLibrary alias]
+  convert --> fallback[GateLibrary.custom matrix]
+  hardcoded --> bg[BaseGate]
+  fallback --> bg
+  bg --> sim[Simulator / digital_tjm]
+  bg --> equiv[EquivalenceChecker]
+  sim --> mps[MPS site updates]
+  equiv --> mpo[MPO or dense tensor backend]
+```
+
+### Internal gate objects
+
+Each {class}`~mqt.yaqs.core.libraries.gate_library.BaseGate` carries:
+
+| Field         | Role                                                                                                                                                                    |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `matrix`      | Dense unitary as a `2^n × 2^n` complex matrix (`n` = number of qubits the gate acts on).                                                                                |
+| `tensor`      | Tensor layout used in MPS/MPO contractions (for two-qubit gates: shape `(2, 2, 2, 2)` after `set_sites`).                                                               |
+| `interaction` | Number of qubits (`1`, `2`, …); inferred from `matrix` size (`dim = 2**interaction`).                                                                                   |
+| `sites`       | MPS site indices the gate acts on, set via `set_sites(...)`.                                                                                                            |
+| `generator`   | Optional. For **two-qubit** built-ins that support TDVP: a list of two `2×2` local operators used to build a generator MPO. Not set by plain `GateLibrary.custom(...)`. |
+| `name`        | Qiskit operation name or `"custom"`.                                                                                                                                    |
+
+Built-in gates (`cx`, `h`, `rxx`, …) are classes on {class}`~mqt.yaqs.core.libraries.gate_library.GateLibrary`.
+`GateLibrary.custom(matrix)` returns a generic {class}`~mqt.yaqs.core.libraries.gate_library.BaseGate`
+backed only by the unitary matrix.
+
+### Translation from Qiskit
+
+{func}`~mqt.yaqs.digital.utils.dag_utils.convert_dag_to_tensor_algorithm` walks a
+{class}`qiskit.dagcircuit.DAGCircuit` and produces a list of `BaseGate` objects.
+
+For each operation node:
+
+1. **Unsupported instructions** raise `ValueError`: `reset`, `delay`, `store`, mid-circuit
+   `measure`, classically controlled ops, and control-flow instructions (`if_else`, `for_loop`, …).
+2. **`barrier`** nodes are skipped during conversion (ignored for unitary evolution).
+3. **Known Qiskit names** (for example `h`, `cx`, `u3`, `u1`, `swap`, `rxx`) map to hardcoded
+   {class}`~mqt.yaqs.core.libraries.gate_library.GateLibrary` classes via `getattr(GateLibrary, name)`.
+4. **Any other one- or two-qubit unitary** falls back to the **matrix path**: Qiskit's
+   `to_matrix()` / {class}`qiskit.quantum_info.Operator` data is wrapped as
+   `GateLibrary.custom(matrix)` with the Qiskit `op.name` preserved.
+
+```{note}
+**Three-qubit and larger gates** (including Toffoli / CCX) are not supported by the Qiskit
+translation layer. Only one- and two-qubit unitaries are accepted on the matrix fallback path.
+```
+
+Symbolic parameters must be bound before translation; unbound {class}`qiskit.circuit.Parameter`
+objects raise `ValueError`.
+
+### Application during circuit simulation
+
+{class}`~mqt.yaqs.Simulator` runs digital circuits through {mod}`~mqt.yaqs.digital.digital_tjm`:
+
+- **Single-qubit gates** — contract the gate tensor onto the corresponding MPS site.
+- **Two-qubit gates** — routed by `StrongSimParams.gate_mode` / `WeakSimParams.gate_mode`
+  (see {doc}`simulation_parameters`):
+  - **`mpo`** (default) — TEBD/SVD on nearest-neighbor pairs; long-range gates via extended gate MPO.
+  - **`swaps`** — TEBD with SWAP routing for long-range pairs.
+  - **`tdvp`** — TEBD on nearest-neighbor pairs; long-range pairs use **2TDVP** only when the gate
+    has a `generator`; otherwise the MPO path is used.
+  - **`full-tdvp`** — 2TDVP on every two-qubit gate that has a `generator`; generator-less gates
+    fall back to TEBD (NN) or MPO (long-range).
+
+**Measurements** are handled differently from unitary conversion:
+
+- During **simulation**, terminal `measure` nodes are removed from the live DAG so evolution can
+  proceed; sampling uses the remaining circuit structure.
+- During **equivalence checking**, final measurements are stripped from both circuits before
+  comparison; mid-circuit measurements raise `ValueError`.
+
+Plain `barrier` instructions are dropped in simulation except barriers labelled
+`SAMPLE_OBSERVABLES` (used for weak-simulation sampling).
+
+### Equivalence checking
+
+{class}`~mqt.yaqs.EquivalenceChecker` compares two circuits by forming $W = U_2^\dagger U_1$ and
+testing whether $W$ is identity-like up to global phase. Custom and QASM-defined gates use the
+same translation path as simulation; unknown one- and two-qubit unitaries work via matrix
+fallback. See {doc}`equivalence_checking` for backend choice (`representation="mpo"` recommended).
+
+---
+
+## Custom gates from Qiskit (most common)
+
+You do **not** need to register custom gates manually when they come from Qiskit.
+
+### `UnitaryGate`
+
+```python
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import UnitaryGate
+
+u = np.array([[0, 1], [1, 0]], dtype=complex)
+qc = QuantumCircuit(1)
+qc.append(UnitaryGate(u), [0])
+```
+
+YAQS translates this to a matrix-backed `BaseGate` named `"unitary"` with **no** `generator`
+attribute.
+
+### OpenQASM 2 custom gates
+
+OpenQASM 2 lets you declare reusable gate bodies (fixed or parameterized) and call them like
+built-in instructions. Load a program with `qiskit.qasm2.loads` or `load`; Qiskit produces a
+{class}`qiskit.circuit.QuantumCircuit` whose operations retain the **user-defined gate names**.
+
+YAQS does not maintain a separate registry of QASM gate definitions. Each DAG node is translated
+by name: if the name matches a {class}`~mqt.yaqs.core.libraries.gate_library.GateLibrary` entry,
+the hardcoded class is used; otherwise, for one- and two-qubit gates, YAQS builds a
+matrix-backed gate from Qiskit's unitary representation (matrix fallback). You do not need to
+inline or transpile custom gates to a fixed basis set before simulation or equivalence checking.
+
+```python
+from qiskit.qasm2 import loads
+
+qasm = """
+OPENQASM 2.0;
+include "qelib1.inc";
+
+gate entangle a,b {
+  h a;
+  cx a,b;
+}
+
+qreg q[2];
+entangle q[0], q[1];
+"""
+qc = loads(qasm)
+```
+
+The same rules apply to **legacy or backend-specific Qiskit gate names** that are not in the
+hardcoded alias list: if Qiskit can supply a unitary matrix and the gate acts on at most two
+qubits, translation succeeds via matrix fallback. Names that already have
+{class}`~mqt.yaqs.core.libraries.gate_library.GateLibrary` aliases (including common single-qubit
+parameterizations) continue to use the built-in implementations.
+
+### TDVP behaviour for matrix-backed custom gates
+
+Matrix-backed custom gates have **no analytic generator**. In `gate_mode="tdvp"` or
+`"full-tdvp"`:
+
+| Gate width                       | Routing                                       |
+| -------------------------------- | --------------------------------------------- |
+| Nearest-neighbor (\|i − j\| = 1) | TEBD/SVD                                      |
+| Long-range (\|i − j\| > 1)       | Extended gate MPO (same as `gate_mode="mpo"`) |
+
+This is intentional: 2TDVP requires a split local generator; a bare unitary matrix does not
+provide one. Use `gate_mode="mpo"` if you want consistent long-range handling for all custom
+unitaries without defining generators.
+
+---
+
+## Manually defining custom gates
+
+Use this path for library code, tests, or workflows that construct gates directly in YAQS
+(without Qiskit).
+
+### Matrix-only custom gate
+
+```python
+import numpy as np
+from mqt.yaqs.core.libraries.gate_library import GateLibrary
+
+unitary = np.eye(4, dtype=complex)  # example 2-qubit unitary
+gate = GateLibrary.custom(unitary)
+gate.name = "my_gate"
+gate.set_sites(0, 1)
+# gate.matrix, gate.tensor, gate.sites are ready for TEBD/MPO application
+```
+
+`GateLibrary.custom` validates that the matrix is square with dimension $2^n$.
+
+For **equivalence checking**, comparing two circuits that use the same custom unitary (or a
+custom gate versus an equivalent decomposition) works the same as for built-in gates.
+
+### Subclassing `BaseGate`
+
+Built-in gates subclass {class}`~mqt.yaqs.core.libraries.gate_library.BaseGate` and often
+override `set_sites` to set `tensor`, optional `mpo_tensors`, and— for TDVP-capable two-qubit
+gates—`generator`. See {class}`~mqt.yaqs.core.libraries.gate_library.CX` in
+{mod}`~mqt.yaqs.core.libraries.gate_library` for a reference implementation.
+
+---
+
+## Generators and the TDVP path
+
+Some two-qubit {class}`~mqt.yaqs.core.libraries.gate_library.GateLibrary` gates (`cx`, `cz`,
+`cp`, `rxx`, `ryy`, `rzz`, …) define a **`generator`**: a list of two `2×2` complex matrices
+`[G_a, G_b]`, one per qubit, ordered by **increasing site index** after `set_sites`.
+
+{func}`~mqt.yaqs.digital.digital_tjm.construct_generator_mpo` embeds these local operators on
+the gate support and places identity `2×2` blocks elsewhere, producing an MPO that represents the
+sum generator on the full chain. {func}`~mqt.yaqs.digital.digital_tjm.apply_two_qubit_gate_tdvp`
+then runs **two-site TDVP** (`tdvp_mode="2site"`) on a window around the gate for a total
+evolution time of **1** (split across `tdvp_sweeps` substeps on
+{class}`~mqt.yaqs.core.data_structures.simulation_parameters.StrongSimParams`).
+
+The controlled-NOT gate illustrates the pattern (see source for exact matrices):
+
+```python
+from mqt.yaqs.core.libraries.gate_library import GateLibrary
+
+gate = GateLibrary.cx()
+gate.set_sites(0, 1)
+# gate.generator is a list of two 2x2 arrays, set inside set_sites
+assert len(gate.generator) == 2
+```
+
+Routing checks `getattr(gate, "generator", None) is not None` in
+{func}`~mqt.yaqs.digital.digital_tjm.apply_two_qubit_gate`. Plain
+`GateLibrary.custom(...)` does **not** set `generator`; TDVP long-range application therefore
+does not activate unless you add one yourself.
+
+### Attaching a generator to a custom gate
+
+Advanced use: if you know a two-local generator decomposition compatible with YAQS digital TDVP,
+you can assign it after `set_sites`:
+
+```python
+import numpy as np
+from mqt.yaqs.core.libraries.gate_library import GateLibrary
+
+unitary = ...  # 4x4 unitary on qubits (i, j), i < j
+G_i = ...  # 2x2 local operator on site i
+G_j = ...  # 2x2 local operator on site j
+
+gate = GateLibrary.custom(unitary)
+gate.set_sites(i, j)
+gate.generator = [G_i, G_j]
+```
+
+```{warning}
+YAQS does not verify that `exp(-i (G_i ⊗ I + I ⊗ G_j))` at evolution time `1` reproduces
+`unitary`. Deriving consistent local generators is the caller's responsibility; use built-in
+gates as templates. Reversed qubit order is handled internally when building the generator MPO,
+but the local matrices must match the **increasing site index** convention used in
+{func}`~mqt.yaqs.digital.digital_tjm.construct_generator_mpo`.
+```
+
+Generators apply only to **two-qubit** digital gates. Single-qubit custom gates always use direct
+MPS contraction; there is no single-qubit TDVP gate path in circuit simulation.
+
+---
+
+## Quick reference
+
+| Source                                     | `generator`            | TDVP long-range (`gate_mode="tdvp"`) | Equivalence check           |
+| ------------------------------------------ | ---------------------- | ------------------------------------ | --------------------------- |
+| Built-in `cx`, `rxx`, …                    | Yes (in `set_sites`)   | 2TDVP window                         | Supported                   |
+| Qiskit `UnitaryGate` / QASM custom         | No                     | MPO fallback                         | Supported (matrix fallback) |
+| `GateLibrary.custom(matrix)`               | No (unless you set it) | MPO fallback                         | Supported                   |
+| `GateLibrary.custom` + manual `.generator` | Yes (if you set it)    | 2TDVP window                         | Supported                   |
+| 3+ qubit Qiskit gates                      | —                      | Not translated                       | Not supported               |
+
+### Rejected Qiskit instructions (translation)
+
+| Instruction                    | Conversion                 | Simulation                            | Equivalence           |
+| ------------------------------ | -------------------------- | ------------------------------------- | --------------------- |
+| `barrier`                      | Skipped                    | Removed (except `SAMPLE_OBSERVABLES`) | Skipped in MPO zones  |
+| Final `measure`                | Rejected in raw conversion | Removed from DAG                      | Stripped before check |
+| Mid-circuit `measure`          | Rejected                   | Removed only if per-qubit terminal    | `ValueError`          |
+| `reset`, `delay`, control-flow | Rejected                   | —                                     | —                     |
+
+---
+
+## See also
+
+- {doc}`simulation_parameters` — `gate_mode`, `tdvp_sweeps`, `tdvp_mode`
+- {doc}`equivalence_checking` — comparing original and transpiled circuits
+- {doc}`strong_circuit_simulation` — running circuits with {class}`~mqt.yaqs.Simulator`
+- {mod}`~mqt.yaqs.digital.utils.dag_utils` — translation implementation and
+  `SUPPORTED_QISKIT_GATE_NAMES`
+- {mod}`~mqt.yaqs.core.libraries.gate_library` — built-in gate definitions and generator examples

--- a/docs/examples/equivalence_checking.md
+++ b/docs/examples/equivalence_checking.md
@@ -214,6 +214,7 @@ everything larger.
 
 ## See also
 
+- {doc}`custom_gates` — Qiskit translation, matrix fallback, and TDVP generators
 - {doc}`simulator_initialization` — running simulations with {class}`~mqt.yaqs.Simulator`
 - {doc}`simulation_parameters` — presets and truncation for **simulation** (separate from
   equivalence `threshold`)

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -183,7 +183,8 @@ Digital circuit simulation on an MPS defaults to **`gate_mode="mpo"`** (generic 
 
 Matrix-backed custom gates (from Qiskit `UnitaryGate` or other unknown 1-/2-qubit unitaries) have no
 analytic generator. In `gate_mode="tdvp"` or `"full-tdvp"`, those gates use TEBD on nearest-neighbor
-pairs and the MPO path on long-range pairs instead of the TDVP generator window.
+pairs and the MPO path on long-range pairs instead of the TDVP generator window. See {doc}`custom_gates`
+for the full gate translation and custom-gate workflow.
 
 Long-range gates in `gate_mode="tdvp"` apply 2TDVP on the gate support window via `evolve_window`.
 

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -181,6 +181,10 @@ Digital circuit simulation on an MPS defaults to **`gate_mode="mpo"`** (generic 
 - **`tdvp`** — TEBD/SVD on nearest-neighbor gates; long-range gates use the generator MPO + **two-site TDVP (2TDVP)** on a local window.
 - **`full-tdvp`** — TDVP (generator MPO + 2TDVP on a local window) on every two-qubit gate.
 
+Matrix-backed custom gates (from Qiskit `UnitaryGate` or other unknown 1-/2-qubit unitaries) have no
+analytic generator. In `gate_mode="tdvp"` or `"full-tdvp"`, those gates use TEBD on nearest-neighbor
+pairs and the MPO path on long-range pairs instead of the TDVP generator window.
+
 Long-range gates in `gate_mode="tdvp"` apply 2TDVP on the gate support window via `evolve_window`.
 
 Use **`tdvp_sweeps`** (default `1`) to split each TDVP evolution step into multiple substeps of equal total time. Values greater than `1` are opt-in and may improve accuracy on some circuits. The setting applies to all TDVP kernels on `AnalogSimParams`, `StrongSimParams`, and `WeakSimParams`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ installation
 examples/state_initialization
 examples/simulator_initialization
 examples/simulation_parameters
+examples/custom_gates
 examples/analog_simulation
 examples/ensemble_evolution
 examples/solver_comparison

--- a/src/mqt/yaqs/core/data_structures/mpo.py
+++ b/src/mqt/yaqs/core/data_structures/mpo.py
@@ -22,8 +22,8 @@ from ..libraries.gate_library import BaseGate, Destroy
 from .mpo_utils import (
     contract_mpo_site_with_mpo_site,
     contract_mpo_site_with_mps_site,
-    gate_support_mpo_tensors,
-    identity_mpo_site,
+    get_support_mpo,
+    make_identity_site,
 )
 from .mps import MPS
 
@@ -644,12 +644,12 @@ class MPO:
             msg = f"chain_length {chain_length} is smaller than gate support length {support_len}."
             raise ValueError(msg)
 
-        support = gate_support_mpo_tensors(gate, first_site=first_site, last_site=last_site)
+        support = get_support_mpo(gate, first_site=first_site, last_site=last_site)
         if chain_length == support_len:
             tensors = support
         else:
             phys_dim = support[0].shape[0]
-            identity_site = identity_mpo_site(phys_dim)
+            identity_site = make_identity_site(phys_dim)
             tensors = []
             for site in range(chain_length):
                 if site < first_site or site > last_site:
@@ -670,7 +670,7 @@ class MPO:
             length: Number of sites.
             physical_dimension: Local dimension per site (default 2).
         """
-        site = identity_mpo_site(physical_dimension)
+        site = make_identity_site(physical_dimension)
         self.length = length
         self.physical_dimension = physical_dimension
 

--- a/src/mqt/yaqs/core/data_structures/mpo_utils.py
+++ b/src/mqt/yaqs/core/data_structures/mpo_utils.py
@@ -88,7 +88,7 @@ def contract_mpo_site_with_mpo_site(
     return np.transpose(fused, (0, 2, 1, 3))
 
 
-def identity_mpo_site(physical_dimension: int) -> NDArray[np.complex128]:
+def make_identity_site(physical_dimension: int) -> NDArray[np.complex128]:
     """Single-site identity MPO tensor ``(phys_out, phys_in, 1, 1)``.
 
     Args:
@@ -101,7 +101,7 @@ def identity_mpo_site(physical_dimension: int) -> NDArray[np.complex128]:
     return np.expand_dims(np.expand_dims(tensor, axis=2), axis=3)
 
 
-def two_qubit_matrix_to_mps_tensor(matrix: NDArray[np.complex128]) -> NDArray[np.complex128]:
+def convert_nn_matrix(matrix: NDArray[np.complex128]) -> NDArray[np.complex128]:
     """Map a ``4 x 4`` two-qubit unitary into ``U[out_l, out_r, in_l, in_r]`` for TEBD.
 
     The MPS merge uses ``ijkl,klab->ijab`` with ``k,l`` the left/right input physical
@@ -124,7 +124,7 @@ def two_qubit_matrix_to_mps_tensor(matrix: NDArray[np.complex128]) -> NDArray[np
     return tensor
 
 
-def gate_tensor_lr_order(
+def resolve_lr_tensor(
     gate: BaseGate,
     left_site: int | None = None,
     right_site: int | None = None,
@@ -134,7 +134,7 @@ def gate_tensor_lr_order(
     When ``gate.sites == (left_site, right_site)``, the gate matrix is reshaped directly.
     When the declared sites are reversed on the same nearest-neighbor pair, the matrix
     already encodes the operator for ``gate.sites`` and is mapped with
-    :func:`two_qubit_matrix_to_mps_tensor` instead of transposing a naive reshape.
+    :func:`convert_nn_matrix` instead of transposing a naive reshape.
 
     Args:
         gate: Two-qubit gate with ``sites`` and ``tensor`` set.
@@ -154,12 +154,12 @@ def gate_tensor_lr_order(
     if gate.sites[0] == left_site and gate.sites[1] == right_site:
         return np.asarray(gate.tensor, dtype=np.complex128)
     if gate.sites[0] == right_site and gate.sites[1] == left_site:
-        return two_qubit_matrix_to_mps_tensor(gate.matrix)
+        return convert_nn_matrix(gate.matrix)
     msg = f"Gate sites {gate.sites!r} are not consistent with MPS sites ({left_site}, {right_site})."
     raise ValueError(msg)
 
 
-def gate_support_mpo_tensors(
+def get_support_mpo(
     gate: BaseGate,
     *,
     first_site: int,
@@ -183,7 +183,7 @@ def gate_support_mpo_tensors(
     if cached is not None and len(cached) == support_len:
         return list(cached)
     return extend_gate(
-        gate_tensor_lr_order(gate),
+        resolve_lr_tensor(gate),
         [first_site, last_site],
     )
 

--- a/src/mqt/yaqs/core/data_structures/mpo_utils.py
+++ b/src/mqt/yaqs/core/data_structures/mpo_utils.py
@@ -101,12 +101,40 @@ def identity_mpo_site(physical_dimension: int) -> NDArray[np.complex128]:
     return np.expand_dims(np.expand_dims(tensor, axis=2), axis=3)
 
 
+def two_qubit_matrix_to_mps_tensor(matrix: NDArray[np.complex128]) -> NDArray[np.complex128]:
+    """Map a ``4 x 4`` two-qubit unitary into ``U[out_l, out_r, in_l, in_r]`` for TEBD.
+
+    The MPS merge uses ``ijkl,klab->ijab`` with ``k,l`` the left/right input physical
+    indices and ``i,j`` the outputs. Qiskit little-endian state indices use
+    ``index = q_left + 2 * q_right`` for the two-site support ``(left, right)``.
+
+    Args:
+        matrix: Unitary on the two-qubit computational basis in that index ordering.
+
+    Returns:
+        Rank-4 gate tensor for nearest-neighbor TEBD contraction.
+    """
+    mat = np.asarray(matrix, dtype=np.complex128)
+    tensor = np.zeros((2, 2, 2, 2), dtype=np.complex128)
+    for col in range(4):
+        in_left, in_right = col % 2, col // 2
+        for row in range(4):
+            out_left, out_right = row % 2, row // 2
+            tensor[out_left, out_right, in_left, in_right] = mat[row, col]
+    return tensor
+
+
 def gate_tensor_lr_order(
     gate: BaseGate,
     left_site: int | None = None,
     right_site: int | None = None,
 ) -> NDArray[np.complex128]:
     """Return ``gate.tensor`` as ``U[out_l, out_r, in_l, in_r]`` on ascending MPS sites.
+
+    When ``gate.sites == (left_site, right_site)``, the gate matrix is reshaped directly.
+    When the declared sites are reversed on the same nearest-neighbor pair, the matrix
+    already encodes the operator for ``gate.sites`` and is mapped with
+    :func:`two_qubit_matrix_to_mps_tensor` instead of transposing a naive reshape.
 
     Args:
         gate: Two-qubit gate with ``sites`` and ``tensor`` set.
@@ -126,7 +154,7 @@ def gate_tensor_lr_order(
     if gate.sites[0] == left_site and gate.sites[1] == right_site:
         return np.asarray(gate.tensor, dtype=np.complex128)
     if gate.sites[0] == right_site and gate.sites[1] == left_site:
-        return np.asarray(np.transpose(gate.tensor, (1, 0, 3, 2)), dtype=np.complex128)
+        return two_qubit_matrix_to_mps_tensor(gate.matrix)
     msg = f"Gate sites {gate.sites!r} are not consistent with MPS sites ({left_site}, {right_site})."
     raise ValueError(msg)
 

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -211,7 +211,7 @@ class BaseGate:
         if self.interaction != other.interaction:
             msg = "Cannot add gates with different interaction"
             raise ValueError(msg)
-        return BaseGate(self.matrix + other.matrix)
+        return self._clone_with_matrix(self.matrix + other.matrix)
 
     def __sub__(self, other: BaseGate) -> BaseGate:
         """Subtracts one gate from another.
@@ -228,7 +228,7 @@ class BaseGate:
         if self.interaction != other.interaction:
             msg = "Cannot subtract gates with different interaction"
             raise ValueError(msg)
-        return BaseGate(self.matrix - other.matrix)
+        return self._clone_with_matrix(self.matrix - other.matrix)
 
     def __mul__(self, other: BaseGate | complex) -> BaseGate:
         """Multiplies two gates or scales a gate by a scalar.
@@ -246,9 +246,9 @@ class BaseGate:
             if self.interaction != other.interaction:
                 msg = "Cannot multiply gates with different interaction"
                 raise ValueError(msg)
-            return BaseGate(self.matrix @ other.matrix)
+            return self._clone_with_matrix(self.matrix @ other.matrix)
 
-        return BaseGate(self.matrix * other)
+        return self._clone_with_matrix(self.matrix * other)
 
     def __rmul__(self, other: BaseGate | complex) -> BaseGate:
         """Multiplies a scalar or another gate with this gate (right multiplication).
@@ -270,7 +270,7 @@ class BaseGate:
         Returns:
             A new BaseGate resulting from matrix multiplication.
         """
-        return BaseGate(self.matrix @ other.matrix)
+        return self._clone_with_matrix(self.matrix @ other.matrix)
 
     def _clone_with_matrix(self, matrix: NDArray[np.complex128]) -> BaseGate:
         """Return a gate with the same interaction level and a new matrix."""

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -273,7 +273,18 @@ class BaseGate:
         return self._clone_with_matrix(self.matrix @ other.matrix)
 
     def _clone_with_matrix(self, matrix: NDArray[np.complex128]) -> BaseGate:
-        """Return a gate with the same interaction level and a new matrix."""
+        """Return a gate with the same interaction level and a new matrix.
+
+        Unlike :meth:`__init__`, this bypasses power-of-two dimension validation so
+        arithmetic on d-level ladder operators preserves non-qubit matrix sizes.
+
+        Args:
+            matrix: Replacement gate matrix.
+
+        Returns:
+            New gate with ``interaction`` copied from ``self`` and ``name`` set to
+            ``"custom"``.
+        """
         clone = BaseGate.__new__(BaseGate)
         clone.matrix = np.asarray(matrix, dtype=np.complex128)
         clone.tensor = clone.matrix

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -272,13 +272,22 @@ class BaseGate:
         """
         return BaseGate(self.matrix @ other.matrix)
 
+    def _clone_with_matrix(self, matrix: NDArray[np.complex128]) -> BaseGate:
+        """Return a gate with the same interaction level and a new matrix."""
+        clone = BaseGate.__new__(BaseGate)
+        clone.matrix = np.asarray(matrix, dtype=np.complex128)
+        clone.tensor = clone.matrix
+        clone.interaction = self.interaction
+        clone.name = "custom"
+        return clone
+
     def dag(self) -> BaseGate:
         """Returns the conjugate transpose (dagger) of the gate.
 
         Returns:
             A new gate representing the conjugate transpose of this gate.
         """
-        return BaseGate(np.conj(self.matrix).T)
+        return self._clone_with_matrix(np.conj(self.matrix).T)
 
     def conj(self) -> BaseGate:
         """Returns the complex conjugate of the gate.
@@ -286,7 +295,7 @@ class BaseGate:
         Returns:
             A new gate representing the complex conjugate of this gate.
         """
-        return BaseGate(np.conj(self.matrix))
+        return self._clone_with_matrix(np.conj(self.matrix))
 
     def trans(self) -> BaseGate:
         """Returns the transpose of the gate.
@@ -294,7 +303,7 @@ class BaseGate:
         Returns:
             A new gate representing the transpose of this gate.
         """
-        return BaseGate(self.matrix.T)
+        return self._clone_with_matrix(self.matrix.T)
 
     @classmethod
     def x(cls) -> X:
@@ -705,8 +714,9 @@ class Destroy(BaseGate):
             d: Physical dimension.
         """
         mat = np.diag(np.sqrt(np.arange(1, d)), k=1)
-
-        super().__init__(mat)
+        self.matrix = np.asarray(mat, dtype=np.complex128)
+        self.tensor = self.matrix
+        self.interaction = 1
 
 
 class Create(BaseGate):
@@ -732,8 +742,9 @@ class Create(BaseGate):
             d: Physical dimension.
         """
         mat = np.diag(np.sqrt(np.arange(1, d)), k=-1)
-
-        super().__init__(mat)
+        self.matrix = np.asarray(mat, dtype=np.complex128)
+        self.tensor = self.matrix
+        self.interaction = 1
 
 
 class Id(BaseGate):

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -195,8 +195,6 @@ class BaseGate:
         if self.interaction == 2:
             self.tensor = np.reshape(self.matrix, (2, 2, 2, 2))
             self.mpo_tensors = extend_gate(self.tensor, self.sites)
-            if self.sites[1] < self.sites[0]:
-                self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
     def __add__(self, other: BaseGate) -> BaseGate:
         """Adds two gates together.

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -22,7 +22,7 @@ import numpy as np
 from .. import linalg
 
 if TYPE_CHECKING:
-    from numpy.typing import NDArray
+    from numpy.typing import ArrayLike, NDArray
     from qiskit.circuit import Parameter
 
 
@@ -141,25 +141,33 @@ class BaseGate:
     generator: NDArray[np.complex128] | list[NDArray[np.complex128]]
     sites: list[int]
 
-    def __init__(self, mat: NDArray[np.complex128]) -> None:
+    def __init__(self, mat: ArrayLike) -> None:
         """Initializes a BaseGate instance with the given matrix.
 
         Args:
             mat: The matrix representation of the gate.
 
         Raises:
-            ValueError: If the matrix is not square.
-            ValueError: If the matrix size is not a power of 2.
+            ValueError: If the matrix is not a square 2-D array.
+            ValueError: If the matrix dimension is not a power of 2.
         """
-        if mat.shape[0] != mat.shape[1]:
+        matrix = np.asarray(mat, dtype=np.complex128)
+        if matrix.ndim != 2:
+            msg = "Matrix must be a 2-D array."
+            raise ValueError(msg)
+        if matrix.shape[0] != matrix.shape[1]:
             msg = "Matrix must be square"
             raise ValueError(msg)
 
-        log = np.log2(mat.shape[0])
+        dim = matrix.shape[0]
+        interaction = int(np.log2(dim))
+        if dim < 1 or 2**interaction != dim:
+            msg = f"Matrix dimension {dim} must be a power of 2."
+            raise ValueError(msg)
 
-        self.matrix = mat
-        self.tensor = mat
-        self.interaction = int(log)
+        self.matrix = matrix
+        self.tensor = matrix
+        self.interaction = interaction
 
     def set_sites(self, *sites: int | list[int]) -> None:
         """Sets the sites for the gate.

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -192,6 +192,11 @@ class BaseGate:
 
         # store as the proper type
         self.sites = sites_list
+        if self.interaction == 2:
+            self.tensor = np.reshape(self.matrix, (2, 2, 2, 2))
+            self.mpo_tensors = extend_gate(self.tensor, self.sites)
+            if self.sites[1] < self.sites[0]:
+                self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
     def __add__(self, other: BaseGate) -> BaseGate:
         """Adds two gates together.
@@ -774,6 +779,116 @@ class SX(BaseGate):
     def __init__(self) -> None:
         """Initializes the square-root X gate."""
         mat = 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=np.complex128)
+        super().__init__(mat)
+
+
+class Sdg(BaseGate):
+    """Class representing the adjoint S (S-dagger) gate.
+
+    Attributes:
+        name: The name of the gate ("sdg").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+
+    Methods:
+        set_sites(*sites: int) -> None:
+            Sets the site(s) where the gate is applied.
+    """
+
+    name = "sdg"
+
+    def __init__(self) -> None:
+        """Initializes the adjoint S gate."""
+        mat = np.array([[1, 0], [0, -1j]], dtype=np.complex128)
+        super().__init__(mat)
+
+
+class S(BaseGate):
+    """Class representing the S gate.
+
+    Attributes:
+        name: The name of the gate ("s").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+
+    Methods:
+        set_sites(*sites: int) -> None:
+            Sets the site(s) where the gate is applied.
+    """
+
+    name = "s"
+
+    def __init__(self) -> None:
+        """Initializes the S gate."""
+        mat = np.array([[1, 0], [0, 1j]], dtype=np.complex128)
+        super().__init__(mat)
+
+
+class Tdg(BaseGate):
+    """Class representing the adjoint T (T-dagger) gate.
+
+    Attributes:
+        name: The name of the gate ("tdg").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+
+    Methods:
+        set_sites(*sites: int) -> None:
+            Sets the site(s) where the gate is applied.
+    """
+
+    name = "tdg"
+
+    def __init__(self) -> None:
+        """Initializes the adjoint T gate."""
+        mat = np.array([[1, 0], [0, np.exp(-1j * np.pi / 4)]], dtype=np.complex128)
+        super().__init__(mat)
+
+
+class T(BaseGate):
+    """Class representing the T gate.
+
+    Attributes:
+        name: The name of the gate ("t").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+
+    Methods:
+        set_sites(*sites: int) -> None:
+            Sets the site(s) where the gate is applied.
+    """
+
+    name = "t"
+
+    def __init__(self) -> None:
+        """Initializes the T gate."""
+        mat = np.array([[1, 0], [0, np.exp(1j * np.pi / 4)]], dtype=np.complex128)
+        super().__init__(mat)
+
+
+class SXdg(BaseGate):
+    """Class representing the adjoint SX (SX-dagger) gate.
+
+    Attributes:
+        name: The name of the gate ("sxdg").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+
+    Methods:
+        set_sites(*sites: int) -> None:
+            Sets the site(s) where the gate is applied.
+    """
+
+    name = "sxdg"
+
+    def __init__(self) -> None:
+        """Initializes the adjoint SX gate."""
+        mat = 0.5 * np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]], dtype=np.complex128)
         super().__init__(mat)
 
 
@@ -1587,14 +1702,23 @@ class GateLibrary:
         y: Class for the Pauli-Y gate.
         z: Class for the Pauli-Z gate.
         sx: Class for the √X (SX) gate.
+        sxdg: Class for the adjoint √X (SX-dagger) gate.
+        s: Class for the S gate.
+        sdg: Class for the adjoint S (S-dagger) gate.
+        t: Class for the T gate.
+        tdg: Class for the adjoint T (T-dagger) gate.
         h: Class for the Hadamard gate.
         id: Class for the identity gate.
+        i: Alias for the identity gate.
+        iden: Alias for the identity gate.
 
         rx: Class for rotation about the X-axis.
         ry: Class for rotation about the Y-axis.
         rz: Class for rotation about the Z-axis.
         u:  Class for the generic single-qubit U gate.
+        u3: Alias for the generic single-qubit U gate.
         u2: Class for the U2 (fixed-θ,φ) single-qubit gate.
+        u1: Alias for the single-qubit phase gate.
 
         cx: Class for the controlled-NOT (CNOT) gate.
         cz: Class for the controlled-Z gate.
@@ -1628,14 +1752,23 @@ class GateLibrary:
     y = Y
     z = Z
     sx = SX
+    sxdg = SXdg
+    s = S
+    sdg = Sdg
+    t = T
+    tdg = Tdg
     h = H
     id = Id
+    i = Id
+    iden = Id
 
     rx = Rx
     ry = Ry
     rz = Rz
     u = U
+    u3 = U
     u2 = U2
+    u1 = Phase
 
     cx = CX
     cz = CZ

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -22,7 +22,7 @@ import opt_einsum as oe
 from qiskit.converters import circuit_to_dag
 
 from ..core.data_structures.mpo import MPO
-from ..core.data_structures.mpo_utils import gate_tensor_lr_order
+from ..core.data_structures.mpo_utils import resolve_lr_tensor
 from ..core.data_structures.mps import MPS
 from ..core.data_structures.noise_model import NoiseModel
 from ..core.data_structures.simulation_parameters import (
@@ -310,7 +310,7 @@ def apply_two_qubit_gate_tebd(
 
     left_site = min(site0, site1)
     right_site = max(site0, site1)
-    u_gate = gate_tensor_lr_order(gate, left_site, right_site)
+    u_gate = resolve_lr_tensor(gate, left_site, right_site)
 
     left_tensor = state.tensors[left_site]
     right_tensor = state.tensors[right_site]

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -70,6 +70,21 @@ def create_local_noise_model(noise_model: NoiseModel, first_site: int, last_site
     return NoiseModel(local_processes)
 
 
+def _is_terminal_measure(dag: DAGCircuit, node: DAGOpNode) -> bool:
+    """Return whether no later op nodes act on qubits measured by ``node``."""
+    measured = {dag.find_bit(q).index for q in node.qargs}
+    topo = list(dag.topological_op_nodes())
+    try:
+        node_index = topo.index(node)
+    except ValueError:
+        return True
+    for later in topo[node_index + 1 :]:
+        later_qubits = {dag.find_bit(q).index for q in later.qargs}
+        if later_qubits & measured:
+            return False
+    return True
+
+
 def process_layer(dag: DAGCircuit) -> tuple[list[DAGOpNode], list[DAGOpNode], list[DAGOpNode], list[DAGOpNode]]:
     """Process quantum circuit layer before applying to MPS.
 
@@ -88,6 +103,7 @@ def process_layer(dag: DAGCircuit) -> tuple[list[DAGOpNode], list[DAGOpNode], li
 
     Raises:
         NotImplementedError: If a node with more than two qubits is encountered.
+        ValueError: If a non-terminal ``measure`` operation is encountered.
     """
     # Extract the current layer
     current_layer = dag.front_layer()
@@ -102,11 +118,18 @@ def process_layer(dag: DAGCircuit) -> tuple[list[DAGOpNode], list[DAGOpNode], li
     for node in current_layer:
         name = node.op.name
 
-        # Drop measurements during simulation. Unlike ``convert_dag_to_tensor_algorithm``,
+        # Drop terminal measurements during simulation. Unlike ``convert_dag_to_tensor_algorithm``,
         # which rejects ``measure`` when building a gate list, the live DAG path removes
         # measurement nodes so terminal Qiskit measurements do not block evolution.
         if name == "measure":
-            dag.remove_op_node(node)
+            if _is_terminal_measure(dag, node):
+                dag.remove_op_node(node)
+            else:
+                msg = (
+                    "Non-terminal measure operations are not supported during simulation; "
+                    "removing them would ignore state collapse and classical dependencies."
+                )
+                raise ValueError(msg)
             continue
 
         # Keep ONLY barriers with label "SAMPLE_OBSERVABLES" (case-insensitive). Remove all other barriers.

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -102,7 +102,9 @@ def process_layer(dag: DAGCircuit) -> tuple[list[DAGOpNode], list[DAGOpNode], li
     for node in current_layer:
         name = node.op.name
 
-        # Drop measurements during simulation; they are rejected by DAG-to-gate conversion.
+        # Drop measurements during simulation. Unlike ``convert_dag_to_tensor_algorithm``,
+        # which rejects ``measure`` when building a gate list, the live DAG path removes
+        # measurement nodes so terminal Qiskit measurements do not block evolution.
         if name == "measure":
             dag.remove_op_node(node)
             continue

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -373,9 +373,14 @@ def apply_two_qubit_gate(state: MPS, node: DAGOpNode, sim_params: StrongSimParam
     site0, site1 = gate.sites[0], gate.sites[1]
     is_nearest_neighbor = abs(site0 - site1) == 1
     gate_mode: GateMode = getattr(sim_params, "gate_mode", "mpo")
+    has_generator = getattr(gate, "generator", None) is not None
 
     if gate_mode == "full-tdvp":
-        return apply_two_qubit_gate_tdvp(state, gate, sim_params)
+        if has_generator:
+            return apply_two_qubit_gate_tdvp(state, gate, sim_params)
+        if is_nearest_neighbor:
+            return apply_two_qubit_gate_tebd(state, gate, sim_params)
+        return apply_long_range_gate_mpo(state, gate, sim_params)
 
     if gate_mode == "swaps":
         return apply_two_qubit_gate_tebd(state, gate, sim_params)
@@ -383,7 +388,9 @@ def apply_two_qubit_gate(state: MPS, node: DAGOpNode, sim_params: StrongSimParam
     if gate_mode == "tdvp":
         if is_nearest_neighbor:
             return apply_two_qubit_gate_tebd(state, gate, sim_params)
-        return apply_two_qubit_gate_tdvp(state, gate, sim_params)
+        if has_generator:
+            return apply_two_qubit_gate_tdvp(state, gate, sim_params)
+        return apply_long_range_gate_mpo(state, gate, sim_params)
 
     if gate_mode == "mpo":
         if is_nearest_neighbor:

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -102,7 +102,7 @@ def process_layer(dag: DAGCircuit) -> tuple[list[DAGOpNode], list[DAGOpNode], li
     for node in current_layer:
         name = node.op.name
 
-        # Drop measurements completely.
+        # Drop measurements during simulation; they are rejected by DAG-to-gate conversion.
         if name == "measure":
             dag.remove_op_node(node)
             continue
@@ -373,6 +373,8 @@ def apply_two_qubit_gate(state: MPS, node: DAGOpNode, sim_params: StrongSimParam
     site0, site1 = gate.sites[0], gate.sites[1]
     is_nearest_neighbor = abs(site0 - site1) == 1
     gate_mode: GateMode = getattr(sim_params, "gate_mode", "mpo")
+    # Matrix-backed custom gates have no ``generator`` and bypass the TDVP window
+    # path in ``tdvp`` / ``full-tdvp`` modes (TEBD for NN, MPO for LR).
     has_generator = getattr(gate, "generator", None) is not None
 
     if gate_mode == "full-tdvp":

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -71,7 +71,18 @@ def create_local_noise_model(noise_model: NoiseModel, first_site: int, last_site
 
 
 def _is_terminal_measure(dag: DAGCircuit, node: DAGOpNode) -> bool:
-    """Return whether no later op nodes act on qubits measured by ``node``."""
+    """Return whether a measure node has no later gates on its qubits.
+
+    A measurement is terminal when no subsequent DAG operation acts on any qubit
+    that the measurement targets.
+
+    Args:
+        dag: Circuit DAG containing ``node``.
+        node: Measure operation node to classify.
+
+    Returns:
+        True if no later op nodes share qubits with ``node``; False otherwise.
+    """
     measured = {dag.find_bit(q).index for q in node.qargs}
     topo = list(dag.topological_op_nodes())
     try:

--- a/src/mqt/yaqs/digital/utils/dag_utils.py
+++ b/src/mqt/yaqs/digital/utils/dag_utils.py
@@ -40,7 +40,10 @@ if TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit
 
 # ``barrier`` is ignored during DAG-to-gate conversion. ``measure`` is rejected
-# here; circuit simulation drops measurements separately in ``process_layer``.
+# here because conversion builds a unitary gate list; mid-circuit measurements are
+# not representable in that form. Circuit simulation (`process_layer` in
+# ``digital_tjm``) still drops ``measure`` nodes from the live DAG before gate
+# application so terminal measurements in a Qiskit circuit do not block simulation.
 _SKIP_INSTRUCTIONS = frozenset({"barrier"})
 _ZONE_SKIP_INSTRUCTIONS = frozenset({"measure", "barrier"})
 _REJECTED_INSTRUCTIONS = frozenset({"reset", "delay", "store", "measure"})
@@ -269,6 +272,14 @@ def convert_dag_to_tensor_algorithm(dag: DAGCircuit) -> list[BaseGate]:
     parameters if present, and assigns the qubit indices (sites) on which the gate acts.
 
     Unknown one- and two-qubit unitary Qiskit gates are converted from their matrix representation.
+    Three-qubit and larger instructions (including Toffoli/CCX) raise ``ValueError``. ``barrier`` nodes
+    are skipped. ``measure``, ``reset``, ``delay``, classically controlled ops, and control-flow
+    instructions are rejected. See :data:`SUPPORTED_QISKIT_GATE_NAMES` for hardcoded gate names.
+
+    Note:
+        This conversion path rejects ``measure`` because it builds a unitary gate list. Circuit
+        simulation removes ``measure`` nodes from the live DAG separately (see ``process_layer`` in
+        ``digital_tjm``) so terminal Qiskit measurements do not block evolution.
 
     Args:
         dag: The DAGCircuit (or a single DAGOpNode) representing a quantum operation.

--- a/src/mqt/yaqs/digital/utils/dag_utils.py
+++ b/src/mqt/yaqs/digital/utils/dag_utils.py
@@ -257,6 +257,9 @@ def _translate_node(dag: DAGCircuit | None, node: DAGOpNode) -> BaseGate:
         msg = f"Cannot translate Qiskit instruction '{name}': {num_qubits}-qubit gates are not supported yet."
         raise ValueError(msg)
 
+    if name not in SUPPORTED_QISKIT_GATE_NAMES:
+        return _translate_matrix(node.op, name=name, sites=sites)
+
     try:
         gate_cls = getattr(GateLibrary, name)
     except AttributeError:

--- a/src/mqt/yaqs/digital/utils/dag_utils.py
+++ b/src/mqt/yaqs/digital/utils/dag_utils.py
@@ -15,8 +15,10 @@ using their DAG representations. It provides utilities to:
 - Determine the maximum distance (in terms of qubit indices) of multi-qubit gates.
 - Select starting points for gate application based on a checkerboard pattern.
 
-These functions facilitate the manipulation and analysis of quantum circuit
-representations.
+Qiskit instructions whose ``op.name`` matches one of the 28 entries in
+:data:`SUPPORTED_QISKIT_GATE_NAMES` are translated via hardcoded ``GateLibrary``
+classes. All other one- and two-qubit unitary gates fall back to matrix-backed
+:class:`~mqt.yaqs.core.libraries.gate_library.BaseGate` instances.
 """
 
 from __future__ import annotations
@@ -37,8 +39,42 @@ if TYPE_CHECKING:
     from qiskit.circuit import Qubit
     from qiskit.dagcircuit import DAGCircuit
 
-_SKIP_INSTRUCTIONS = frozenset({"measure", "barrier"})
-_REJECTED_INSTRUCTIONS = frozenset({"reset", "delay", "store"})
+# ``barrier`` is ignored during DAG-to-gate conversion. ``measure`` is rejected
+# here; circuit simulation drops measurements separately in ``process_layer``.
+_SKIP_INSTRUCTIONS = frozenset({"barrier"})
+_ZONE_SKIP_INSTRUCTIONS = frozenset({"measure", "barrier"})
+_REJECTED_INSTRUCTIONS = frozenset({"reset", "delay", "store", "measure"})
+# Qiskit ``op.name`` values resolved through ``getattr(GateLibrary, name)``.
+SUPPORTED_QISKIT_GATE_NAMES: tuple[str, ...] = (
+    "cp",
+    "cx",
+    "cz",
+    "h",
+    "i",
+    "id",
+    "iden",
+    "p",
+    "rx",
+    "ry",
+    "rz",
+    "rxx",
+    "ryy",
+    "rzz",
+    "s",
+    "sdg",
+    "swap",
+    "sx",
+    "sxdg",
+    "t",
+    "tdg",
+    "u",
+    "u1",
+    "u2",
+    "u3",
+    "x",
+    "y",
+    "z",
+)
 _CONTROL_FLOW_INSTRUCTIONS = frozenset({
     "for_loop",
     "while_loop",
@@ -138,7 +174,13 @@ def _reject_unsupported(node: DAGOpNode) -> None:
     """
     name = node.op.name
     if name in _REJECTED_INSTRUCTIONS:
-        msg = f"Cannot translate Qiskit instruction '{name}': {name} is not supported in YAQS circuit simulation."
+        if name == "measure":
+            msg = (
+                f"Cannot translate Qiskit instruction '{name}': mid-circuit measurements are not supported; "
+                "remove measure instructions before conversion."
+            )
+        else:
+            msg = f"Cannot translate Qiskit instruction '{name}': {name} is not supported in YAQS circuit simulation."
         raise ValueError(msg)
     if name in _CONTROL_FLOW_INSTRUCTIONS:
         msg = f"Cannot translate Qiskit instruction '{name}': control-flow operations are not supported."
@@ -297,14 +339,14 @@ def _build_temporal_zone(dag: DAGCircuit, qubits: list[int]) -> DAGCircuit:
 
                 # If the gate acts entirely within the current cone of qubits.
                 if qubit_set <= qubits_to_check:
-                    if node.op.name in _SKIP_INSTRUCTIONS:
+                    if node.op.name in _ZONE_SKIP_INSTRUCTIONS:
                         dag.remove_op_node(node)
                         continue
                     new_dag.apply_operation_back(node.op, node.qargs)
                     dag.remove_op_node(node)
                 else:
                     # For partial overlap, remove the overlapping qubits from the cone.
-                    if node.op.name in _SKIP_INSTRUCTIONS:
+                    if node.op.name in _ZONE_SKIP_INSTRUCTIONS:
                         dag.remove_op_node(node)
                         continue
                     for item in qubit_set & qubits_to_check:

--- a/src/mqt/yaqs/digital/utils/dag_utils.py
+++ b/src/mqt/yaqs/digital/utils/dag_utils.py
@@ -23,16 +23,200 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+from qiskit.circuit import Operation, Parameter, ParameterExpression
 from qiskit.converters import dag_to_circuit
 from qiskit.dagcircuit import DAGOpNode
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info import Operator
 
-from ...core.libraries.gate_library import GateLibrary
+from ...core.libraries.gate_library import BaseGate, GateLibrary
 
 if TYPE_CHECKING:
+    from numpy.typing import NDArray
     from qiskit.circuit import Qubit
     from qiskit.dagcircuit import DAGCircuit
 
-    from ...core.libraries.gate_library import BaseGate
+_SKIP_INSTRUCTIONS = frozenset({"measure", "barrier"})
+_REJECTED_INSTRUCTIONS = frozenset({"reset", "delay", "store"})
+_CONTROL_FLOW_INSTRUCTIONS = frozenset({
+    "for_loop",
+    "while_loop",
+    "if_else",
+    "switch_case",
+    "break_loop",
+    "continue_loop",
+})
+
+
+def _convert_matrix_layout(matrix: NDArray[np.complex128]) -> NDArray[np.complex128]:
+    """Convert a Qiskit two-qubit unitary matrix into YAQS gate storage order.
+
+    Args:
+        matrix: Dense ``4 x 4`` unitary in Qiskit little-endian ordering.
+
+    Returns:
+        Matrix that reshapes to the YAQS two-qubit gate tensor convention.
+    """
+    tensor = np.reshape(matrix, (2, 2, 2, 2)).transpose(1, 0, 3, 2)
+    return np.asarray(tensor.reshape(4, 4), dtype=np.complex128)
+
+
+def _get_qubit_indices(dag: DAGCircuit | None, node: DAGOpNode) -> list[int]:
+    """Return MPS site indices for a DAG operation node.
+
+    Args:
+        dag: Parent DAG when available; used for ``find_bit`` lookup.
+        node: DAG operation node.
+
+    Returns:
+        Qubit indices in circuit order.
+    """
+    indices: list[int] = []
+    for qubit in node.qargs:
+        if dag is not None:
+            indices.append(dag.find_bit(qubit).index)
+        else:
+            indices.append(qubit._index)  # noqa: SLF001
+    return indices
+
+
+def _has_unbound_params(op: object) -> bool:
+    """Return whether a Qiskit operation still has free symbolic parameters."""
+    params = getattr(op, "params", ())
+    return any(
+        isinstance(param, Parameter) or (isinstance(param, ParameterExpression) and bool(param.parameters))
+        for param in params
+    )
+
+
+def _is_unitary(matrix: NDArray[np.complex128], *, atol: float = 1e-10) -> bool:
+    """Return whether ``matrix`` is unitary within tolerance."""
+    dim = matrix.shape[0]
+    product = matrix @ matrix.conj().T
+    return bool(np.allclose(product, np.eye(dim, dtype=np.complex128), atol=atol))
+
+
+def _extract_matrix(op: Operation, *, name: str) -> NDArray[np.complex128]:
+    """Extract a unitary matrix from a Qiskit operation.
+
+    Args:
+        op: Qiskit instruction or gate.
+        name: Operation name for error reporting.
+
+    Returns:
+        Complex unitary matrix.
+
+    Raises:
+        ValueError: If no matrix representation is available.
+    """
+    to_matrix = getattr(op, "to_matrix", None)
+    if callable(to_matrix):
+        try:
+            matrix = to_matrix()
+        except (TypeError, QiskitError) as exc:
+            msg = f"Cannot translate Qiskit instruction '{name}': failed to build a matrix representation."
+            raise ValueError(msg) from exc
+        if matrix is not None:
+            return np.asarray(matrix, dtype=np.complex128)
+
+    try:
+        return np.asarray(Operator(op).data, dtype=np.complex128)
+    except (TypeError, QiskitError, ValueError) as exc:
+        msg = f"Cannot translate Qiskit instruction '{name}': no matrix representation available."
+        raise ValueError(msg) from exc
+
+
+def _reject_unsupported(node: DAGOpNode) -> None:
+    """Raise for Qiskit instructions that YAQS cannot translate.
+
+    Args:
+        node: DAG operation node.
+
+    Raises:
+        ValueError: If the instruction is unsupported.
+    """
+    name = node.op.name
+    if name in _REJECTED_INSTRUCTIONS:
+        msg = f"Cannot translate Qiskit instruction '{name}': {name} is not supported in YAQS circuit simulation."
+        raise ValueError(msg)
+    if name in _CONTROL_FLOW_INSTRUCTIONS:
+        msg = f"Cannot translate Qiskit instruction '{name}': control-flow operations are not supported."
+        raise ValueError(msg)
+    if getattr(node.op, "condition", None) is not None:
+        msg = f"Cannot translate Qiskit instruction '{name}': conditional operations are not supported."
+        raise ValueError(msg)
+    if node.cargs:
+        msg = f"Cannot translate Qiskit instruction '{name}': classically controlled operations are not supported."
+        raise ValueError(msg)
+
+
+def _translate_matrix(op: Operation, *, name: str, sites: list[int]) -> BaseGate:
+    """Build a YAQS gate from a Qiskit operation matrix.
+
+    Args:
+        op: Qiskit instruction or gate.
+        name: Qiskit operation name to store on the YAQS gate.
+        sites: Target qubit indices.
+
+    Returns:
+        Matrix-backed YAQS gate without an analytic generator.
+
+    Raises:
+        ValueError: If parameters are unbound or the operator is not unitary.
+    """
+    if _has_unbound_params(op):
+        msg = f"Cannot translate Qiskit gate '{name}': unbound parameters; bind parameters before simulation."
+        raise ValueError(msg)
+
+    matrix = _extract_matrix(op, name=name)
+    if not _is_unitary(matrix):
+        msg = f"Cannot translate Qiskit gate '{name}': operator is not unitary."
+        raise ValueError(msg)
+
+    if len(sites) == 2:
+        matrix = _convert_matrix_layout(matrix)
+
+    gate = GateLibrary.custom(matrix)
+    gate.name = name
+    gate.set_sites(*sites)
+    return gate
+
+
+def _translate_node(dag: DAGCircuit | None, node: DAGOpNode) -> BaseGate:
+    """Convert a single DAG operation node into a YAQS gate.
+
+    Args:
+        dag: Parent DAG when available.
+        node: DAG operation node.
+
+    Returns:
+        Initialized YAQS gate with sites assigned.
+
+    Raises:
+        ValueError: If the instruction cannot be translated.
+    """
+    name = node.op.name
+    _reject_unsupported(node)
+
+    if _has_unbound_params(node.op):
+        msg = f"Cannot translate Qiskit gate '{name}': unbound parameters; bind parameters before simulation."
+        raise ValueError(msg)
+
+    sites = _get_qubit_indices(dag, node)
+    num_qubits = len(sites)
+    if num_qubits > 2:
+        msg = f"Cannot translate Qiskit instruction '{name}': {num_qubits}-qubit gates are not supported yet."
+        raise ValueError(msg)
+
+    try:
+        gate_cls = getattr(GateLibrary, name)
+    except AttributeError:
+        return _translate_matrix(node.op, name=name, sites=sites)
+
+    gate_object = gate_cls(node.op.params) if node.op.params else gate_cls()
+    gate_object.set_sites(*sites)
+    return gate_object
 
 
 def convert_dag_to_tensor_algorithm(dag: DAGCircuit) -> list[BaseGate]:
@@ -42,51 +226,25 @@ def convert_dag_to_tensor_algorithm(dag: DAGCircuit) -> list[BaseGate]:
     For each node, it retrieves the corresponding gate class from the GateLibrary, initializes it, sets any
     parameters if present, and assigns the qubit indices (sites) on which the gate acts.
 
+    Unknown one- and two-qubit unitary Qiskit gates are converted from their matrix representation.
+
     Args:
         dag: The DAGCircuit (or a single DAGOpNode) representing a quantum operation.
 
     Returns:
         A list of gate objects, each with attributes such as .tensor and .sites.
     """
-    algorithm = []
+    algorithm: list[BaseGate] = []
 
     if isinstance(dag, DAGOpNode):
-        # Single node DAG.
-        gate = dag
-        name = gate.op.name
-
-        attr = getattr(GateLibrary, name)
-
-        gate_object = attr(gate.op.params) if gate.op.params else attr()
-
-        sites = [gate.qargs[0]._index]  # noqa: SLF001
-        if len(gate.qargs) == 2:
-            sites.append(gate.qargs[1]._index)  # noqa: SLF001
-        if len(gate.qargs) == 3:
-            sites.extend((gate.qargs[1]._index, gate.qargs[2]._index))  # noqa: SLF001
-
-        gate_object.set_sites(*sites)
-        algorithm.append(gate_object)
+        algorithm.append(_translate_node(None, dag))
     else:
-        # Multi-node DAG.
+        parent_dag = dag
         for gate in dag.op_nodes():
             name = gate.op.name
-            if name in {"measure", "barrier"}:
+            if name in _SKIP_INSTRUCTIONS:
                 continue
-
-            attr = getattr(GateLibrary, name)
-
-            gate_object = attr(gate.op.params) if gate.op.params else attr()
-
-            sites = [gate.qargs[0]._index]  # noqa: SLF001
-            if len(gate.qargs) == 2:
-                sites.append(gate.qargs[1]._index)  # noqa: SLF001
-            if len(gate.qargs) == 3:
-                sites.append(gate.qargs[1]._index)  # noqa: SLF001
-                sites.append(gate.qargs[2]._index)  # noqa: SLF001
-
-            gate_object.set_sites(*sites)
-            algorithm.append(gate_object)
+            algorithm.append(_translate_node(parent_dag, gate))
 
     return algorithm
 
@@ -139,14 +297,14 @@ def _build_temporal_zone(dag: DAGCircuit, qubits: list[int]) -> DAGCircuit:
 
                 # If the gate acts entirely within the current cone of qubits.
                 if qubit_set <= qubits_to_check:
-                    if node.op.name in {"measure", "barrier"}:
+                    if node.op.name in _SKIP_INSTRUCTIONS:
                         dag.remove_op_node(node)
                         continue
                     new_dag.apply_operation_back(node.op, node.qargs)
                     dag.remove_op_node(node)
                 else:
                     # For partial overlap, remove the overlapping qubits from the cone.
-                    if node.op.name in {"measure", "barrier"}:
+                    if node.op.name in _SKIP_INSTRUCTIONS:
                         dag.remove_op_node(node)
                         continue
                     for item in qubit_set & qubits_to_check:

--- a/src/mqt/yaqs/digital/utils/dag_utils.py
+++ b/src/mqt/yaqs/digital/utils/dag_utils.py
@@ -154,8 +154,11 @@ def _extract_matrix(op: Operation, *, name: str) -> NDArray[np.complex128]:
         try:
             matrix = to_matrix()
         except (TypeError, QiskitError) as exc:
-            msg = f"Cannot translate Qiskit instruction '{name}': failed to build a matrix representation."
-            raise ValueError(msg) from exc
+            try:
+                return np.asarray(Operator(op).data, dtype=np.complex128)
+            except (TypeError, QiskitError, ValueError):
+                msg = f"Cannot translate Qiskit instruction '{name}': failed to build a matrix representation."
+                raise ValueError(msg) from exc
         if matrix is not None:
             return np.asarray(matrix, dtype=np.complex128)
 

--- a/src/mqt/yaqs/digital/utils/dag_utils.py
+++ b/src/mqt/yaqs/digital/utils/dag_utils.py
@@ -121,7 +121,15 @@ def _get_qubit_indices(dag: DAGCircuit | None, node: DAGOpNode) -> list[int]:
 
 
 def _has_unbound_params(op: object) -> bool:
-    """Return whether a Qiskit operation still has free symbolic parameters."""
+    """Return whether a Qiskit operation still has free symbolic parameters.
+
+    Args:
+        op: Qiskit instruction or gate.
+
+    Returns:
+        True if any entry in ``op.params`` is an unbound ``Parameter`` or
+        ``ParameterExpression`` with remaining free symbols.
+    """
     params = getattr(op, "params", ())
     return any(
         isinstance(param, Parameter) or (isinstance(param, ParameterExpression) and bool(param.parameters))
@@ -130,7 +138,15 @@ def _has_unbound_params(op: object) -> bool:
 
 
 def _is_unitary(matrix: NDArray[np.complex128], *, atol: float = 1e-10) -> bool:
-    """Return whether ``matrix`` is unitary within tolerance."""
+    """Return whether ``matrix`` is unitary within tolerance.
+
+    Args:
+        matrix: Square complex operator matrix.
+        atol: Absolute tolerance for ``matrix @ matrix.conj().T ≈ I``.
+
+    Returns:
+        True if the matrix is unitary within ``atol``.
+    """
     dim = matrix.shape[0]
     product = matrix @ matrix.conj().T
     return bool(np.allclose(product, np.eye(dim, dtype=np.complex128), atol=atol))

--- a/src/mqt/yaqs/digital/utils/matrix_utils.py
+++ b/src/mqt/yaqs/digital/utils/matrix_utils.py
@@ -37,7 +37,7 @@ _EINSUM_LETTERS = string.ascii_lowercase
 _GATE_EINSUM_LETTERS = string.ascii_uppercase
 
 
-def _circuit_without_measurements(circuit: QuantumCircuit) -> QuantumCircuit:
+def strip_final_measurements(circuit: QuantumCircuit) -> QuantumCircuit:
     """Return a copy of ``circuit`` with final measurements removed.
 
     Args:
@@ -53,12 +53,12 @@ def _circuit_without_measurements(circuit: QuantumCircuit) -> QuantumCircuit:
     qc.remove_final_measurements(inplace=True)
     dag = circuit_to_dag(qc)
     if any(isinstance(node, DAGOpNode) and node.op.name == "measure" for node in dag.op_nodes()):
-        msg = "Mid-circuit measurements are not supported by the matrix equivalence backend."
+        msg = "Mid-circuit measurements are not supported by the equivalence checker."
         raise ValueError(msg)
     return qc
 
 
-def _identity_operator_tensor(num_qubits: int) -> NDArray[np.complex128]:
+def make_identity_tensor(num_qubits: int) -> NDArray[np.complex128]:
     """Return the identity operator as a tensor with ``2 * num_qubits`` indices of size 2.
 
     Args:
@@ -71,7 +71,7 @@ def _identity_operator_tensor(num_qubits: int) -> NDArray[np.complex128]:
     return np.eye(dim, dtype=np.complex128).reshape((2,) * (2 * num_qubits))
 
 
-def _embed_unitary(local: NDArray[np.complex128], sites: list[int], num_qubits: int) -> NDArray[np.complex128]:
+def embed_unitary(local: NDArray[np.complex128], sites: list[int], num_qubits: int) -> NDArray[np.complex128]:
     """Embed a k-qubit unitary on the given sites (Qiskit little-endian ordering).
 
     Args:
@@ -90,7 +90,7 @@ def _embed_unitary(local: NDArray[np.complex128], sites: list[int], num_qubits: 
     return Operator(qc).data
 
 
-def _apply_single_qubit_left(
+def apply_1q_left(
     op: NDArray[np.complex128],
     matrix: NDArray[np.complex128],
     qubit: int,
@@ -113,7 +113,7 @@ def _apply_single_qubit_left(
     gate = matrix.conj().T if dagger else matrix
     if num_qubits > len(_EINSUM_LETTERS) // 2:
         op_mat = op.reshape(2**num_qubits, 2**num_qubits)
-        full = _embed_unitary(gate, [qubit], num_qubits)
+        full = embed_unitary(gate, [qubit], num_qubits)
         return (full @ op_mat).reshape((2,) * (2 * num_qubits))
 
     out_labels = list(_EINSUM_LETTERS[:num_qubits])
@@ -127,7 +127,7 @@ def _apply_single_qubit_left(
     return np.einsum(eq, gate, op, optimize=True)
 
 
-def _apply_two_qubit_left(
+def apply_2q_left(
     op: NDArray[np.complex128],
     gate_tensor: NDArray[np.complex128],
     site0: int,
@@ -150,7 +150,7 @@ def _apply_two_qubit_left(
         The updated operator tensor.
     """
     if site0 > site1:
-        return _apply_two_qubit_left(
+        return apply_2q_left(
             op,
             np.transpose(gate_tensor, (1, 0, 3, 2)),
             site1,
@@ -166,7 +166,7 @@ def _apply_two_qubit_left(
     if num_qubits > len(_EINSUM_LETTERS) // 2:
         op_mat = op.reshape(2**num_qubits, 2**num_qubits)
         local = np.transpose(gate, (0, 2, 1, 3)).reshape(4, 4)
-        full = _embed_unitary(local, [site0, site1], num_qubits)
+        full = embed_unitary(local, [site0, site1], num_qubits)
         return (full @ op_mat).reshape((2,) * (2 * num_qubits))
 
     out_labels = list(_EINSUM_LETTERS[:num_qubits])
@@ -182,7 +182,7 @@ def _apply_two_qubit_left(
     return np.einsum(eq, gate, op, optimize=True)
 
 
-def _apply_gate_left(
+def apply_gate_left(
     op: NDArray[np.complex128],
     gate: BaseGate,
     num_qubits: int,
@@ -201,19 +201,19 @@ def _apply_gate_left(
         The updated operator tensor.
     """
     if gate.interaction == 1:
-        return _apply_single_qubit_left(op, gate.matrix, gate.sites[0], num_qubits, dagger=dagger)
+        return apply_1q_left(op, gate.matrix, gate.sites[0], num_qubits, dagger=dagger)
     if gate.interaction == 2:
-        return _apply_two_qubit_left(op, gate.tensor, gate.sites[0], gate.sites[1], num_qubits, dagger=dagger)
+        return apply_2q_left(op, gate.tensor, gate.sites[0], gate.sites[1], num_qubits, dagger=dagger)
 
     local = gate.matrix
     if dagger:
         local = local.conj().T
     op_mat = op.reshape(2**num_qubits, 2**num_qubits)
-    full = _embed_unitary(local, gate.sites, num_qubits)
+    full = embed_unitary(local, gate.sites, num_qubits)
     return (full @ op_mat).reshape((2,) * (2 * num_qubits))
 
 
-def _pop_front_layer_gates(dag: DAGCircuit) -> list[BaseGate]:
+def pop_front_gates(dag: DAGCircuit) -> list[BaseGate]:
     """Remove and return gates from the current DAG front layer.
 
     Args:
@@ -234,7 +234,7 @@ def _pop_front_layer_gates(dag: DAGCircuit) -> list[BaseGate]:
     return gates
 
 
-def _apply_gate_batch(
+def apply_gate_batch(
     op: NDArray[np.complex128],
     gates: list[BaseGate],
     num_qubits: int,
@@ -253,11 +253,11 @@ def _apply_gate_batch(
         The operator tensor after applying all gates in the batch.
     """
     for gate in sorted(gates, key=lambda g: min(g.sites)):
-        op = _apply_gate_left(op, gate, num_qubits, dagger=dagger)
+        op = apply_gate_left(op, gate, num_qubits, dagger=dagger)
     return op
 
 
-def _apply_layer_gates(
+def apply_layer(
     op: NDArray[np.complex128],
     layer_gates: list[BaseGate],
     num_qubits: int,
@@ -276,11 +276,11 @@ def _apply_layer_gates(
         The operator tensor after applying the full layer.
     """
     for batch in partition_disjoint_gate_batches(layer_gates):
-        op = _apply_gate_batch(op, batch, num_qubits, dagger=dagger)
+        op = apply_gate_batch(op, batch, num_qubits, dagger=dagger)
     return op
 
 
-def _collect_layer_groups(dag: DAGCircuit) -> list[list[BaseGate]]:
+def collect_layers(dag: DAGCircuit) -> list[list[BaseGate]]:
     """Consume ``dag`` layer by layer and return gate lists per layer.
 
     Args:
@@ -291,13 +291,13 @@ def _collect_layer_groups(dag: DAGCircuit) -> list[list[BaseGate]]:
     """
     layers: list[list[BaseGate]] = []
     while dag.op_nodes():
-        layer_gates = _pop_front_layer_gates(dag)
+        layer_gates = pop_front_gates(dag)
         if layer_gates:
             layers.append(layer_gates)
     return layers
 
 
-def build_composed_operator_tensor(
+def compose_operator_tensor(
     circuit1: QuantumCircuit,
     circuit2: QuantumCircuit,
 ) -> NDArray[np.complex128]:
@@ -320,22 +320,22 @@ def build_composed_operator_tensor(
         msg = "Circuits must have the same number of qubits."
         raise ValueError(msg)
     num_qubits = circuit1.num_qubits
-    op = _identity_operator_tensor(num_qubits)
+    op = make_identity_tensor(num_qubits)
 
-    dag1 = circuit_to_dag(_circuit_without_measurements(circuit1))
-    dag2 = circuit_to_dag(_circuit_without_measurements(circuit2))
+    dag1 = circuit_to_dag(strip_final_measurements(circuit1))
+    dag2 = circuit_to_dag(strip_final_measurements(circuit2))
 
-    for layer_gates in _collect_layer_groups(dag1):
-        op = _apply_layer_gates(op, layer_gates, num_qubits, dagger=False)
+    for layer_gates in collect_layers(dag1):
+        op = apply_layer(op, layer_gates, num_qubits, dagger=False)
 
-    layers2 = _collect_layer_groups(dag2)
+    layers2 = collect_layers(dag2)
     for layer_gates in reversed(layers2):
-        op = _apply_layer_gates(op, layer_gates, num_qubits, dagger=True)
+        op = apply_layer(op, layer_gates, num_qubits, dagger=True)
 
     return op
 
 
-def check_operator_is_identity(
+def is_identity_tensor(
     operator_tensor: NDArray[np.complex128],
     fidelity: float,
 ) -> bool:
@@ -359,7 +359,7 @@ def check_operator_is_identity(
     return normalized >= fidelity
 
 
-def check_equivalence_matrix(
+def check_matrix_equivalence(
     circuit1: QuantumCircuit,
     circuit2: QuantumCircuit,
     *,
@@ -375,5 +375,5 @@ def check_equivalence_matrix(
     Returns:
         Whether the circuits are equivalent within ``fidelity``.
     """
-    composed = build_composed_operator_tensor(circuit1, circuit2)
-    return check_operator_is_identity(composed, fidelity)
+    composed = compose_operator_tensor(circuit1, circuit2)
+    return is_identity_tensor(composed, fidelity)

--- a/src/mqt/yaqs/equivalence_checker.py
+++ b/src/mqt/yaqs/equivalence_checker.py
@@ -23,7 +23,7 @@ from qiskit.converters import circuit_to_dag
 
 from .core.data_structures.mpo import MPO
 from .digital.utils.contraction_utils import iterate
-from .digital.utils.matrix_utils import check_equivalence_matrix
+from .digital.utils.matrix_utils import check_matrix_equivalence, strip_final_measurements
 
 if TYPE_CHECKING:
     from qiskit.circuit import QuantumCircuit
@@ -184,17 +184,20 @@ class EquivalenceChecker:
             and ``representation`` (``"matrix"`` or ``"mpo"``) indicating the backend used.
 
         Raises:
-            ValueError: If the circuits have different numbers of qubits.
+            ValueError: If the circuits have different numbers of qubits or contain mid-circuit measurements.
         """
         if circuit1.num_qubits != circuit2.num_qubits:
             msg = "Circuits must have the same number of qubits."
             raise ValueError(msg)
 
+        circuit1 = strip_final_measurements(circuit1)
+        circuit2 = strip_final_measurements(circuit2)
+
         backend = self._resolve_representation(circuit1.num_qubits)
         start_time = time.time()
 
         if backend == "matrix":
-            equivalent = check_equivalence_matrix(
+            equivalent = check_matrix_equivalence(
                 circuit1,
                 circuit2,
                 fidelity=self.fidelity,

--- a/src/mqt/yaqs/equivalence_checker.py
+++ b/src/mqt/yaqs/equivalence_checker.py
@@ -190,9 +190,6 @@ class EquivalenceChecker:
             msg = "Circuits must have the same number of qubits."
             raise ValueError(msg)
 
-        circuit1 = strip_final_measurements(circuit1)
-        circuit2 = strip_final_measurements(circuit2)
-
         backend = self._resolve_representation(circuit1.num_qubits)
         start_time = time.time()
 
@@ -203,6 +200,8 @@ class EquivalenceChecker:
                 fidelity=self.fidelity,
             )
         else:
+            circuit1 = strip_final_measurements(circuit1)
+            circuit2 = strip_final_measurements(circuit2)
             mpo = MPO.identity(circuit1.num_qubits)
             circuit1_dag = circuit_to_dag(circuit1)
             circuit2_dag = circuit_to_dag(circuit2)

--- a/tests/core/data_structures/test_mpo_utils.py
+++ b/tests/core/data_structures/test_mpo_utils.py
@@ -22,27 +22,27 @@ from mqt.yaqs.core.data_structures.mpo_utils import (
     gate_support_mpo_tensors,
     gate_tensor_lr_order,
     identity_mpo_site,
+    two_qubit_matrix_to_mps_tensor,
 )
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary, extend_gate
 
 
 def test_gate_tensor_lr_order_swaps_sites() -> None:
-    """Gate tensor axes follow ascending MPS site order."""
+    """Reversed nearest-neighbor qargs use the matrix MPS map, not a tensor transpose."""
     gate = GateLibrary.cx()
-    gate.set_sites(2, 0)
-    ordered = gate_tensor_lr_order(gate)
-    gate.set_sites(0, 2)
-    direct = gate_tensor_lr_order(gate)
-    np.testing.assert_allclose(ordered, direct)
+    gate.set_sites(1, 0)
+    reversed_tensor = gate_tensor_lr_order(gate)
+    expected = two_qubit_matrix_to_mps_tensor(gate.matrix)
+    np.testing.assert_allclose(reversed_tensor, expected)
 
 
 def test_gate_tensor_lr_order_explicit_sites() -> None:
-    """Explicit left/right sites select the transpose branch."""
+    """Explicit left/right sites select the reversed-qarg branch on long-range pairs."""
     gate = GateLibrary.cx()
     gate.set_sites(3, 1)
     tensor = gate_tensor_lr_order(gate, left_site=1, right_site=3)
-    gate.set_sites(1, 3)
-    np.testing.assert_allclose(tensor, gate.tensor)
+    expected = two_qubit_matrix_to_mps_tensor(gate.matrix)
+    np.testing.assert_allclose(tensor, expected)
 
 
 def test_gate_tensor_lr_order_inconsistent_sites_raises() -> None:

--- a/tests/core/data_structures/test_mpo_utils.py
+++ b/tests/core/data_structures/test_mpo_utils.py
@@ -18,76 +18,76 @@ from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.mpo_utils import (
     contract_mpo_site_with_mpo_site,
     contract_mpo_site_with_mps_site,
+    convert_nn_matrix,
     decompose_theta,
-    gate_support_mpo_tensors,
-    gate_tensor_lr_order,
-    identity_mpo_site,
-    two_qubit_matrix_to_mps_tensor,
+    get_support_mpo,
+    make_identity_site,
+    resolve_lr_tensor,
 )
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary, extend_gate
 
 
-def test_gate_tensor_lr_order_swaps_sites() -> None:
+def test_resolve_lr_tensor_swaps_sites() -> None:
     """Reversed nearest-neighbor qargs use the matrix MPS map, not a tensor transpose."""
     gate = GateLibrary.cx()
     gate.set_sites(1, 0)
-    reversed_tensor = gate_tensor_lr_order(gate)
-    expected = two_qubit_matrix_to_mps_tensor(gate.matrix)
+    reversed_tensor = resolve_lr_tensor(gate)
+    expected = convert_nn_matrix(gate.matrix)
     np.testing.assert_allclose(reversed_tensor, expected)
 
 
-def test_gate_tensor_lr_order_explicit_sites() -> None:
+def test_resolve_lr_tensor_explicit_sites() -> None:
     """Explicit left/right sites select the reversed-qarg branch on long-range pairs."""
     gate = GateLibrary.cx()
     gate.set_sites(3, 1)
-    tensor = gate_tensor_lr_order(gate, left_site=1, right_site=3)
-    expected = two_qubit_matrix_to_mps_tensor(gate.matrix)
+    tensor = resolve_lr_tensor(gate, left_site=1, right_site=3)
+    expected = convert_nn_matrix(gate.matrix)
     np.testing.assert_allclose(tensor, expected)
 
 
-def test_gate_tensor_lr_order_inconsistent_sites_raises() -> None:
+def test_resolve_lr_tensor_inconsistent_sites_raises() -> None:
     """Mismatched site indices raise ValueError."""
     gate = GateLibrary.cx()
     gate.set_sites(0, 2)
     with pytest.raises(ValueError, match="not consistent"):
-        gate_tensor_lr_order(gate, left_site=0, right_site=3)
+        resolve_lr_tensor(gate, left_site=0, right_site=3)
 
 
-def test_identity_mpo_site_shape() -> None:
+def test_make_identity_site_shape() -> None:
     """Identity MPO site has bond dimension one."""
-    site = identity_mpo_site(2)
+    site = make_identity_site(2)
     assert site.shape == (2, 2, 1, 1)
     np.testing.assert_allclose(site[:, :, 0, 0], np.eye(2))
 
 
-def test_gate_support_mpo_tensors_uses_cached_mpo_tensors() -> None:
+def test_get_support_mpo_uses_cached_mpo_tensors() -> None:
     """Cached gate MPO tensors are returned when the support length matches."""
     gate = GateLibrary.cx()
     gate.set_sites(1, 3)
-    first = gate_support_mpo_tensors(gate, first_site=1, last_site=3)
-    second = gate_support_mpo_tensors(gate, first_site=1, last_site=3)
+    first = get_support_mpo(gate, first_site=1, last_site=3)
+    second = get_support_mpo(gate, first_site=1, last_site=3)
     assert len(first) == len(second) == 3
     np.testing.assert_allclose(first[0], second[0])
 
 
-def test_gate_support_mpo_tensors_reextends_when_cache_length_mismatches() -> None:
+def test_get_support_mpo_reextends_when_cache_length_mismatches() -> None:
     """A cached tensor list with the wrong length triggers ``extend_gate``."""
     gate = GateLibrary.cx()
     gate.set_sites(0, 1)
-    nn_support = gate_support_mpo_tensors(gate, first_site=0, last_site=1)
+    nn_support = get_support_mpo(gate, first_site=0, last_site=1)
     assert len(nn_support) == 2
-    wide = gate_support_mpo_tensors(gate, first_site=0, last_site=2)
+    wide = get_support_mpo(gate, first_site=0, last_site=2)
     assert len(wide) == 3
 
 
-def test_gate_support_mpo_tensors_calls_extend_gate_without_cache() -> None:
+def test_get_support_mpo_calls_extend_gate_without_cache() -> None:
     """Gates without ``mpo_tensors`` build support tensors via ``extend_gate``."""
     gate = GateLibrary.cx()
     gate.set_sites(0, 1)
     tensor = np.asarray(gate.tensor, dtype=np.complex128)
     stub = cast("BaseGate", type("GateStub", (), {"interaction": 2, "sites": [0, 1], "tensor": tensor})())
-    support = gate_support_mpo_tensors(stub, first_site=0, last_site=1)
-    expected = extend_gate(gate_tensor_lr_order(gate), [0, 1])
+    support = get_support_mpo(stub, first_site=0, last_site=1)
+    expected = extend_gate(resolve_lr_tensor(gate), [0, 1])
     assert len(support) == 2
     np.testing.assert_allclose(support[0], expected[0])
     np.testing.assert_allclose(support[1], expected[1])
@@ -95,7 +95,7 @@ def test_gate_support_mpo_tensors_calls_extend_gate_without_cache() -> None:
 
 def test_contract_mpo_site_with_mps_site() -> None:
     """MPO--MPS site contraction fuses virtual bonds in library order."""
-    mpo_site = identity_mpo_site(2)
+    mpo_site = make_identity_site(2)
     mps_site = np.ones((2, 1, 1), dtype=np.complex128)
     out = contract_mpo_site_with_mps_site(mpo_site, mps_site)
     assert out.shape == (2, 1, 1)
@@ -103,8 +103,8 @@ def test_contract_mpo_site_with_mps_site() -> None:
 
 def test_contract_mpo_site_with_mpo_site_conjugate_flag() -> None:
     """MPO--MPO contraction supports the conjugated equivalence-checking path."""
-    left = identity_mpo_site(2)
-    right = identity_mpo_site(2)
+    left = make_identity_site(2)
+    right = make_identity_site(2)
     plain = contract_mpo_site_with_mpo_site(left, right, conjugate=False)
     conj = contract_mpo_site_with_mpo_site(left, right, conjugate=True)
     assert plain.shape == conj.shape == (2, 2, 1, 1)

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -679,3 +679,50 @@ def test_base_gate_three_by_three_matrix_raises() -> None:
     """A 3x3 matrix should be rejected because 3 is not a power of two."""
     with pytest.raises(ValueError, match="Matrix dimension 3 must be a power of 2"):
         BaseGate(np.eye(3, dtype=np.complex128))
+
+
+@pytest.mark.parametrize(
+    ("factory", "sites", "expected_mpo_len"),
+    [
+        (GateLibrary.xx, [0, 1], 2),
+        (GateLibrary.yy, [1, 2], 2),
+        (GateLibrary.zz, [0, 2], 3),
+    ],
+)
+def test_two_qubit_correlator_set_sites_builds_mpo(
+    factory: type,
+    sites: list[int],
+    expected_mpo_len: int,
+) -> None:
+    """XX/YY/ZZ correlators should still build tensor/MPO data via ``BaseGate.set_sites``."""
+    gate = factory()
+    gate.set_sites(*sites)
+    assert gate.sites == sites
+    assert gate.tensor.shape == (2, 2, 2, 2)
+    assert len(gate.mpo_tensors) == expected_mpo_len
+
+
+@pytest.mark.parametrize(
+    ("factory", "site"),
+    [
+        (GateLibrary.p0, 2),
+        (GateLibrary.p1, 3),
+    ],
+)
+def test_projector_set_sites_preserves_tensor(factory: type, site: int) -> None:
+    """Single-qubit projectors should keep their matrix/tensor after ``set_sites``."""
+    gate = factory()
+    matrix_before = gate.matrix.copy()
+    gate.set_sites(site)
+    assert gate.sites == [site]
+    assert_array_equal(gate.matrix, matrix_before)
+    assert gate.tensor.shape == (2, 2)
+
+
+def test_pvm_set_sites_preserves_placeholder_matrix() -> None:
+    """PVM should remain a 1-qubit placeholder after ``set_sites``."""
+    gate = GateLibrary.pvm("01")
+    gate.set_sites(4)
+    assert gate.sites == [4]
+    assert gate.interaction == 1
+    assert_array_equal(gate.matrix, np.eye(2))

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -31,7 +31,17 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.simulation_parameters import Observable
-from mqt.yaqs.core.libraries.gate_library import BaseGate, Destroy, GateLibrary, X, Y, Z, extend_gate, split_tensor
+from mqt.yaqs.core.libraries.gate_library import (
+    BaseGate,
+    Create,
+    Destroy,
+    GateLibrary,
+    X,
+    Y,
+    Z,
+    extend_gate,
+    split_tensor,
+)
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -679,6 +689,15 @@ def test_base_gate_three_by_three_matrix_raises() -> None:
     """A 3x3 matrix should be rejected because 3 is not a power of two."""
     with pytest.raises(ValueError, match="Matrix dimension 3 must be a power of 2"):
         BaseGate(np.eye(3, dtype=np.complex128))
+
+
+def test_destroy_d_level_arithmetic() -> None:
+    """Destroy/Create arithmetic on non-qubit dimensions should not re-validate matrix size."""
+    d = 3
+    destroy = Destroy(d)
+    create = Create(d)
+    combined = destroy.dag() @ destroy + create @ create.dag()
+    assert combined.matrix.shape == (d, d)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -653,3 +653,29 @@ def test_meta_schmidt_spectrum_sites_len_flexible() -> None:
     g.set_sites(7, 8)
     assert g.sites == [7, 8]
     assert_array_equal(BaseGate.schmidt_spectrum().matrix, g.matrix)
+
+
+def test_base_gate_one_qubit_matrix_infers_interaction() -> None:
+    """A valid 1-qubit matrix should infer ``interaction == 1``."""
+    gate = BaseGate(np.array([[1, 0], [0, 1]], dtype=np.float64))
+    assert gate.interaction == 1
+    assert gate.matrix.dtype == np.complex128
+
+
+def test_base_gate_two_qubit_matrix_infers_interaction() -> None:
+    """A valid 2-qubit matrix should infer ``interaction == 2``."""
+    gate = BaseGate(np.eye(4, dtype=np.complex128))
+    assert gate.interaction == 2
+    assert gate.matrix.dtype == np.complex128
+
+
+def test_base_gate_non_square_matrix_raises() -> None:
+    """A non-square matrix should be rejected."""
+    with pytest.raises(ValueError, match="Matrix must be square"):
+        BaseGate(np.array([[1, 2, 3], [4, 5, 6]]))
+
+
+def test_base_gate_three_by_three_matrix_raises() -> None:
+    """A 3x3 matrix should be rejected because 3 is not a power of two."""
+    with pytest.raises(ValueError, match="Matrix dimension 3 must be a power of 2"):
+        BaseGate(np.eye(3, dtype=np.complex128))

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1826,23 +1826,23 @@ def test_counts_multiple_mid_measurement_barriers() -> None:
 
 
 def test_ignores_non_mid_barriers_and_handles_measures() -> None:
-    """Barriers without the label and measurements are ignored for sampling.
+    """Barriers without the label and terminal measurements are ignored for sampling.
 
     Creates a 2-qubit circuit that includes an unlabelled barrier (ignored), a labelled
-    'SAMPLE_OBSERVABLES' barrier (counted), a measurement operation (removed), and a barrier
-    with a non-matching label (ignored). With layer sampling enabled, the test asserts
-    that each observable's results has shape (3,), corresponding to initial, one mid,
-    and final sampling points.
+    'SAMPLE_OBSERVABLES' barrier (counted), a terminal measurement operation (removed),
+    and a barrier with a non-matching label (ignored). With layer sampling enabled, the
+    test asserts that each observable's results has shape (3,), corresponding to initial,
+    one mid, and final sampling points.
     """
     num_qubits = 2
     qc = QuantumCircuit(num_qubits, num_qubits)
     qc.barrier()  # no label -> ignored
     qc.rx(0.1, 0)
     qc.barrier(label="SAMPLE_OBSERVABLES")
-    qc.measure(0, 0)  # measurements are removed
     qc.cx(0, 1)
     qc.barrier(label="not-mid")  # ignored
     qc.rzz(0.2, 0, 1)
+    qc.measure(0, 0)  # terminal measurements are removed
 
     sim_params = StrongSimParams(observables=[Observable(Z(), i) for i in range(num_qubits)], sample_layers=True)
     state = State(num_qubits, initial="zeros")

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -231,6 +231,18 @@ def test_process_layer() -> None:
         assert min(q0, q1) % 2 == 1, f"Node with qubits {q0, q1} not in odd group."
 
 
+def test_process_layer_rejects_mid_circuit_measure() -> None:
+    """Mid-circuit measurements must not be silently dropped during layer processing."""
+    qc = QuantumCircuit(2, 1)
+    qc.measure(0, 0)
+    qc.x(0)
+
+    dag = circuit_to_dag(qc)
+
+    with pytest.raises(ValueError, match="Non-terminal measure operations are not supported"):
+        process_layer(dag)
+
+
 def test_process_layer_unsupported_gate() -> None:
     """Test that process_layer raises an exception when encountering an unsupported gate.
 

--- a/tests/digital/utils/test_dag_utils.py
+++ b/tests/digital/utils/test_dag_utils.py
@@ -25,6 +25,7 @@ import pytest
 from numpy.testing import assert_allclose
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
+from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.library import (
     CRZGate,
     CXGate,
@@ -41,6 +42,7 @@ from qiskit.circuit.library import (
 )
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGOpNode
+from qiskit.qasm2 import loads
 from qiskit.quantum_info import Operator, Statevector
 
 from mqt.yaqs import EquivalenceChecker
@@ -115,6 +117,28 @@ def test_custom_one_qubit_unitary_gate_translation() -> None:
     assert gate.interaction == 1
     assert gate.sites == [0]
     assert_allclose(gate.matrix, unitary, atol=1e-12)
+    assert not hasattr(gate, "generator")
+
+
+def test_qasm_defined_gate_translates_when_to_matrix_raises() -> None:
+    """QASM custom gates without ``to_matrix`` (older Qiskit) still translate via ``Operator``."""
+    qasm = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    gate prep a,b { h a; cx a,b; }
+    qreg q[2];
+    prep q[0], q[1];
+    """
+    qc = loads(qasm)
+    dag = circuit_to_dag(qc)
+    node = next(n for n in dag.op_nodes() if n.op.name == "prep")
+    reference = convert_dag_to_tensor_algorithm(node)[0]
+
+    with patch.object(node.op, "to_matrix", side_effect=CircuitError("to_matrix unavailable")):
+        gate = convert_dag_to_tensor_algorithm(node)[0]
+
+    assert gate.name == "prep"
+    assert_allclose(gate.matrix, reference.matrix, atol=1e-12)
     assert not hasattr(gate, "generator")
 
 

--- a/tests/digital/utils/test_dag_utils.py
+++ b/tests/digital/utils/test_dag_utils.py
@@ -278,6 +278,33 @@ def test_custom_long_range_two_qubit_unitary_matches_qiskit() -> None:
 
 
 @pytest.mark.parametrize(
+    ("gate_name", "qargs", "gate_mode"),
+    [
+        ("swap", (0, 1), "tdvp"),
+        ("swap", (1, 0), "tdvp"),
+        ("cz", (0, 1), "tdvp"),
+        ("cz", (1, 0), "tdvp"),
+        ("cx", (0, 1), "tdvp"),
+        ("cx", (1, 0), "tdvp"),
+    ],
+)
+def test_builtin_two_qubit_gate_reversed_qargs_match_qiskit(
+    gate_name: str,
+    qargs: tuple[int, int],
+    gate_mode: Literal["tdvp"],
+) -> None:
+    """Built-in two-qubit gates should match Qiskit for forward and reversed qargs."""
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    getattr(qc, gate_name)(*qargs)
+
+    vec = _run_strong_noiseless(qc, gate_mode=gate_mode, get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+@pytest.mark.parametrize(
     ("num_qubits", "qargs", "gate_mode"),
     [
         (2, (0, 1), "tdvp"),

--- a/tests/digital/utils/test_dag_utils.py
+++ b/tests/digital/utils/test_dag_utils.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from qiskit import QuantumCircuit
-from qiskit.circuit import Parameter
+from qiskit.circuit import Gate, Parameter
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.library import (
     CRZGate,
@@ -351,6 +351,30 @@ def test_fixed_nonsymmetric_two_qubit_unitary_qarg_ordering(
     assert isinstance(vec, np.ndarray)
     ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
     assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+class _CustomNamedUnitary(Gate):
+    """Qiskit gate whose ``name`` collides with a non-alias ``GateLibrary`` attribute."""
+
+    def __init__(self) -> None:
+        super().__init__("custom", 1, [])
+
+    def to_matrix(self) -> np.ndarray:  # noqa: PLR6301
+        return np.array([[0, 1], [1, 0]], dtype=np.complex128)
+
+
+def test_translate_unknown_name_skips_gate_library_attributes() -> None:
+    """Names outside ``SUPPORTED_QISKIT_GATE_NAMES`` must not bind ``GateLibrary`` helpers."""
+    assert "custom" not in SUPPORTED_QISKIT_GATE_NAMES
+    assert hasattr(GateLibrary, "custom")
+
+    qc = QuantumCircuit(1)
+    qc.append(_CustomNamedUnitary(), [0])
+    dag = circuit_to_dag(qc)
+    gate = convert_dag_to_tensor_algorithm(dag)[0]
+
+    assert gate.name == "custom"
+    assert_allclose(gate.matrix, _CustomNamedUnitary().to_matrix())
 
 
 @pytest.mark.parametrize(

--- a/tests/digital/utils/test_dag_utils.py
+++ b/tests/digital/utils/test_dag_utils.py
@@ -16,14 +16,20 @@ ranges for gate application.
 
 from __future__ import annotations
 
+import copy
+from typing import Literal
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import (
+    CRZGate,
     CXGate,
     IGate,
+    RZXGate,
     SdgGate,
     SGate,
     SXdgGate,
@@ -35,10 +41,15 @@ from qiskit.circuit.library import (
 )
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGOpNode
-from qiskit.quantum_info import Statevector
+from qiskit.quantum_info import Operator, Statevector
 
+from mqt.yaqs import EquivalenceChecker
+from mqt.yaqs.core.data_structures.simulation_parameters import StrongSimParams
+from mqt.yaqs.core.data_structures.state import State
 from mqt.yaqs.core.libraries.gate_library import GateLibrary, Rx
+from mqt.yaqs.digital.digital_tjm import apply_two_qubit_gate
 from mqt.yaqs.digital.utils.dag_utils import (
+    SUPPORTED_QISKIT_GATE_NAMES,
     check_longest_gate,
     convert_dag_to_tensor_algorithm,
     get_temporal_zone,
@@ -46,6 +57,14 @@ from mqt.yaqs.digital.utils.dag_utils import (
 )
 from tests.core.methods.tdvp.conftest import _fidelity
 from tests.digital.conftest import _run_strong_noiseless
+
+
+def test_supported_qiskit_gate_names_exact() -> None:
+    """The documented Qiskit gate-name list must match ``GateLibrary`` exactly."""
+    assert len(SUPPORTED_QISKIT_GATE_NAMES) == 28
+    for name in SUPPORTED_QISKIT_GATE_NAMES:
+        assert hasattr(GateLibrary, name), f"GateLibrary missing hardcoded alias '{name}'"
+        assert getattr(GateLibrary, name) is not GateLibrary.custom
 
 
 def _qiskit_gate_matrix(gate_cls: type, *params: float) -> np.ndarray:
@@ -119,18 +138,17 @@ def test_custom_two_qubit_unitary_gate_translation() -> None:
 
 
 def test_custom_two_qubit_unitary_gate_reversed_qargs() -> None:
-    """Reversed two-qubit qargs should transpose the gate tensor like built-in gates."""
+    """Reversed two-qubit qargs should store the Qiskit operator matrix for those sites."""
     unitary = np.asarray(CXGate().to_matrix(), dtype=np.complex128)
     qc = QuantumCircuit(2)
     qc.append(UnitaryGate(unitary), [1, 0])
     dag = circuit_to_dag(qc)
 
     gate = convert_dag_to_tensor_algorithm(dag)[0]
-    expected = GateLibrary.cx()
-    expected.set_sites(1, 0)
+    expected_op = Operator(qc).data
 
     assert gate.sites == [1, 0]
-    assert_allclose(gate.tensor, expected.tensor, atol=1e-12)
+    assert_allclose(gate.matrix, expected_op, atol=1e-12)
 
 
 def test_unbound_parameterized_gate_raises() -> None:
@@ -156,6 +174,29 @@ def test_unsupported_reset_instruction_raises() -> None:
         convert_dag_to_tensor_algorithm(node)
 
 
+def test_unsupported_measure_instruction_raises() -> None:
+    """Measure instructions should be rejected during DAG-to-gate conversion."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    dag = circuit_to_dag(qc)
+    node = next(n for n in dag.op_nodes() if n.op.name == "measure")
+
+    with pytest.raises(ValueError, match="mid-circuit measurements are not supported"):
+        convert_dag_to_tensor_algorithm(node)
+
+
+def test_unsupported_measure_in_full_dag_raises() -> None:
+    """A DAG containing measure nodes should fail conversion."""
+    qc = QuantumCircuit(1, 1)
+    qc.x(0)
+    qc.measure(0, 0)
+    dag = circuit_to_dag(qc)
+
+    with pytest.raises(ValueError, match="mid-circuit measurements are not supported"):
+        convert_dag_to_tensor_algorithm(dag)
+
+
 def test_unsupported_control_flow_raises() -> None:
     """Control-flow instructions should be rejected with a clear error."""
     qc = QuantumCircuit(1, 1)
@@ -178,6 +219,10 @@ def _haar_unitary(dim: int, rng: np.random.Generator) -> np.ndarray:
     q, r = np.linalg.qr(z)
     phases = np.diagonal(r) / np.abs(np.diagonal(r))
     return np.asarray(q * phases, dtype=np.complex128)
+
+
+# Fixed Haar-random 2-qubit unitary (seed 42); not symmetric under qubit interchange.
+_FIXED_NONSYMMETRIC_2Q = _haar_unitary(4, np.random.default_rng(42))
 
 
 def test_custom_one_qubit_unitary_matches_qiskit_statevector() -> None:
@@ -230,6 +275,149 @@ def test_custom_long_range_two_qubit_unitary_matches_qiskit() -> None:
     assert isinstance(vec, np.ndarray)
     ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
     assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+@pytest.mark.parametrize(
+    ("num_qubits", "qargs", "gate_mode"),
+    [
+        (2, (0, 1), "tdvp"),
+        (2, (1, 0), "tdvp"),
+        (3, (0, 2), "mpo"),
+        (3, (2, 0), "mpo"),
+    ],
+)
+def test_fixed_nonsymmetric_two_qubit_unitary_qarg_ordering(
+    num_qubits: int,
+    qargs: tuple[int, int],
+    gate_mode: Literal["tdvp", "mpo"],
+) -> None:
+    """A fixed non-symmetric custom unitary should match Qiskit for every qarg ordering."""
+    qc = QuantumCircuit(num_qubits)
+    qc.h(0)
+    qc.append(UnitaryGate(_FIXED_NONSYMMETRIC_2Q), list(qargs))
+
+    vec = _run_strong_noiseless(qc, gate_mode=gate_mode, get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+@pytest.mark.parametrize(
+    ("qiskit_gate_cls", "params", "qargs"),
+    [
+        (CRZGate, (0.37,), (0, 1)),
+        (RZXGate, (0.42,), (0, 1)),
+    ],
+)
+def test_qiskit_standard_gate_matrix_fallback_matches_qiskit(
+    qiskit_gate_cls: type,
+    params: tuple[float, ...],
+    qargs: tuple[int, int],
+) -> None:
+    """Unsupported standard Qiskit gates should use the matrix fallback and match Qiskit."""
+    gate_name = qiskit_gate_cls(*params).name
+    assert gate_name not in SUPPORTED_QISKIT_GATE_NAMES
+
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.append(qiskit_gate_cls(*params), list(qargs))
+    dag = circuit_to_dag(qc)
+    gate = next(g for g in convert_dag_to_tensor_algorithm(dag) if g.name == gate_name)
+
+    assert gate.name == gate_name
+    assert not hasattr(gate, "generator")
+
+    vec = _run_strong_noiseless(qc, gate_mode="tdvp", get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+def test_unitary_gate_equivalent_to_decomposition() -> None:
+    """A custom ``UnitaryGate`` circuit should be equivalent to an equivalent decomposition."""
+    theta = 0.31
+    unitary = np.asarray(GateLibrary.rx([theta]).matrix, dtype=np.complex128)
+
+    qc_unitary = QuantumCircuit(1)
+    qc_unitary.append(UnitaryGate(unitary), [0])
+
+    qc_decomposed = QuantumCircuit(1)
+    qc_decomposed.rx(theta, 0)
+
+    result = EquivalenceChecker(representation="matrix", fidelity=1 - 1e-12).check(qc_unitary, qc_decomposed)
+    assert result["equivalent"] is True
+
+
+def _haar_unitary_2q(seed: int) -> np.ndarray:
+    """Return a Haar-random ``4 x 4`` unitary for generator-less routing tests."""
+    rng = np.random.default_rng(seed)
+    z = rng.standard_normal((4, 4)) + 1j * rng.standard_normal((4, 4))
+    q, r = np.linalg.qr(z)
+    phases = np.diagonal(r) / np.abs(np.diagonal(r))
+    return np.asarray(q * phases, dtype=np.complex128)
+
+
+def test_generator_less_nn_custom_gate_routes_tebd() -> None:
+    """Custom NN gates without a generator should use TEBD in ``gate_mode='tdvp'``."""
+    unitary = _haar_unitary_2q(11)
+    qc = QuantumCircuit(2)
+    qc.append(UnitaryGate(unitary), [0, 1])
+    dag = circuit_to_dag(qc)
+    node = dag.op_nodes()[0]
+    gate = convert_dag_to_tensor_algorithm(node)[0]
+    assert not hasattr(gate, "generator")
+
+    out = copy.deepcopy(State(2, initial="zeros").mps)
+    params = StrongSimParams(
+        observables=[],
+        gate_mode="tdvp",
+        preset="exact",
+        svd_threshold=1e-12,
+        tdvp_sweeps=1,
+    )
+
+    with (
+        patch("mqt.yaqs.digital.digital_tjm.apply_two_qubit_gate_tebd") as mock_tebd,
+        patch("mqt.yaqs.digital.digital_tjm.apply_two_qubit_gate_tdvp") as mock_tdvp,
+        patch("mqt.yaqs.digital.digital_tjm.apply_long_range_gate_mpo") as mock_mpo,
+    ):
+        mock_tebd.return_value = (0, 1)
+        apply_two_qubit_gate(out, node, params)
+        mock_tebd.assert_called_once()
+        mock_tdvp.assert_not_called()
+        mock_mpo.assert_not_called()
+
+
+def test_generator_less_lr_custom_gate_routes_mpo() -> None:
+    """Custom LR gates without a generator should use the MPO path in ``gate_mode='tdvp'``."""
+    unitary = _haar_unitary_2q(13)
+    length = 3
+    qc = QuantumCircuit(length)
+    qc.append(UnitaryGate(unitary), [0, length - 1])
+    dag = circuit_to_dag(qc)
+    node = dag.op_nodes()[0]
+    gate = convert_dag_to_tensor_algorithm(node)[0]
+    assert not hasattr(gate, "generator")
+
+    out = copy.deepcopy(State(length, initial="zeros").mps)
+    params = StrongSimParams(
+        observables=[],
+        gate_mode="tdvp",
+        preset="exact",
+        svd_threshold=1e-12,
+        tdvp_sweeps=1,
+    )
+
+    with (
+        patch("mqt.yaqs.digital.digital_tjm.apply_two_qubit_gate_tebd") as mock_tebd,
+        patch("mqt.yaqs.digital.digital_tjm.apply_two_qubit_gate_tdvp") as mock_tdvp,
+        patch("mqt.yaqs.digital.digital_tjm.apply_long_range_gate_mpo") as mock_mpo,
+    ):
+        mock_mpo.return_value = (0, length - 1)
+        apply_two_qubit_gate(out, node, params)
+        mock_mpo.assert_called_once()
+        mock_tdvp.assert_not_called()
+        mock_tebd.assert_not_called()
 
 
 def test_convert_dag_to_tensor_algorithm_single_qubit_gate() -> None:
@@ -309,23 +497,29 @@ def test_convert_dag_to_tensor_algorithm_single_dagopnode() -> None:
     assert gate.sites == [0], "Gate should act on qubit 0."
 
 
-def test_convert_dag_to_tensor_algorithm_ignores_measure_barrier() -> None:
-    """Test that convert_dag_to_tensor_algorithm ignores measure and barrier nodes.
+def test_convert_dag_to_tensor_algorithm_ignores_barrier() -> None:
+    """Test that convert_dag_to_tensor_algorithm ignores barrier nodes but rejects measure.
 
-    This test constructs a two-qubit circuit that includes an X gate, a barrier, and measurement operations.
-    After converting the circuit to a DAG and extracting gates, the function should return only the X gate,
-    ignoring measure and barrier operations.
+    This test constructs a two-qubit circuit that includes an X gate and a barrier.
+    After converting the circuit to a DAG and extracting gates, the function should
+    return only the X gate. Measurements must be rejected explicitly.
     """
     qc = QuantumCircuit(2)
     qc.x(0)
     qc.barrier()
-    qc.measure_all()
     dag = circuit_to_dag(qc)
 
     gates = convert_dag_to_tensor_algorithm(dag)
     assert len(gates) == 1, "Only the X gate should be extracted."
     gate = gates[0]
     assert gate.name.lower() == "x", "The extracted gate should be an X gate."
+
+    qc_measure = QuantumCircuit(2, 2)
+    qc_measure.x(0)
+    qc_measure.barrier()
+    qc_measure.measure_all()
+    with pytest.raises(ValueError, match="mid-circuit measurements are not supported"):
+        convert_dag_to_tensor_algorithm(circuit_to_dag(qc_measure))
 
 
 def test_get_temporal_zone_simple() -> None:

--- a/tests/digital/utils/test_dag_utils.py
+++ b/tests/digital/utils/test_dag_utils.py
@@ -18,17 +18,218 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from qiskit import QuantumCircuit
+from qiskit.circuit import Parameter
+from qiskit.circuit.library import (
+    CXGate,
+    IGate,
+    SdgGate,
+    SGate,
+    SXdgGate,
+    TdgGate,
+    TGate,
+    U1Gate,
+    U3Gate,
+    UnitaryGate,
+)
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGOpNode
+from qiskit.quantum_info import Statevector
 
-from mqt.yaqs.core.libraries.gate_library import Rx
+from mqt.yaqs.core.libraries.gate_library import GateLibrary, Rx
 from mqt.yaqs.digital.utils.dag_utils import (
     check_longest_gate,
     convert_dag_to_tensor_algorithm,
     get_temporal_zone,
     select_starting_point,
 )
+from tests.core.methods.tdvp.conftest import _fidelity
+from tests.digital.conftest import _run_strong_noiseless
+
+
+def _qiskit_gate_matrix(gate_cls: type, *params: float) -> np.ndarray:
+    """Return the Qiskit dense matrix for a standard gate class."""
+    gate = gate_cls(*params) if params else gate_cls()
+    matrix = gate.to_matrix()
+    assert matrix is not None
+    return np.asarray(matrix, dtype=np.complex128)
+
+
+@pytest.mark.parametrize(
+    ("library_name", "qiskit_gate_cls", "params"),
+    [
+        ("s", SGate, ()),
+        ("sdg", SdgGate, ()),
+        ("t", TGate, ()),
+        ("tdg", TdgGate, ()),
+        ("sxdg", SXdgGate, ()),
+        ("i", IGate, ()),
+        ("iden", IGate, ()),
+        ("u1", U1Gate, (0.37,)),
+        ("u3", U3Gate, (0.2, 0.3, 0.4)),
+    ],
+)
+def test_qiskit_gate_aliases_match_qiskit_matrices(
+    library_name: str,
+    qiskit_gate_cls: type,
+    params: tuple[float, ...],
+) -> None:
+    """Hardcoded Qiskit aliases should match standard Qiskit gate matrices."""
+    gate_cls = getattr(GateLibrary, library_name)
+    yaqs_gate = gate_cls(list(params)) if params else gate_cls()
+    expected = _qiskit_gate_matrix(qiskit_gate_cls, *params)
+    assert_allclose(yaqs_gate.matrix, expected, atol=1e-12)
+
+
+def test_custom_one_qubit_unitary_gate_translation() -> None:
+    """Unknown 1-qubit UnitaryGate nodes should translate from the Qiskit matrix."""
+    unitary = np.array([[0, 1], [1, 0]], dtype=np.complex128)
+    qc = QuantumCircuit(1)
+    qc.append(UnitaryGate(unitary), [0])
+    dag = circuit_to_dag(qc)
+    node = dag.op_nodes()[0]
+    assert isinstance(node, DAGOpNode)
+
+    gate = convert_dag_to_tensor_algorithm(node)[0]
+    assert gate.name == "unitary"
+    assert gate.interaction == 1
+    assert gate.sites == [0]
+    assert_allclose(gate.matrix, unitary, atol=1e-12)
+    assert not hasattr(gate, "generator")
+
+
+def test_custom_two_qubit_unitary_gate_translation() -> None:
+    """Unknown 2-qubit UnitaryGate nodes should build tensor/MPO data like other 2Q gates."""
+    unitary = np.asarray(CXGate().to_matrix(), dtype=np.complex128)
+    qc = QuantumCircuit(2)
+    qc.append(UnitaryGate(unitary), [0, 1])
+    dag = circuit_to_dag(qc)
+
+    gate = convert_dag_to_tensor_algorithm(dag)[0]
+    expected = GateLibrary.cx()
+    expected.set_sites(0, 1)
+
+    assert gate.name == "unitary"
+    assert gate.interaction == 2
+    assert gate.sites == [0, 1]
+    assert_allclose(gate.matrix, expected.matrix, atol=1e-12)
+    assert_allclose(gate.tensor, expected.tensor, atol=1e-12)
+    assert len(gate.mpo_tensors) == 2
+
+
+def test_custom_two_qubit_unitary_gate_reversed_qargs() -> None:
+    """Reversed two-qubit qargs should transpose the gate tensor like built-in gates."""
+    unitary = np.asarray(CXGate().to_matrix(), dtype=np.complex128)
+    qc = QuantumCircuit(2)
+    qc.append(UnitaryGate(unitary), [1, 0])
+    dag = circuit_to_dag(qc)
+
+    gate = convert_dag_to_tensor_algorithm(dag)[0]
+    expected = GateLibrary.cx()
+    expected.set_sites(1, 0)
+
+    assert gate.sites == [1, 0]
+    assert_allclose(gate.tensor, expected.tensor, atol=1e-12)
+
+
+def test_unbound_parameterized_gate_raises() -> None:
+    """Unbound symbolic parameters should be rejected with a clear error."""
+    theta = Parameter("theta")
+    qc = QuantumCircuit(1)
+    qc.rx(theta, 0)
+    dag = circuit_to_dag(qc)
+    node = dag.op_nodes()[0]
+
+    with pytest.raises(ValueError, match="unbound parameters"):
+        convert_dag_to_tensor_algorithm(node)
+
+
+def test_unsupported_reset_instruction_raises() -> None:
+    """Reset instructions should be rejected with a clear error."""
+    qc = QuantumCircuit(1)
+    qc.reset(0)
+    dag = circuit_to_dag(qc)
+    node = dag.op_nodes()[0]
+
+    with pytest.raises(ValueError, match="reset is not supported"):
+        convert_dag_to_tensor_algorithm(node)
+
+
+def test_unsupported_control_flow_raises() -> None:
+    """Control-flow instructions should be rejected with a clear error."""
+    qc = QuantumCircuit(1, 1)
+    with qc.if_test((qc.clbits[0], 1)):
+        qc.x(0)
+    dag = circuit_to_dag(qc)
+    node = dag.op_nodes()[0]
+
+    with pytest.raises(ValueError, match="control-flow"):
+        convert_dag_to_tensor_algorithm(node)
+
+
+def _haar_unitary(dim: int, rng: np.random.Generator) -> np.ndarray:
+    """Sample a Haar-random unitary matrix of size ``dim x dim``.
+
+    Returns:
+        A ``dim x dim`` unitary matrix.
+    """
+    z = rng.standard_normal((dim, dim)) + 1j * rng.standard_normal((dim, dim))
+    q, r = np.linalg.qr(z)
+    phases = np.diagonal(r) / np.abs(np.diagonal(r))
+    return np.asarray(q * phases, dtype=np.complex128)
+
+
+def test_custom_one_qubit_unitary_matches_qiskit_statevector() -> None:
+    """Custom 1-qubit UnitaryGate circuits should match Qiskit statevectors."""
+    unitary = _haar_unitary(2, np.random.default_rng(0))
+    qc = QuantumCircuit(2)
+    qc.append(UnitaryGate(unitary), [1])
+    qc.h(0)
+
+    vec = _run_strong_noiseless(qc, gate_mode="tdvp", get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+def test_custom_two_qubit_unitary_matches_qiskit_statevector() -> None:
+    """Custom 2-qubit UnitaryGate circuits should match Qiskit statevectors."""
+    unitary = _haar_unitary(4, np.random.default_rng(1))
+    qc = QuantumCircuit(2)
+    qc.append(UnitaryGate(unitary), [0, 1])
+    qc.h(0)
+
+    vec = _run_strong_noiseless(qc, gate_mode="tdvp", get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+def test_custom_two_qubit_unitary_reversed_qargs_matches_qiskit() -> None:
+    """Reversed custom two-qubit qargs on a long-range pair should match Qiskit."""
+    unitary = _haar_unitary(4, np.random.default_rng(2))
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.append(UnitaryGate(unitary), [2, 0])
+
+    vec = _run_strong_noiseless(qc, gate_mode="mpo", get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
+
+
+def test_custom_long_range_two_qubit_unitary_matches_qiskit() -> None:
+    """Long-range custom two-qubit gates should work via the MPO application path."""
+    unitary = _haar_unitary(4, np.random.default_rng(3))
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.append(UnitaryGate(unitary), [0, 2])
+
+    vec = _run_strong_noiseless(qc, gate_mode="mpo", get_state=True)
+    assert isinstance(vec, np.ndarray)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+    assert _fidelity(ref, vec) == pytest.approx(1.0, abs=1e-10)
 
 
 def test_convert_dag_to_tensor_algorithm_single_qubit_gate() -> None:

--- a/tests/digital/utils/test_matrix_utils.py
+++ b/tests/digital/utils/test_matrix_utils.py
@@ -5,8 +5,6 @@
 #
 # Licensed under the MIT License
 
-# ruff: noqa: PLC2701 -- white-box tests import private matrix_utils helpers
-
 """Tests for matrix equivalence utilities."""
 
 from __future__ import annotations
@@ -21,21 +19,21 @@ from qiskit import QuantumCircuit
 from mqt.yaqs import EquivalenceChecker
 from mqt.yaqs.core.libraries.gate_library import BaseGate
 from mqt.yaqs.digital.utils.matrix_utils import (
-    _apply_gate_left,
-    _identity_operator_tensor,
-    build_composed_operator_tensor,
-    check_equivalence_matrix,
-    check_operator_is_identity,
+    apply_gate_left,
+    check_matrix_equivalence,
+    compose_operator_tensor,
+    is_identity_tensor,
+    make_identity_tensor,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def test_build_composed_operator_tensor_rejects_mismatched_widths() -> None:
+def test_compose_operator_tensor_rejects_mismatched_widths() -> None:
     """Different qubit counts raise before tensor construction."""
     with pytest.raises(ValueError, match="same number of qubits"):
-        build_composed_operator_tensor(QuantumCircuit(2), QuantumCircuit(3))
+        compose_operator_tensor(QuantumCircuit(2), QuantumCircuit(3))
 
 
 def test_mid_circuit_measurement_rejected() -> None:
@@ -46,7 +44,7 @@ def test_mid_circuit_measurement_rejected() -> None:
     qc.cx(0, 1)
 
     with pytest.raises(ValueError, match="Mid-circuit measurements"):
-        build_composed_operator_tensor(qc, qc)
+        compose_operator_tensor(qc, qc)
 
 
 def test_final_measurements_are_stripped() -> None:
@@ -60,7 +58,7 @@ def test_final_measurements_are_stripped() -> None:
     qc2.h(0)
     qc2.cx(0, 1)
 
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is True
 
 
 def test_barriers_are_ignored() -> None:
@@ -74,16 +72,16 @@ def test_barriers_are_ignored() -> None:
     qc2.h(0)
     qc2.cx(0, 1)
 
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is True
 
 
-def test_check_equivalence_matrix_empty_circuits() -> None:
+def test_check_matrix_equivalence_empty_circuits() -> None:
     """Empty circuits compose to the identity."""
     qc = QuantumCircuit(3)
-    assert check_equivalence_matrix(qc, qc, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc, qc, fidelity=1 - 1e-12) is True
 
 
-def test_check_equivalence_matrix_identical_circuits() -> None:
+def test_check_matrix_equivalence_identical_circuits() -> None:
     """Identical non-trivial circuits are equivalent."""
     qc1 = QuantumCircuit(3)
     qc1.h(0)
@@ -91,10 +89,10 @@ def test_check_equivalence_matrix_identical_circuits() -> None:
     qc1.rz(np.pi / 4, 2)
     qc2 = qc1.copy()
 
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is True
 
 
-def test_check_equivalence_matrix_non_equivalent() -> None:
+def test_check_matrix_equivalence_non_equivalent() -> None:
     """An extra gate breaks equivalence."""
     qc1 = QuantumCircuit(2)
     qc1.h(0)
@@ -105,10 +103,10 @@ def test_check_equivalence_matrix_non_equivalent() -> None:
     qc2.cx(0, 1)
     qc2.x(1)
 
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is False
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is False
 
 
-def test_check_equivalence_matrix_global_phase() -> None:
+def test_check_matrix_equivalence_global_phase() -> None:
     """Circuits differing only by global phase are equivalent."""
     qc1 = QuantumCircuit(2)
     qc1.h(0)
@@ -117,20 +115,20 @@ def test_check_equivalence_matrix_global_phase() -> None:
     qc2 = qc1.copy()
     qc2.global_phase = np.pi / 5
 
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is True
 
 
-def test_check_equivalence_matrix_long_range_cx() -> None:
+def test_check_matrix_equivalence_long_range_cx() -> None:
     """Long-range two-qubit gates are supported."""
     qc1 = QuantumCircuit(3)
     qc1.h(0)
     qc1.cx(0, 2)
 
     qc2 = qc1.copy()
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is True
 
 
-def test_check_equivalence_matrix_different_single_qubit_gates() -> None:
+def test_check_matrix_equivalence_different_single_qubit_gates() -> None:
     """Distinct single-qubit circuits are not equivalent."""
     qc1 = QuantumCircuit(1)
     qc1.h(0)
@@ -138,10 +136,10 @@ def test_check_equivalence_matrix_different_single_qubit_gates() -> None:
     qc2 = QuantumCircuit(1)
     qc2.x(0)
 
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is False
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is False
 
 
-def test_check_equivalence_matrix_disjoint_single_qubit_layer() -> None:
+def test_check_matrix_equivalence_disjoint_single_qubit_layer() -> None:
     """A wide single-qubit layer applies all gates in one front layer."""
     qc1 = QuantumCircuit(4)
     qc1.h(0)
@@ -152,19 +150,19 @@ def test_check_equivalence_matrix_disjoint_single_qubit_layer() -> None:
     qc1.cx(2, 3)
 
     qc2 = qc1.copy()
-    assert check_equivalence_matrix(qc1, qc2, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc1, qc2, fidelity=1 - 1e-12) is True
 
 
-def test_check_equivalence_matrix_cx_with_swapped_sites() -> None:
+def test_check_matrix_equivalence_cx_with_swapped_sites() -> None:
     """Two-qubit gates with reversed site order compose correctly."""
     qc = QuantumCircuit(2)
     qc.cx(1, 0)
 
-    assert check_equivalence_matrix(qc, qc, fidelity=1 - 1e-12) is True
+    assert check_matrix_equivalence(qc, qc, fidelity=1 - 1e-12) is True
 
 
-def test_apply_gate_left_three_qubit_embedding() -> None:
-    """Multi-qubit gates use the dense embedding path in ``_apply_gate_left``."""
+def testapply_gate_left_three_qubit_embedding() -> None:
+    """Multi-qubit gates use the dense embedding path in ``apply_gate_left``."""
     swap = np.array(
         [
             [1, 0, 0, 0, 0, 0, 0, 0],
@@ -182,29 +180,29 @@ def test_apply_gate_left_three_qubit_embedding() -> None:
     gate.interaction = 3
     gate.set_sites(0, 1, 2)
 
-    op = _identity_operator_tensor(3)
-    updated = _apply_gate_left(op, gate, 3, dagger=False)
-    round_trip = _apply_gate_left(updated, gate, 3, dagger=True)
-    assert check_operator_is_identity(round_trip, fidelity=1 - 1e-12) is True
+    op = make_identity_tensor(3)
+    updated = apply_gate_left(op, gate, 3, dagger=False)
+    round_trip = apply_gate_left(updated, gate, 3, dagger=True)
+    assert is_identity_tensor(round_trip, fidelity=1 - 1e-12) is True
 
 
-def test_build_composed_operator_tensor_is_identity_for_matching_circuits() -> None:
+def test_compose_operator_tensor_is_identity_for_matching_circuits() -> None:
     """Matching circuits produce an identity-like composed operator tensor."""
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
 
-    composed = build_composed_operator_tensor(qc, qc)
+    composed = compose_operator_tensor(qc, qc)
     assert composed.shape == (2, 2, 2, 2)
-    assert check_operator_is_identity(composed, fidelity=1 - 1e-12) is True
+    assert is_identity_tensor(composed, fidelity=1 - 1e-12) is True
 
 
-def test_check_operator_is_identity_without_premature_rounding() -> None:
+def test_is_identity_tensor_without_premature_rounding() -> None:
     """Near-identity overlap is not lost to one-decimal rounding."""
     op = np.diag([1.0, 0.99995]).astype(np.complex128)
     tensor = op.reshape((2, 2))
-    assert check_operator_is_identity(tensor, fidelity=0.9999) is True
-    assert check_operator_is_identity(tensor, fidelity=1.0) is False
+    assert is_identity_tensor(tensor, fidelity=0.9999) is True
+    assert is_identity_tensor(tensor, fidelity=1.0) is False
 
 
 def _bell_pair() -> tuple[QuantumCircuit, QuantumCircuit]:

--- a/tests/test_equivalence_checker.py
+++ b/tests/test_equivalence_checker.py
@@ -9,7 +9,7 @@
 
 This module provides unit tests for :class:`~mqt.yaqs.EquivalenceChecker`. It verifies
 the MPO and dense matrix backends by comparing quantum circuits, including automatic
-backend selection and global-phase equivalence.
+backend selection, global-phase equivalence, and regression coverage for QASM custom gates.
 """
 
 from __future__ import annotations
@@ -20,10 +20,14 @@ from typing import TYPE_CHECKING, Literal, cast
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit
-from qiskit.qasm2 import load
+from qiskit.circuit.library import ECRGate, U1Gate, U3Gate
+from qiskit.converters import circuit_to_dag
+from qiskit.qasm2 import load, loads
 
 from mqt.yaqs import DEFAULT_MATRIX_MAX_QUBITS, EquivalenceChecker
+from mqt.yaqs.core.libraries.gate_library import GateLibrary
 from mqt.yaqs.digital.utils.contraction_utils import MIN_QUBITS_FOR_MPO_PARALLEL
+from mqt.yaqs.digital.utils.dag_utils import SUPPORTED_QISKIT_GATE_NAMES, convert_dag_to_tensor_algorithm
 
 if TYPE_CHECKING:
     from mqt.yaqs.equivalence_checker import Representation
@@ -142,6 +146,147 @@ def test_large_equivalence() -> None:
     result = checker.check(qc, qc)
     assert result["equivalent"] is True, "Large scale test fails. Circuits should be equivalent."
     assert result["representation"] == "mpo"
+
+
+ISSUE_QASM_WITH_MEASURES = """
+OPENQASM 2.0;
+include "qelib1.inc";
+
+gate bellprep a,b {
+  h a;
+  cx a,b;
+}
+
+gate phase_kick(theta) q {
+  rz(theta) q;
+  x q;
+  rz(-theta) q;
+  x q;
+}
+
+qreg q[3];
+creg c[3];
+
+bellprep q[0], q[1];
+phase_kick(pi/4) q[2];
+
+cx q[1], q[2];
+h q[0];
+
+measure q -> c;
+"""
+
+ISSUE_QASM_CUSTOM = """
+OPENQASM 2.0;
+include "qelib1.inc";
+
+gate bellprep a,b {
+  h a;
+  cx a,b;
+}
+
+gate phase_kick(theta) q {
+  rz(theta) q;
+  x q;
+  rz(-theta) q;
+  x q;
+}
+
+qreg q[3];
+
+bellprep q[0], q[1];
+phase_kick(pi/4) q[2];
+cx q[1], q[2];
+h q[0];
+"""
+
+ISSUE_QASM_EXPANDED = """
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[3];
+
+h q[0];
+cx q[0], q[1];
+rz(pi/4) q[2];
+x q[2];
+rz(-pi/4) q[2];
+x q[2];
+cx q[1], q[2];
+h q[0];
+"""
+
+
+def _issue_checker(*, representation: Literal["mpo", "matrix", "auto"] = "mpo") -> EquivalenceChecker:
+    """Return an equivalence checker configured for issue regression tests."""
+    return EquivalenceChecker(
+        threshold=1e-13,
+        fidelity=1 - 1e-13,
+        representation=representation,
+    )
+
+
+def test_issue_qasm_self_equivalence_with_final_measurements() -> None:
+    """The exact issue QASM circuit with custom gates and final measurements is self-equivalent."""
+    qc = loads(ISSUE_QASM_WITH_MEASURES)
+    result = _issue_checker(representation="mpo").check(qc, qc)
+    assert result["equivalent"] is True
+    assert result["representation"] == "mpo"
+
+
+def test_issue_qasm_custom_vs_expanded_equivalence() -> None:
+    """QASM custom gates should be equivalent to their manually expanded decomposition."""
+    qc_custom = loads(ISSUE_QASM_CUSTOM)
+    qc_expanded = loads(ISSUE_QASM_EXPANDED)
+    result = _issue_checker(representation="mpo").check(qc_custom, qc_expanded)
+    assert result["equivalent"] is True
+    assert result["representation"] == "mpo"
+
+
+@pytest.mark.parametrize("gate_name", ["u1", "u3", "ecr"])
+def test_u1_u3_ecr_self_equivalence(gate_name: str) -> None:
+    """Legacy Qiskit gate names from the issue should self-equivalence-check on the MPO path."""
+    if gate_name == "u1":
+        qc = QuantumCircuit(2)
+        qc.append(U1Gate(0.37), [0])
+    elif gate_name == "u3":
+        qc = QuantumCircuit(2)
+        qc.append(U3Gate(0.2, 0.3, 0.4), [0])
+    else:
+        qc = QuantumCircuit(2)
+        qc.append(ECRGate(), [0, 1])
+
+    result = _issue_checker(representation="mpo").check(qc, qc)
+    assert result["equivalent"] is True
+    assert result["representation"] == "mpo"
+
+
+def test_ecr_has_no_hardcoded_gate_library_path() -> None:
+    """``ecr`` must not use a hardcoded GateLibrary entry and should translate via matrix fallback."""
+    assert "ecr" not in SUPPORTED_QISKIT_GATE_NAMES
+    assert not hasattr(GateLibrary, "ecr")
+
+    qc = QuantumCircuit(2)
+    qc.append(ECRGate(), [0, 1])
+    gates = convert_dag_to_tensor_algorithm(circuit_to_dag(qc))
+    assert len(gates) == 1
+    assert gates[0].name == "ecr"
+
+
+def test_equivalence_checker_rejects_mid_circuit_measurements() -> None:
+    """Mid-circuit measurements must be rejected clearly by the equivalence checker."""
+    qc1 = QuantumCircuit(2, 1)
+    qc1.x(0)
+    qc1.measure(0, 0)
+    qc1.x(0)
+
+    qc2 = QuantumCircuit(2, 1)
+    qc2.x(0)
+    qc2.measure(0, 0)
+    qc2.x(0)
+
+    with pytest.raises(ValueError, match="Mid-circuit measurements are not supported"):
+        _issue_checker(representation="mpo").check(qc1, qc2)
 
 
 @pytest.mark.parametrize("representation", ["matrix", "mpo"])

--- a/tests/test_equivalence_checker.py
+++ b/tests/test_equivalence_checker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -26,6 +27,7 @@ from qiskit.qasm2 import load, loads
 
 from mqt.yaqs import DEFAULT_MATRIX_MAX_QUBITS, EquivalenceChecker
 from mqt.yaqs.core.libraries.gate_library import GateLibrary
+from mqt.yaqs.digital.utils import matrix_utils
 from mqt.yaqs.digital.utils.contraction_utils import MIN_QUBITS_FOR_MPO_PARALLEL
 from mqt.yaqs.digital.utils.dag_utils import SUPPORTED_QISKIT_GATE_NAMES, convert_dag_to_tensor_algorithm
 
@@ -287,6 +289,22 @@ def test_equivalence_checker_rejects_mid_circuit_measurements() -> None:
 
     with pytest.raises(ValueError, match="Mid-circuit measurements are not supported"):
         _issue_checker(representation="mpo").check(qc1, qc2)
+    with pytest.raises(ValueError, match="Mid-circuit measurements are not supported"):
+        _issue_checker(representation="matrix").check(qc1, qc2)
+
+
+def test_equivalence_checker_matrix_backend_strips_measurements_once() -> None:
+    """The matrix backend should strip final measurements only inside ``compose_operator_tensor``."""
+    qc1 = QuantumCircuit(1, 1)
+    qc1.x(0)
+    qc1.measure(0, 0)
+    qc2 = qc1.copy()
+
+    with patch.object(matrix_utils, "strip_final_measurements", wraps=matrix_utils.strip_final_measurements) as strip:
+        result = _issue_checker(representation="matrix").check(qc1, qc2)
+
+    assert result["equivalent"] is True
+    assert strip.call_count == 2
 
 
 @pytest.mark.parametrize("representation", ["matrix", "mpo"])


### PR DESCRIPTION
## Description

This PR extends the gates allowed in YAQS to the majority available within qiskit. If a gate is not known, but has a matrix representation in qiskit, then this is used as a fallback as a custom gate.

Users can also supply their own generator if using the digital TDVP path.

Documentation has been added to show how to properly create custom gates and explain the internal process between user input and how YAQS converts this to the tensor level.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
