### PR TITLE
extended get_state functionality to Lindblad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- extended get_state functionality to Lindblad ([#475]) ([**@aaronleesander**])
 - extended EquivalenceChecker output to include entropy and the resulting diff data structure ([#364]) ([**@yiranwang-phys**])
 - OpenQASM2 and 3 files can now be read directly by the Simulator and EquivalenceChecker ([#464]) ([**@Marerido**])
 - improved Qiskit gate compatibility with matrix fallback ([#464]) ([**@aaronleesander**])
@@ -139,6 +140,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#475]: https://github.com/munich-quantum-toolkit/yaqs/pull/475
 [#467]: https://github.com/munich-quantum-toolkit/yaqs/pull/467
 [#465]: https://github.com/munich-quantum-toolkit/yaqs/pull/465
 [#396]: https://github.com/munich-quantum-toolkit/yaqs/pull/396

--- a/docs/examples/simulator_initialization.md
+++ b/docs/examples/simulator_initialization.md
@@ -253,7 +253,7 @@ The properties that don't apply to your simulation kind return `None` (or an emp
 | `max_bond`                               | MPS-backed analog and strong digital runs (maximum bond dimension over time).       |
 | `total_bond`                             | MPS-backed analog and strong digital runs (sum of internal bond dimensions).        |
 | `noise_model`                            | Any run that was given a `NoiseModel`; otherwise `None`.                            |
-| `output_state`                           | Runs with `get_state=True` on `AnalogSimParams` or `StrongSimParams` (no noise).    |
+| `output_state`                           | Runs with `get_state=True` on `AnalogSimParams` or `StrongSimParams`. For Lindblad (`density_matrix`), noisy runs are supported; for `mps`/`vector`, noiseless only. |
 | `multi_time_times`, `multi_time_results` | Analog deterministic ensembles with `multi_time_observables` set.                   |
 | `counts`                                 | Weak digital simulations (the `dict[int, int]` of aggregated measurement outcomes). |
 

--- a/docs/examples/simulator_initialization.md
+++ b/docs/examples/simulator_initialization.md
@@ -243,19 +243,19 @@ print("total_bond:           ", result.total_bond)
 
 The properties that don't apply to your simulation kind return `None` (or an empty list for `observables` in weak simulations), so you can branch on them safely. The full set is:
 
-| Property                                 | Populated for                                                                       |
-| ---------------------------------------- | ----------------------------------------------------------------------------------- |
-| `observables`                            | Analog and strong digital runs. Empty list for weak digital.                        |
-| `expectation_values`                     | Aggregated expectation per observable (parallel to `observables`).                  |
-| `trajectories`                           | Per-trajectory data per observable (parallel to `observables`).                     |
-| `times`                                  | Shared analog time grid; `None` for digital circuits.                               |
-| `runtime_cost`                           | MPS-backed analog and strong digital runs (contraction-cost heuristic over time).   |
-| `max_bond`                               | MPS-backed analog and strong digital runs (maximum bond dimension over time).       |
-| `total_bond`                             | MPS-backed analog and strong digital runs (sum of internal bond dimensions).        |
-| `noise_model`                            | Any run that was given a `NoiseModel`; otherwise `None`.                            |
+| Property                                 | Populated for                                                                                                                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `observables`                            | Analog and strong digital runs. Empty list for weak digital.                                                                                                         |
+| `expectation_values`                     | Aggregated expectation per observable (parallel to `observables`).                                                                                                   |
+| `trajectories`                           | Per-trajectory data per observable (parallel to `observables`).                                                                                                      |
+| `times`                                  | Shared analog time grid; `None` for digital circuits.                                                                                                                |
+| `runtime_cost`                           | MPS-backed analog and strong digital runs (contraction-cost heuristic over time).                                                                                    |
+| `max_bond`                               | MPS-backed analog and strong digital runs (maximum bond dimension over time).                                                                                        |
+| `total_bond`                             | MPS-backed analog and strong digital runs (sum of internal bond dimensions).                                                                                         |
+| `noise_model`                            | Any run that was given a `NoiseModel`; otherwise `None`.                                                                                                             |
 | `output_state`                           | Runs with `get_state=True` on `AnalogSimParams` or `StrongSimParams`. For Lindblad (`density_matrix`), noisy runs are supported; for `mps`/`vector`, noiseless only. |
-| `multi_time_times`, `multi_time_results` | Analog deterministic ensembles with `multi_time_observables` set.                   |
-| `counts`                                 | Weak digital simulations (the `dict[int, int]` of aggregated measurement outcomes). |
+| `multi_time_times`, `multi_time_results` | Analog deterministic ensembles with `multi_time_observables` set.                                                                                                    |
+| `counts`                                 | Weak digital simulations (the `dict[int, int]` of aggregated measurement outcomes).                                                                                  |
 
 `Result` (and its wrapped `sim_params`) is pickleable, so you can checkpoint and resume analysis from disk:
 

--- a/docs/examples/state_initialization.md
+++ b/docs/examples/state_initialization.md
@@ -197,7 +197,7 @@ print("From vector=, MCWF Z_0:", result.expectation_values[0][-1])
 - **Entangled presets**: `"haar-random"` may need an internal MPS for dense representations.
 - **Circuits**: use `State(..., representation="mps")` (default); `vector=` / `density_matrix=` states cannot run circuits.
 - **Ensemble runs**: `list[State]` for deterministic unitary ensembles requires each member with `representation="mps"`.
-- **`get_state`**: when supported, `result.output_state` is a [`State`](mqt.yaqs.core.data_structures.state.State) (use `.mps` for the underlying MPS). Not supported with `representation="density_matrix"` or with stochastic noise.
+- **`get_state`**: when supported, `result.output_state` is a [`State`](mqt.yaqs.core.data_structures.state.State). Use `.mps` for MPS runs, `.vector` for MCWF, or `.density_matrix` for Lindblad. Not supported with stochastic noise on `mps` or `vector` representations (use `density_matrix` for the exact ensemble average).
 
 For MPO/TJM details without `State`, see {doc}`analog_simulation` and the [`MPS`](mqt.yaqs.core.data_structures.mps.MPS) API reference.
 

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -273,14 +273,15 @@ def _measure_rho(
             obs_results[i, t_idx] = 0.0
 
 
-def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
+def _evolve_with_propagator(ctx: LindbladContext) -> tuple[NDArray[np.float64], NDArray[np.complex128]]:
     """Evolve rho on the fixed grid ``sim_params.times`` via vec(rho) <- exp(L dt) vec(rho).
 
     Matches the user ``dt`` step used elsewhere in YAQS (not adaptive substeps).
     Noiseless runs use the same map but without separate dissipator terms in L.
 
     Returns:
-        Observable expectation values at each sampled time.
+        Observable expectation values at each sampled time and the final flattened
+        ``vec(rho)`` at ``sim_params.elapsed_time``.
     """
     sim_params = ctx.sim_params
     dim = ctx.dim
@@ -303,17 +304,18 @@ def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
     if not sim_params.sample_timesteps:
         _measure_rho(rho_vec, dim, ctx, obs_results, 0)
 
-    return obs_results
+    return obs_results, rho_vec
 
 
-def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
+def _evolve_with_ode(ctx: LindbladContext) -> tuple[NDArray[np.float64], NDArray[np.complex128]]:
     """Adaptive RK45 integration when ``vec(rho)`` is too large to store ``exp(L dt)``.
 
     Uses the same ``_lindblad_rhs_flat`` as the propagator path; tolerances come from
     ``sim_params.svd_threshold``.
 
     Returns:
-        Observable expectation values at each sampled time.
+        Observable expectation values at each sampled time and the final flattened
+        ``vec(rho)`` at ``sim_params.elapsed_time``.
 
     Raises:
         RuntimeError: If the ODE integration fails.
@@ -357,22 +359,27 @@ def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
         obs_results = np.zeros((num_obs, 1), dtype=np.float64)
         _measure_rho(result.y.T[-1], dim, ctx, obs_results, 0)
 
-    return obs_results
+    rho_vec = result.y.T[-1]
+    return obs_results, rho_vec
 
 
-def lindblad_evolve(ctx: LindbladContext) -> tuple[NDArray[np.float64], None, None]:
+def lindblad_evolve(ctx: LindbladContext) -> tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
     """Evolve a preprocessed Lindblad context and return observable trajectories.
 
     Returns:
-        tuple[NDArray[np.float64], None, None]: Observable data, no diagnostics, no final state.
+        tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]: Observable data,
+        no diagnostics, and optional final density matrix when ``get_state`` is set.
     """
-    obs = _evolve_with_propagator(ctx) if ctx.step_propagator is not None else _evolve_with_ode(ctx)
+    obs, rho_vec = _evolve_with_propagator(ctx) if ctx.step_propagator is not None else _evolve_with_ode(ctx)
+    if ctx.sim_params.get_state:
+        rho_mat = rho_vec.reshape((ctx.dim, ctx.dim), order="F")
+        return obs, None, rho_mat
     return obs, None, None
 
 
 def lindblad(
     args: tuple[int, MPS, NoiseModel | None, AnalogSimParams, MPO],
-) -> tuple[NDArray[np.float64], None, None]:
+) -> tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
     """Run an exact Lindblad master-equation simulation.
 
     Args:
@@ -384,9 +391,9 @@ def lindblad(
             - MPO: The Hamiltonian.
 
     Returns:
-        tuple[NDArray[np.float64], None, None]: Observable data, no diagnostics, no final state.
+        tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]: Observable data,
+        no diagnostics, and optional final density matrix when ``get_state`` is set.
     """
     _i, initial_state, noise_model, sim_params, hamiltonian = args
     ctx = preprocess_lindblad(initial_state, hamiltonian, noise_model, sim_params)
-    obs_results, _, _ = lindblad_evolve(ctx)
-    return obs_results, None, None
+    return lindblad_evolve(ctx)

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -134,11 +134,11 @@ def preprocess_lindblad(
             raise ValueError(msg)
         if not np.isclose(trace, 1.0):
             rho_mat /= trace
-        rho_vec = rho_mat.flatten(order="F")
+        rho_vec = np.asarray(rho_mat.flatten(order="F"), dtype=np.complex128)
     else:
         assert initial_state is not None
         psi = initial_state.to_vec()
-        rho_vec = np.outer(psi, psi.conj()).flatten(order="F")
+        rho_vec = np.asarray(np.outer(psi, psi.conj()).flatten(order="F"), dtype=np.complex128)
 
     # 2. Hamiltonian as sparse matrix on the full Hilbert space.
     if h_sparse is not None:

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -273,15 +273,69 @@ def _measure_rho(
             obs_results[i, t_idx] = 0.0
 
 
-def _evolve_with_propagator(ctx: LindbladContext) -> tuple[NDArray[np.float64], NDArray[np.complex128]]:
+def _rho_vec_at_elapsed_time(ctx: LindbladContext) -> NDArray[np.complex128]:
+    """Evolve ``vec(rho)`` to ``sim_params.elapsed_time`` (not ``times[-1]``).
+
+    Args:
+        ctx: Preprocessed Lindblad context.
+
+    Returns:
+        Flattened density matrix at ``sim_params.elapsed_time``.
+
+    Raises:
+        RuntimeError: If the ODE integration fails on the large-system fallback path.
+    """
+    sim_params = ctx.sim_params
+    dim = ctx.dim
+    target_t = sim_params.elapsed_time
+    if target_t <= 0.0:
+        return ctx.rho_initial.copy()
+
+    dt = sim_params.dt
+    n_full = int(target_t // dt)
+    remainder = target_t - n_full * dt
+
+    if ctx.step_propagator is not None:
+        rho_vec = ctx.rho_initial.copy()
+        for _ in range(n_full):
+            rho_vec = ctx.step_propagator @ rho_vec
+        if remainder > 1e-12:
+            liouvillian = _build_liouvillian_superoperator(dim, ctx.h_mat, ctx.jump_ops, ctx.l_dag_l_sum)
+            rho_vec = linalg.expm(liouvillian * remainder) @ rho_vec
+        return rho_vec
+
+    def lindblad_rhs(_t: float, rho_flat: NDArray[np.complex128]) -> NDArray[np.complex128]:
+        return _lindblad_rhs_flat(rho_flat, dim, ctx.h_mat, ctx.jump_ops, ctx.l_dag_l_sum)
+
+    result = solve_ivp(
+        lindblad_rhs,
+        (0.0, target_t),
+        ctx.rho_initial,
+        t_eval=[target_t],
+        method="RK45",
+        rtol=sim_params.svd_threshold,
+        atol=sim_params.svd_threshold * 1e-2,
+    )
+    if not result.success:
+        msg = (
+            f"Lindblad integration to elapsed_time={target_t} failed: {result.message} "
+            f"(rtol={sim_params.svd_threshold}, atol={sim_params.svd_threshold * 1e-2})"
+        )
+        raise RuntimeError(msg)
+    return result.y.T[0]
+
+
+def _evolve_with_propagator(ctx: LindbladContext) -> NDArray[np.float64]:
     """Evolve rho on the fixed grid ``sim_params.times`` via vec(rho) <- exp(L dt) vec(rho).
 
     Matches the user ``dt`` step used elsewhere in YAQS (not adaptive substeps).
     Noiseless runs use the same map but without separate dissipator terms in L.
 
+    Args:
+        ctx: Preprocessed Lindblad context.
+
     Returns:
-        Observable expectation values at each sampled time and the final flattened
-        ``vec(rho)`` at ``sim_params.elapsed_time``.
+        Observable expectation values at each sampled time on ``sim_params.times``.
     """
     sim_params = ctx.sim_params
     dim = ctx.dim
@@ -304,18 +358,20 @@ def _evolve_with_propagator(ctx: LindbladContext) -> tuple[NDArray[np.float64], 
     if not sim_params.sample_timesteps:
         _measure_rho(rho_vec, dim, ctx, obs_results, 0)
 
-    return obs_results, rho_vec
+    return obs_results
 
 
-def _evolve_with_ode(ctx: LindbladContext) -> tuple[NDArray[np.float64], NDArray[np.complex128]]:
+def _evolve_with_ode(ctx: LindbladContext) -> NDArray[np.float64]:
     """Adaptive RK45 integration when ``vec(rho)`` is too large to store ``exp(L dt)``.
 
     Uses the same ``_lindblad_rhs_flat`` as the propagator path; tolerances come from
     ``sim_params.svd_threshold``.
 
+    Args:
+        ctx: Preprocessed Lindblad context.
+
     Returns:
-        Observable expectation values at each sampled time and the final flattened
-        ``vec(rho)`` at ``sim_params.elapsed_time``.
+        Observable expectation values at each sampled time on ``sim_params.times``.
 
     Raises:
         RuntimeError: If the ODE integration fails.
@@ -359,19 +415,23 @@ def _evolve_with_ode(ctx: LindbladContext) -> tuple[NDArray[np.float64], NDArray
         obs_results = np.zeros((num_obs, 1), dtype=np.float64)
         _measure_rho(result.y.T[-1], dim, ctx, obs_results, 0)
 
-    rho_vec = result.y.T[-1]
-    return obs_results, rho_vec
+    return obs_results
 
 
 def lindblad_evolve(ctx: LindbladContext) -> tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
     """Evolve a preprocessed Lindblad context and return observable trajectories.
 
+    Args:
+        ctx: Preprocessed Lindblad context.
+
     Returns:
         tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]: Observable data,
-        no diagnostics, and optional final density matrix when ``get_state`` is set.
+        no diagnostics, and optional final density matrix at ``sim_params.elapsed_time``
+        when ``get_state`` is set.
     """
-    obs, rho_vec = _evolve_with_propagator(ctx) if ctx.step_propagator is not None else _evolve_with_ode(ctx)
+    obs = _evolve_with_propagator(ctx) if ctx.step_propagator is not None else _evolve_with_ode(ctx)
     if ctx.sim_params.get_state:
+        rho_vec = _rho_vec_at_elapsed_time(ctx)
         rho_mat = rho_vec.reshape((ctx.dim, ctx.dim), order="F")
         return obs, None, rho_mat
     return obs, None, None

--- a/src/mqt/yaqs/characterization/tomography/process_tensor.py
+++ b/src/mqt/yaqs/characterization/tomography/process_tensor.py
@@ -141,7 +141,7 @@ class ProcessTensor:
             # Multiply and sum out the last axis (axis -1) with c_maps[step]
             result_tensor = np.tensordot(result_tensor, c_maps[step], axes=([-1], [0]))
 
-        return result_tensor.reshape(2, 2)
+        return result_tensor.reshape(2, 2).astype(np.complex128)
 
     def quantum_mutual_information(self, base: int = 2) -> float:
         """Calculate the Quantum Mutual Information between the input sequence and the output state.

--- a/src/mqt/yaqs/characterization/tomography/tomography.py
+++ b/src/mqt/yaqs/characterization/tomography/tomography.py
@@ -88,7 +88,7 @@ def get_choi_basis() -> tuple[list[NDArray[np.complex128]], list[tuple[int, int]
     for p, (_, _, rho_p) in enumerate(basis_set):
         for m, (_, _, e_m) in enumerate(basis_set):
             b_pm = np.kron(rho_p, e_m.T)
-            choi_matrices.append(b_pm)
+            choi_matrices.append(np.asarray(b_pm, dtype=np.complex128))
             indices.append((p, m))
 
     return choi_matrices, indices
@@ -121,7 +121,7 @@ def calculate_dual_choi_basis(basis_matrices: list[NDArray[np.complex128]]) -> l
     dual_frame = dual_frame_dag.conj().T
 
     # Unpack columns of dual_frame into matrices
-    return [dual_frame[:, k].reshape(dim, dim) for k in range(dual_frame.shape[1])]
+    return [dual_frame[:, k].reshape(dim, dim).astype(np.complex128) for k in range(dual_frame.shape[1])]
 
 
 def _reprepare_site_zero_forced(
@@ -192,7 +192,7 @@ def _reprepare_site_zero_vector_forced(
         env_vec /= np.sqrt(prob)
 
     new_psi = np.outer(new_state, env_vec).flatten()
-    return new_psi, prob
+    return np.asarray(new_psi, dtype=np.complex128), prob
 
 
 def _reconstruct_state(expectations: dict[str, float]) -> NDArray[np.complex128]:
@@ -257,7 +257,7 @@ def _tomography_sequence_worker(job_idx: int) -> tuple[int, int, list[NDArray[np
     # We only need the final output state after all evolution steps
     def _get_rho_site_zero(state: MPS | NDArray[np.complex128]) -> NDArray[np.complex128]:
         if isinstance(state, np.ndarray):
-            rho = np.reshape(state, (2, -1))
+            rho = np.reshape(np.asarray(state, dtype=np.complex128), (2, -1))
             return rho @ rho.conj().T
         assert isinstance(state, MPS)
         trace = float(state.norm() ** 2)

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -18,14 +18,14 @@ import opt_einsum as oe
 from tqdm import tqdm
 
 from mqt.yaqs.parallel_utils import available_cpus, get_parallel_context, limit_worker_threads
-
-from .. import linalg
-from ..methods.decompositions import merge_two_site, right_qr, split_two_site
+from yaqs.core import linalg
+from yaqs.core.methods.decompositions import merge_two_site, right_qr, split_two_site
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from ..methods.decompositions import TruncMode
+    from yaqs.core.methods.decompositions import TruncMode
+
     from .simulation_parameters import AnalogSimParams, Observable, StrongSimParams
 
 # Worker-global state for parallel ``measure_shots`` (initialized once per process).
@@ -41,7 +41,14 @@ def _measure_shots_worker_init(mps: MPS, basis: str) -> None:
 
 
 def _measure_shots_worker(_shot_idx: int) -> int:
-    """Run a single measurement shot using the worker-global MPS context."""
+    """Run a single measurement shot using the worker-global MPS context.
+
+    Args:
+        _shot_idx: Unused shot index (required for executor compatibility).
+
+    Returns:
+        The measured basis state encoded as an integer.
+    """
     return _MEASURE_SHOTS_CTX["mps"].measure_single_shot(_MEASURE_SHOTS_CTX["basis"])
 
 
@@ -1284,7 +1291,7 @@ class MPS:
 
         # Normalize and update the site tensor
         self.tensors[site] = (1.0 / np.sqrt(probabilities[chosen_index])) * oe.contract(
-            "a, cd->acd", original_basis_selection, projected_rotated_tensor
+            "a, cd->acd", original_basis_selection, projected_rotated_tensor,
         )
 
         return int(chosen_index)

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -9,14 +9,15 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import copy
-import multiprocessing
-from typing import TYPE_CHECKING
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import opt_einsum as oe
 from tqdm import tqdm
+
+from mqt.yaqs.parallel_utils import available_cpus, get_parallel_context, limit_worker_threads
 
 from .. import linalg
 from ..methods.decompositions import merge_two_site, right_qr, split_two_site
@@ -26,6 +27,22 @@ if TYPE_CHECKING:
 
     from ..methods.decompositions import TruncMode
     from .simulation_parameters import AnalogSimParams, Observable, StrongSimParams
+
+# Worker-global state for parallel ``measure_shots`` (initialized once per process).
+_MEASURE_SHOTS_CTX: dict[str, Any] = {}
+
+
+def _measure_shots_worker_init(mps: MPS, basis: str) -> None:
+    """Initialize a measure-shots worker and cap numerical thread pools."""
+    limit_worker_threads(1)
+    _MEASURE_SHOTS_CTX.clear()
+    _MEASURE_SHOTS_CTX["mps"] = mps
+    _MEASURE_SHOTS_CTX["basis"] = basis
+
+
+def _measure_shots_worker(_shot_idx: int) -> int:
+    """Run a single measurement shot using the worker-global MPS context."""
+    return _MEASURE_SHOTS_CTX["mps"].measure_single_shot(_MEASURE_SHOTS_CTX["basis"])
 
 
 class MPS:
@@ -503,7 +520,7 @@ class MPS:
         theta = np.tensordot(a, b, axes=(2, 1))
         phys_i, left = a.shape[0], a.shape[1]
         phys_j, right = b.shape[0], b.shape[2]
-        theta_mat = theta.reshape(left * phys_i, phys_j * right)
+        theta_mat = theta.reshape(left * phys_i, phys_j * right).astype(np.complex128)
 
         s = linalg.svd(theta_mat, full_matrices=False, compute_uv=False)
         s2 = (s.astype(np.float64)) ** 2
@@ -545,7 +562,7 @@ class MPS:
         theta = np.tensordot(a, b, axes=(2, 1))
         phys_i, left = a.shape[0], a.shape[1]
         phys_j, right = b.shape[0], b.shape[2]
-        theta_mat = theta.reshape(left * phys_i, phys_j * right)
+        theta_mat = theta.reshape(left * phys_i, phys_j * right).astype(np.complex128)
 
         _, s_vec, _ = linalg.svd(theta_mat, full_matrices=False)
 
@@ -1153,20 +1170,53 @@ class MPS:
             - A progress bar (via tqdm) displays the progress of the measurement process.
         """
         results: dict[int, int] = {}
-        if shots > 1:
-            max_workers = max(1, multiprocessing.cpu_count() - 1)
-            with (
-                concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor,
-                tqdm(total=shots, desc="Measuring shots", ncols=80) as pbar,
-            ):
-                futures = [executor.submit(self.measure_single_shot, basis) for _ in range(shots)]
-                for future in concurrent.futures.as_completed(futures):
-                    result = future.result()
-                    results[result] = results.get(result, 0) + 1
+        if shots <= 1:
+            basis_state = self.measure_single_shot(basis)
+            results[basis_state] = results.get(basis_state, 0) + 1
+            return results
+
+        max_workers = max(1, min(max(1, available_cpus() - 1), shots))
+        if max_workers == 1:
+            with tqdm(total=shots, desc="Measuring shots", ncols=80) as pbar:
+                for _ in range(shots):
+                    outcome = self.measure_single_shot(basis)
+                    results[outcome] = results.get(outcome, 0) + 1
                     pbar.update(1)
             return results
-        basis_state = self.measure_single_shot(basis)
-        results[basis_state] = results.get(basis_state, 0) + 1
+
+        ctx = get_parallel_context("auto")
+        inflight_factor = 2
+        max_inflight = max_workers * inflight_factor
+
+        with (
+            ProcessPoolExecutor(
+                max_workers=max_workers,
+                mp_context=ctx,
+                initializer=_measure_shots_worker_init,
+                initargs=(self, basis),
+            ) as executor,
+            tqdm(total=shots, desc="Measuring shots", ncols=80) as pbar,
+        ):
+            futures: dict[Future[int], None] = {}
+            next_shot = 0
+
+            def submit_shot(idx: int) -> None:
+                futures[executor.submit(_measure_shots_worker, idx)] = None
+
+            while next_shot < shots and len(futures) < max_inflight:
+                submit_shot(next_shot)
+                next_shot += 1
+
+            while futures:
+                done, _ = wait(futures, return_when=FIRST_COMPLETED)
+                for fut in done:
+                    futures.pop(fut)
+                    outcome = fut.result()
+                    results[outcome] = results.get(outcome, 0) + 1
+                    pbar.update(1)
+                    if next_shot < shots:
+                        submit_shot(next_shot)
+                        next_shot += 1
         return results
 
     def measure(self, site: int, basis: str = "Z", rng: np.random.Generator | None = None) -> int:

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -18,13 +18,14 @@ import opt_einsum as oe
 from tqdm import tqdm
 
 from mqt.yaqs.parallel_utils import available_cpus, get_parallel_context, limit_worker_threads
-from yaqs.core import linalg
-from yaqs.core.methods.decompositions import merge_two_site, right_qr, split_two_site
+
+from .. import linalg
+from ..methods.decompositions import merge_two_site, right_qr, split_two_site
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from yaqs.core.methods.decompositions import TruncMode
+    from ..methods.decompositions import TruncMode
 
     from .simulation_parameters import AnalogSimParams, Observable, StrongSimParams
 

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from ..methods.decompositions import TruncMode
-
     from .simulation_parameters import AnalogSimParams, Observable, StrongSimParams
 
 # Worker-global state for parallel ``measure_shots`` (initialized once per process).

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -1291,7 +1291,9 @@ class MPS:
 
         # Normalize and update the site tensor
         self.tensors[site] = (1.0 / np.sqrt(probabilities[chosen_index])) * oe.contract(
-            "a, cd->acd", original_basis_selection, projected_rotated_tensor,
+            "a, cd->acd",
+            original_basis_selection,
+            projected_rotated_tensor,
         )
 
         return int(chosen_index)

--- a/src/mqt/yaqs/core/data_structures/result.py
+++ b/src/mqt/yaqs/core/data_structures/result.py
@@ -59,7 +59,7 @@ def allocate_observable_buffers(
 
     if isinstance(sim_params, AnalogSimParams):
         if sim_params.sample_timesteps:
-            times = sim_params.times
+            times = np.asarray(sim_params.times, dtype=np.float64)
             for _ in range(num_observables):
                 trajectories.append(np.empty((num_traj, len(sim_params.times)), dtype=np.float64))
                 expectation_values.append(np.empty(len(sim_params.times), dtype=np.float64))

--- a/src/mqt/yaqs/core/data_structures/state.py
+++ b/src/mqt/yaqs/core/data_structures/state.py
@@ -309,17 +309,17 @@ class State:
             elif self._vector is not None:
                 vec = normalize_vector(self._vector)
                 dim = vec.size
-                self._density_matrix = np.outer(vec, vec.conj()).reshape(dim, dim)
+                self._density_matrix = np.asarray(np.outer(vec, vec.conj()).reshape(dim, dim), dtype=np.complex128)
             elif self._can_build_dense_from_preset():
                 vec = self._dense_vector_from_preset()
                 self._vector = vec
                 dim = vec.size
-                self._density_matrix = np.outer(vec, vec.conj()).reshape(dim, dim)
+                self._density_matrix = np.asarray(np.outer(vec, vec.conj()).reshape(dim, dim), dtype=np.complex128)
             else:
                 mps = self._build_mps()
                 vec = normalize_vector(mps.to_vec())
                 dim = vec.size
-                self._density_matrix = np.outer(vec, vec.conj()).reshape(dim, dim)
+                self._density_matrix = np.asarray(np.outer(vec, vec.conj()).reshape(dim, dim), dtype=np.complex128)
         else:
             msg = f"Unknown representation: {rep!r}"
             raise ValueError(msg)

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -598,7 +598,7 @@ class BaseGate:
 
     @property
     def mpo_tensors(self) -> list[NDArray[np.complex128]]:
-        """Returns a list of MPO tensors representing the gate.
+        """List of MPO tensors representing the gate.
 
         Raises:
             AttributeError: If the gate does not have MPO tensors defined.

--- a/src/mqt/yaqs/core/methods/bug.py
+++ b/src/mqt/yaqs/core/methods/bug.py
@@ -58,7 +58,7 @@ def prepare_canonical_site_tensors(
         # Leg order of local_tensor: (left, phys, right)
         local_tensor = local_tensor.transpose(1, 0, 2)
         # Correct leg order: (phys, left, right) and orth center
-        canon_tensors[i] = local_tensor
+        canon_tensors[i] = np.asarray(local_tensor, dtype=np.complex128)
         new_env = update_left_environment(left_q, left_q, mpo.tensors[i - 1], left_blocks[i - 1])
         left_blocks.append(new_env)
     return canon_tensors, left_blocks
@@ -126,7 +126,7 @@ def build_basis_change_tensor(
 
     """
     new_m = np.tensordot(old_q, old_m, axes=(2, 0))
-    return np.tensordot(new_m, new_q.conj(), axes=([0, 2], [0, 2]))
+    return np.asarray(np.tensordot(new_m, new_q.conj(), axes=([0, 2], [0, 2])), dtype=np.complex128)
 
 
 def local_update(
@@ -171,7 +171,10 @@ def local_update(
     old_q = state.tensors[site]
     basis_change_m = build_basis_change_tensor(old_q, new_q, right_m_block)
     state.tensors[site] = new_q
-    canon_center_tensors[site - 1] = np.tensordot(canon_center_tensors[site - 1], basis_change_m, axes=(2, 0))
+    canon_center_tensors[site - 1] = np.asarray(
+        np.tensordot(canon_center_tensors[site - 1], basis_change_m, axes=(2, 0)),
+        dtype=np.complex128,
+    )
     new_right_block = update_right_environment(new_q, new_q, mpo.tensors[site], right_block)
     return basis_change_m, new_right_block
 

--- a/src/mqt/yaqs/core/methods/bug.py
+++ b/src/mqt/yaqs/core/methods/bug.py
@@ -49,7 +49,9 @@ def prepare_canonical_site_tensors(
     # This will merely do a shallow copy of the MPS.
     canon_tensors = copy(state.tensors)
     left_end_dimension = state.tensors[0].shape[1]
-    left_blocks = [np.eye(left_end_dimension, dtype=np.complex128).reshape(left_end_dimension, 1, left_end_dimension)]
+    left_blocks: list[NDArray[np.complex128]] = [
+        np.eye(left_end_dimension, dtype=np.complex128).reshape(left_end_dimension, 1, left_end_dimension)
+    ]
     for i, old_local_tensor in enumerate(canon_tensors[1:], start=1):
         left_tensor = canon_tensors[i - 1]
         left_q, left_r = right_qr(left_tensor)

--- a/src/mqt/yaqs/core/methods/tdvp/primitives.py
+++ b/src/mqt/yaqs/core/methods/tdvp/primitives.py
@@ -105,7 +105,7 @@ def update_right_environment(
     tensor = np.tensordot(ket, right_env, axes=1)
     tensor = np.tensordot(op, tensor, axes=((1, 3), (0, 2)))
     tensor = tensor.transpose((2, 1, 0, 3))
-    return np.tensordot(tensor, bra.conj(), axes=((2, 3), (0, 2)))
+    return np.asarray(np.tensordot(tensor, bra.conj(), axes=((2, 3), (0, 2))), dtype=np.complex128)
 
 
 def update_left_environment(
@@ -133,7 +133,7 @@ def update_left_environment(
     """
     tensor = np.tensordot(left_env, bra.conj(), axes=(2, 1))
     tensor = np.tensordot(op, tensor, axes=((0, 2), (2, 1)))
-    return np.tensordot(ket, tensor, axes=((0, 1), (0, 2)))
+    return np.asarray(np.tensordot(ket, tensor, axes=((0, 1), (0, 2))), dtype=np.complex128)
 
 
 def initialize_right_environments(psi: MPS, op: MPO) -> list[NDArray[np.complex128]]:
@@ -223,7 +223,7 @@ def project_bond(
 
     """
     tensor = np.tensordot(bond_tensor, right_env, axes=1)
-    return np.tensordot(left_env, tensor, axes=((0, 1), (0, 1)))
+    return np.asarray(np.tensordot(left_env, tensor, axes=((0, 1), (0, 1))), dtype=np.complex128)
 
 
 # --- Dense effective operator ---

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -238,8 +238,12 @@ def _mcwf_worker(traj_idx: int) -> tuple[NDArray[np.float64], None, np.ndarray |
 def _lindblad_ctx_worker(_traj_idx: int) -> tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
     """Execute Lindblad evolution from a preprocessed context in `WORKER_CTX`.
 
+    Args:
+        _traj_idx: Trajectory index (unused; Lindblad evolution is deterministic in rho).
+
     Returns:
-        Observable expectation values over time and optional final density matrix.
+        tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
+            Observable expectation values over time and optional final density matrix.
     """
     return lindblad_evolve(WORKER_CTX["ctx"])
 
@@ -425,9 +429,30 @@ def _store_mcwf_final_state(result: Result, psi: np.ndarray | None) -> None:
         result.output_state = State(vector=psi)
 
 
-def _store_lindblad_final_state(result: Result, rho: np.ndarray | None) -> None:
+def _store_lindblad_final_state(
+    result: Result,
+    rho: np.ndarray | None,
+    *,
+    length: int,
+    physical_dimensions: list[int] | int | None,
+) -> None:
+    """Store the final Lindblad density matrix on ``result.output_state``.
+
+    Args:
+        result: Output container for the simulation run.
+        rho: Final density matrix, or ``None`` when ``get_state`` is ``False``.
+        length: Number of lattice sites from the initial state.
+        physical_dimensions: Per-site physical dimensions from the initial state.
+
+    Returns:
+        None. Mutates ``result.output_state`` when ``rho`` is not ``None``.
+    """
     if rho is not None:
-        result.output_state = State(density_matrix=rho)
+        result.output_state = State(
+            density_matrix=rho,
+            length=length,
+            physical_dimensions=physical_dimensions,
+        )
 
 
 def _expect_shot_counts(payload: NDArray[np.float64] | dict[int, int]) -> dict[int, int]:
@@ -903,7 +928,12 @@ class Simulator:
         if state_rep == "vector":
             _store_mcwf_final_state(result, final_psi)
         elif state_rep == "density_matrix":
-            _store_lindblad_final_state(result, final_rho)
+            _store_lindblad_final_state(
+                result,
+                final_rho,
+                length=initial_state.length,
+                physical_dimensions=initial_state.physical_dimensions,
+            )
         else:
             _store_final_mps(result, final_mps)
 

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -1257,10 +1257,9 @@ class Simulator:
         multi_time_matrix: NDArray[np.complex128] | None = None
         if n_pairs > 0:
             multi_time_matrix = np.zeros((len(initial_states), n_pairs, n_cols), dtype=np.complex128)
-            result.multi_time_times = (
-                sim_params.times
-                if sim_params.sample_timesteps
-                else np.array([sim_params.elapsed_time], dtype=np.float64)
+            result.multi_time_times = np.asarray(
+                sim_params.times if sim_params.sample_timesteps else [sim_params.elapsed_time],
+                dtype=np.float64,
             )
 
         payload: dict[str, Any] = {

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -443,9 +443,6 @@ def _store_lindblad_final_state(
         rho: Final density matrix, or ``None`` when ``get_state`` is ``False``.
         length: Number of lattice sites from the initial state.
         physical_dimensions: Per-site physical dimensions from the initial state.
-
-    Returns:
-        None. Mutates ``result.output_state`` when ``rho`` is not ``None``.
     """
     if rho is not None:
         result.output_state = State(

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -235,11 +235,11 @@ def _mcwf_worker(traj_idx: int) -> tuple[NDArray[np.float64], None, np.ndarray |
     return mcwf((traj_idx, WORKER_CTX["ctx"]))
 
 
-def _lindblad_ctx_worker(_traj_idx: int) -> tuple[NDArray[np.float64], None, None]:
+def _lindblad_ctx_worker(_traj_idx: int) -> tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
     """Execute Lindblad evolution from a preprocessed context in `WORKER_CTX`.
 
     Returns:
-        Observable expectation values over time for one trajectory.
+        Observable expectation values over time and optional final density matrix.
     """
     return lindblad_evolve(WORKER_CTX["ctx"])
 
@@ -423,6 +423,11 @@ def _store_final_mps(result: Result, final_mps: MPS | None) -> None:
 def _store_mcwf_final_state(result: Result, psi: np.ndarray | None) -> None:
     if psi is not None:
         result.output_state = State(vector=psi)
+
+
+def _store_lindblad_final_state(result: Result, rho: np.ndarray | None) -> None:
+    if rho is not None:
+        result.output_state = State(density_matrix=rho)
 
 
 def _expect_shot_counts(payload: NDArray[np.float64] | dict[int, int]) -> dict[int, int]:
@@ -745,9 +750,10 @@ class Simulator:
             result: Output container populated during this run.
 
         Raises:
-            ValueError: If ``get_state=True`` with ``State.representation='density_matrix'``,
-                or if ``get_state=True`` is combined with a non-trivial noise model
-                (the trajectory ensemble has no single representative state).
+            ValueError: If ``get_state=True`` is combined with a non-trivial noise model
+                on ``mps`` or ``vector`` representations (the trajectory ensemble has no
+                single representative state). Lindblad ``density_matrix`` evolution always
+                returns the exact ensemble-averaged state when ``get_state=True``.
         """
         if isinstance(initial_state, list):
             initial_state_list = cast("list[State]", initial_state)
@@ -782,10 +788,6 @@ class Simulator:
             backend = analog_tjm_1
         else:
             backend = analog_tjm_2
-
-        if state_rep == "density_matrix" and sim_params.get_state:
-            msg = "get_state=True is not supported for State.representation='density_matrix'."
-            raise ValueError(msg)
 
         if (
             noise_model is None
@@ -847,6 +849,7 @@ class Simulator:
 
         final_mps: MPS | None = None
         final_psi: np.ndarray | None = None
+        final_rho: np.ndarray | None = None
 
         if self.parallel and effective_num_traj > 1:
             for i, traj_payload in run_backend_parallel(
@@ -867,6 +870,8 @@ class Simulator:
                 if traj_final is not None:
                     if state_rep == "vector":
                         final_psi = cast("np.ndarray", traj_final)
+                    elif state_rep == "density_matrix":
+                        final_rho = cast("np.ndarray", traj_final)
                     else:
                         final_mps = cast("MPS", traj_final)
         else:
@@ -890,11 +895,15 @@ class Simulator:
                 if traj_final is not None:
                     if state_rep == "vector":
                         final_psi = cast("np.ndarray", traj_final)
+                    elif state_rep == "density_matrix":
+                        final_rho = cast("np.ndarray", traj_final)
                     else:
                         final_mps = cast("MPS", traj_final)
 
         if state_rep == "vector":
             _store_mcwf_final_state(result, final_psi)
+        elif state_rep == "density_matrix":
+            _store_lindblad_final_state(result, final_rho)
         else:
             _store_final_mps(result, final_mps)
 

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -9,8 +9,9 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import pytest
 
 import mqt.yaqs.analog.lindblad as lindblad_mod
 from mqt.yaqs import (
@@ -30,6 +31,9 @@ from mqt.yaqs.analog.lindblad import (
 )
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.mps import MPS
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_lindblad_amplitude_damping() -> None:
@@ -363,7 +367,9 @@ def test_lindblad_evolve_get_state_false_returns_no_matrix() -> None:
     for i in range(len(h.tensors)):
         h.tensors[i] *= 0.0
     noise = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+        processes=[
+            {"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
+        ],
     )
     sim_params = AnalogSimParams(
         observables=[Observable("z", sites=[0])],
@@ -407,7 +413,9 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
     gamma = 1.0
     elapsed_time = 0.25
     noise = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+        processes=[
+            {"name": "destroy", "sites": [0], "strength": gamma, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
+        ],
     )
     sim_params = AnalogSimParams(
         observables=[Observable("z", sites=[0])],
@@ -441,7 +449,9 @@ def test_lindblad_entry_point_returns_density_matrix() -> None:
     for i in range(len(h.tensors)):
         h.tensors[i] *= 0.0
     noise = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+        processes=[
+            {"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
+        ],
     )
     sim_params = AnalogSimParams(
         observables=[Observable("z", sites=[0])],

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -336,6 +336,7 @@ def test_lindblad_ode_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
         elapsed_time=0.2,
         dt=0.05,
         sample_timesteps=True,
+        get_state=True,
     )
 
     ctx = preprocess_lindblad(psi, h, noise, sim_params)
@@ -348,3 +349,5 @@ def test_lindblad_ode_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     assert expectation is not None
     assert expectation.shape == (len(sim_params.times),)
     assert np.all(np.isfinite(expectation))
+    assert result.output_state is not None
+    assert result.output_state.density_matrix.shape == (4, 4)

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -9,9 +9,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
+import pytest
 
 import mqt.yaqs.analog.lindblad as lindblad_mod
 from mqt.yaqs import (
@@ -22,12 +21,15 @@ from mqt.yaqs import (
     Simulator,
     State,
 )
-from mqt.yaqs.analog.lindblad import MAX_LIOUVILLIAN_VECTOR_DIM, preprocess_lindblad
+from mqt.yaqs.analog.lindblad import (
+    MAX_LIOUVILLIAN_VECTOR_DIM,
+    _rho_vec_at_elapsed_time,
+    lindblad,
+    lindblad_evolve,
+    preprocess_lindblad,
+)
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.mps import MPS
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def test_lindblad_amplitude_damping() -> None:
@@ -351,3 +353,106 @@ def test_lindblad_ode_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     assert np.all(np.isfinite(expectation))
     assert result.output_state is not None
     assert result.output_state.density_matrix.shape == (4, 4)
+
+
+def test_lindblad_evolve_get_state_false_returns_no_matrix() -> None:
+    """``lindblad_evolve`` omits the density matrix unless ``get_state`` is requested."""
+    n_sites = 1
+    psi = MPS(n_sites, state="ones")
+    h = MPO.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    noise = NoiseModel(
+        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+    )
+    sim_params = AnalogSimParams(
+        observables=[Observable("z", sites=[0])],
+        elapsed_time=0.1,
+        dt=0.1,
+        get_state=False,
+        sample_timesteps=False,
+    )
+    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    obs, diag, rho = lindblad_evolve(ctx)
+    assert obs.shape == (1, 1)
+    assert diag is None
+    assert rho is None
+
+
+def test_rho_vec_at_elapsed_time_returns_initial_state_at_zero() -> None:
+    """``_rho_vec_at_elapsed_time`` returns the initial vector when ``elapsed_time`` is zero."""
+    n_sites = 1
+    psi = MPS(n_sites, state="ones")
+    h = MPO.identity(n_sites)
+    sim_params = AnalogSimParams(
+        observables=[Observable("z", sites=[0])],
+        elapsed_time=0.0,
+        dt=0.1,
+        get_state=True,
+    )
+    ctx = preprocess_lindblad(psi, h, None, sim_params)
+    rho_vec = _rho_vec_at_elapsed_time(ctx)
+    np.testing.assert_allclose(rho_vec, ctx.rho_initial)
+
+
+def test_rho_vec_at_elapsed_time_fractional_step() -> None:
+    """Fractional elapsed times use an extra ``expm(L * remainder)`` after full ``dt`` steps."""
+    n_sites = 1
+    initial_state = State(n_sites, initial="ones", representation="density_matrix")
+    psi = MPS(n_sites, state="ones")
+    h = MPO.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    hamiltonian = Hamiltonian.from_mpo(h)
+    gamma = 1.0
+    elapsed_time = 0.25
+    noise = NoiseModel(
+        processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+    )
+    sim_params = AnalogSimParams(
+        observables=[Observable("z", sites=[0])],
+        elapsed_time=elapsed_time,
+        dt=0.1,
+        get_state=True,
+    )
+    ctx = preprocess_lindblad(
+        psi,
+        hamiltonian.mpo,
+        noise,
+        sim_params,
+        rho_initial=initial_state.density_matrix,
+        num_sites=n_sites,
+    )
+    assert ctx.step_propagator is not None
+    rho_vec = _rho_vec_at_elapsed_time(ctx)
+    rho = rho_vec.reshape((2, 2), order="F")
+    expected = np.array(
+        [[1.0 - np.exp(-gamma * elapsed_time), 0.0], [0.0, np.exp(-gamma * elapsed_time)]],
+        dtype=np.complex128,
+    )
+    np.testing.assert_allclose(rho, expected, atol=1e-4)
+
+
+def test_lindblad_entry_point_returns_density_matrix() -> None:
+    """The ``lindblad`` worker entry point forwards ``get_state`` output."""
+    n_sites = 1
+    psi = MPS(n_sites, state="ones")
+    h = MPO.identity(n_sites)
+    for i in range(len(h.tensors)):
+        h.tensors[i] *= 0.0
+    noise = NoiseModel(
+        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+    )
+    sim_params = AnalogSimParams(
+        observables=[Observable("z", sites=[0])],
+        elapsed_time=0.2,
+        dt=0.1,
+        get_state=True,
+        sample_timesteps=False,
+    )
+    obs, diag, rho = lindblad((0, psi, noise, sim_params, h))
+    assert obs.shape == (1, 1)
+    assert diag is None
+    assert rho is not None
+    assert rho.shape == (2, 2)
+    assert np.isclose(np.trace(rho), 1.0)

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -7,10 +7,13 @@
 
 """Tests for the Exact Lindblad Solver."""
 
+# ruff: noqa: SLF001
+
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import pytest
 
 import mqt.yaqs.analog.lindblad as lindblad_mod
 from mqt.yaqs import (
@@ -23,13 +26,15 @@ from mqt.yaqs import (
 )
 from mqt.yaqs.analog.lindblad import (
     MAX_LIOUVILLIAN_VECTOR_DIM,
-    _rho_vec_at_elapsed_time,
     lindblad,
     lindblad_evolve,
     preprocess_lindblad,
 )
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.mps import MPS
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_lindblad_amplitude_damping() -> None:
@@ -363,7 +368,9 @@ def test_lindblad_evolve_get_state_false_returns_no_matrix() -> None:
     for i in range(len(h.tensors)):
         h.tensors[i] *= 0.0
     noise = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+        processes=[
+            {"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
+        ],
     )
     sim_params = AnalogSimParams(
         observables=[Observable("z", sites=[0])],
@@ -391,7 +398,7 @@ def test_rho_vec_at_elapsed_time_returns_initial_state_at_zero() -> None:
         get_state=True,
     )
     ctx = preprocess_lindblad(psi, h, None, sim_params)
-    rho_vec = _rho_vec_at_elapsed_time(ctx)
+    rho_vec = lindblad_mod._rho_vec_at_elapsed_time(ctx)
     np.testing.assert_allclose(rho_vec, ctx.rho_initial)
 
 
@@ -407,7 +414,9 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
     gamma = 1.0
     elapsed_time = 0.25
     noise = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+        processes=[
+            {"name": "destroy", "sites": [0], "strength": gamma, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
+        ],
     )
     sim_params = AnalogSimParams(
         observables=[Observable("z", sites=[0])],
@@ -424,7 +433,7 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
         num_sites=n_sites,
     )
     assert ctx.step_propagator is not None
-    rho_vec = _rho_vec_at_elapsed_time(ctx)
+    rho_vec = lindblad_mod._rho_vec_at_elapsed_time(ctx)
     rho = rho_vec.reshape((2, 2), order="F")
     expected = np.array(
         [[1.0 - np.exp(-gamma * elapsed_time), 0.0], [0.0, np.exp(-gamma * elapsed_time)]],
@@ -441,7 +450,9 @@ def test_lindblad_entry_point_returns_density_matrix() -> None:
     for i in range(len(h.tensors)):
         h.tensors[i] *= 0.0
     noise = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}],
+        processes=[
+            {"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
+        ],
     )
     sim_params = AnalogSimParams(
         observables=[Observable("z", sites=[0])],

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -21,6 +21,7 @@ from qiskit.circuit import QuantumCircuit
 from scipy.stats import unitary_group
 
 from mqt.yaqs import AnalogSimParams, Observable, Simulator, State, StrongSimParams
+from mqt.yaqs.core.data_structures import mps as mps_mod
 from mqt.yaqs.core.data_structures.mps import MPS
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary, X, Z
 
@@ -602,6 +603,105 @@ def test_measure_shots_avoids_nested_process_pool_in_xdist(monkeypatch: pytest.M
     with patch("mqt.yaqs.core.data_structures.mps.ProcessPoolExecutor") as mock_executor:
         psi.measure_shots(shots=5)
     mock_executor.assert_not_called()
+
+
+def test_measure_shots_single_shot() -> None:
+    """A single shot uses the fast path without a process pool."""
+    psi = MPS(length=1, state="zeros")
+    with patch("mqt.yaqs.core.data_structures.mps.ProcessPoolExecutor") as mock_executor:
+        results = psi.measure_shots(shots=1)
+    mock_executor.assert_not_called()
+    assert results == {0: 1}
+
+
+def test_measure_shots_serial_when_one_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multiple shots fall back to a serial loop when only one worker is available."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.setattr(mps_mod, "available_cpus", lambda: 1)
+    psi = MPS(length=1, state="x+")
+    with patch("mqt.yaqs.core.data_structures.mps.ProcessPoolExecutor") as mock_executor:
+        results = psi.measure_shots(shots=5, basis="X")
+    mock_executor.assert_not_called()
+    assert results == {0: 5}
+
+
+class _NoOpPbar:
+    """No-op tqdm stand-in for tests."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> _NoOpPbar:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def update(self, _n: int = 1) -> None:
+        return None
+
+
+class _ImmediateFuture:
+    """Minimal future stand-in that runs the submitted callable immediately."""
+
+    def __init__(self, fn: object, shot_idx: int) -> None:
+        self._outcome = fn(shot_idx)  # type: ignore[operator]
+
+    def result(self) -> int:
+        return self._outcome
+
+
+class _ImmediateProcessPoolExecutor:
+    """Process pool test double that still exercises worker init and submission."""
+
+    def __init__(self, *, max_workers: int, mp_context: object, initializer: object, initargs: tuple[object, ...]) -> None:
+        self.max_workers = max_workers
+        self.initializer = initializer
+        if initializer is not None:
+            initializer(*initargs)
+
+    def __enter__(self) -> _ImmediateProcessPoolExecutor:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def submit(self, fn: object, shot_idx: int) -> _ImmediateFuture:
+        return _ImmediateFuture(fn, shot_idx)
+
+
+def test_measure_shots_parallel_pool_submits_bounded_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parallel ``measure_shots`` initializes worker context and aggregates all outcomes."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.setattr(mps_mod, "available_cpus", lambda: 8)
+    monkeypatch.setattr(mps_mod, "get_parallel_context", lambda _mode: None)
+
+    created: list[_ImmediateProcessPoolExecutor] = []
+
+    def _factory(**kwargs: object) -> _ImmediateProcessPoolExecutor:
+        executor = _ImmediateProcessPoolExecutor(**kwargs)  # type: ignore[arg-type]
+        created.append(executor)
+        return executor
+
+    psi = MPS(length=1, state="x+")
+    with (
+        patch("mqt.yaqs.core.data_structures.mps.ProcessPoolExecutor", side_effect=_factory),
+        patch("mqt.yaqs.core.data_structures.mps.wait", side_effect=lambda futures, **_: (list(futures), [])),
+        patch("mqt.yaqs.core.data_structures.mps.tqdm", _NoOpPbar),
+    ):
+        results = psi.measure_shots(shots=6, basis="X")
+
+    assert len(created) == 1
+    assert created[0].max_workers == 6
+    assert results == {0: 6}
+
+
+def test_measure_shots_worker_helpers() -> None:
+    """Worker helpers measure using the process-global MPS context."""
+    psi = MPS(length=1, state="x+")
+    mps_mod._measure_shots_worker_init(psi, "X")
+    assert mps_mod._measure_shots_worker(0) == 0
+    assert mps_mod._measure_shots_worker(3) == 0
 
 
 def test_inplace_measure() -> None:

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import copy
+from unittest.mock import patch
 
 import numpy as np
 import opt_einsum as oe
@@ -592,6 +593,15 @@ def test_measure_shots_basis() -> None:
     assert results.get(0, 0) > 0
     assert results.get(1, 0) > 0
     assert sum(results.values()) == 20
+
+
+def test_measure_shots_avoids_nested_process_pool_in_xdist(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``measure_shots`` must not spawn extra workers inside a pytest-xdist worker."""
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    psi = MPS(length=2, state="zeros")
+    with patch("mqt.yaqs.core.data_structures.mps.ProcessPoolExecutor") as mock_executor:
+        psi.measure_shots(shots=5)
+    mock_executor.assert_not_called()
 
 
 def test_inplace_measure() -> None:

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -7,11 +7,12 @@
 
 """Tests for :class:`mqt.yaqs.core.data_structures.mps.MPS`."""
 
-# ruff: noqa: N806
+# ruff: noqa: N806, SLF001, PLR6301
 
 from __future__ import annotations
 
 import copy
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import numpy as np
@@ -19,11 +20,15 @@ import opt_einsum as oe
 import pytest
 from qiskit.circuit import QuantumCircuit
 from scipy.stats import unitary_group
+from typing_extensions import Self
 
 from mqt.yaqs import AnalogSimParams, Observable, Simulator, State, StrongSimParams
 from mqt.yaqs.core.data_structures import mps as mps_mod
 from mqt.yaqs.core.data_structures.mps import MPS
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary, X, Z
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _I2 = np.eye(2, dtype=complex)
 _X2 = np.array([[0, 1], [1, 0]], dtype=complex)
@@ -631,7 +636,7 @@ class _NoOpPbar:
     def __init__(self, *args: object, **kwargs: object) -> None:
         pass
 
-    def __enter__(self) -> _NoOpPbar:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *_args: object) -> None:
@@ -644,8 +649,8 @@ class _NoOpPbar:
 class _ImmediateFuture:
     """Minimal future stand-in that runs the submitted callable immediately."""
 
-    def __init__(self, fn: object, shot_idx: int) -> None:
-        self._outcome = fn(shot_idx)  # type: ignore[operator]
+    def __init__(self, fn: Callable[[int], int], shot_idx: int) -> None:
+        self._outcome = fn(shot_idx)
 
     def result(self) -> int:
         return self._outcome
@@ -654,19 +659,27 @@ class _ImmediateFuture:
 class _ImmediateProcessPoolExecutor:
     """Process pool test double that still exercises worker init and submission."""
 
-    def __init__(self, *, max_workers: int, mp_context: object, initializer: object, initargs: tuple[object, ...]) -> None:
+    def __init__(
+        self,
+        *,
+        max_workers: int,
+        mp_context: object,
+        initializer: Callable[..., None] | None,
+        initargs: tuple[object, ...],
+    ) -> None:
         self.max_workers = max_workers
+        _ = mp_context
         self.initializer = initializer
         if initializer is not None:
             initializer(*initargs)
 
-    def __enter__(self) -> _ImmediateProcessPoolExecutor:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *_args: object) -> None:
         return None
 
-    def submit(self, fn: object, shot_idx: int) -> _ImmediateFuture:
+    def submit(self, fn: Callable[[int], int], shot_idx: int) -> _ImmediateFuture:
         return _ImmediateFuture(fn, shot_idx)
 
 
@@ -678,8 +691,19 @@ def test_measure_shots_parallel_pool_submits_bounded_workers(monkeypatch: pytest
 
     created: list[_ImmediateProcessPoolExecutor] = []
 
-    def _factory(**kwargs: object) -> _ImmediateProcessPoolExecutor:
-        executor = _ImmediateProcessPoolExecutor(**kwargs)  # type: ignore[arg-type]
+    def _factory(
+        *,
+        max_workers: int,
+        mp_context: object,
+        initializer: Callable[..., None] | None,
+        initargs: tuple[object, ...],
+    ) -> _ImmediateProcessPoolExecutor:
+        executor = _ImmediateProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=mp_context,
+            initializer=initializer,
+            initargs=initargs,
+        )
         created.append(executor)
         return executor
 

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -19,6 +19,7 @@ import opt_einsum as oe
 import pytest
 from qiskit.circuit import QuantumCircuit
 from scipy.stats import unitary_group
+from typing_extensions import Self
 
 from mqt.yaqs import AnalogSimParams, Observable, Simulator, State, StrongSimParams
 from mqt.yaqs.core.data_structures import mps as mps_mod
@@ -631,7 +632,7 @@ class _NoOpPbar:
     def __init__(self, *args: object, **kwargs: object) -> None:
         pass
 
-    def __enter__(self) -> _NoOpPbar:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *_args: object) -> None:
@@ -654,13 +655,15 @@ class _ImmediateFuture:
 class _ImmediateProcessPoolExecutor:
     """Process pool test double that still exercises worker init and submission."""
 
-    def __init__(self, *, max_workers: int, mp_context: object, initializer: object, initargs: tuple[object, ...]) -> None:
+    def __init__(
+        self, *, max_workers: int, mp_context: object, initializer: object, initargs: tuple[object, ...]
+    ) -> None:
         self.max_workers = max_workers
         self.initializer = initializer
         if initializer is not None:
             initializer(*initargs)
 
-    def __enter__(self) -> _ImmediateProcessPoolExecutor:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *_args: object) -> None:

--- a/tests/core/methods/test_bug.py
+++ b/tests/core/methods/test_bug.py
@@ -139,7 +139,7 @@ def test_prepare_canonical_site_tensors_three_sites() -> None:
     assert np.allclose(correct_env, left_envs[1])
     assert np.allclose(correct_canon, canon_sites[1])
     # Site 2
-    q_last, r_matrix = right_qr(correct_canon)
+    q_last, r_matrix = right_qr(np.asarray(correct_canon, dtype=np.complex128))
     correct_canon = np.tensordot(r_matrix, mps_tensors[2], axes=(1, 1)).transpose(1, 0, 2)
     correct_env = update_left_environment(q_last, q_last, mpo_tensors[1], left_envs[1])
     assert np.allclose(correct_env, left_envs[2])

--- a/tests/core/methods/test_dissipation.py
+++ b/tests/core/methods/test_dissipation.py
@@ -35,7 +35,7 @@ def test_apply_dissipation_one_site_canonical_0() -> None:
         # Create a random 2-element vector, normalize it, and reshape to (pdim, 1, 1)
         vec = rng.random(pdim).astype(complex)
         vec /= np.linalg.norm(vec)
-        tensor = vec.reshape(pdim, 1, 1)
+        tensor = np.asarray(vec.reshape(pdim, 1, 1), dtype=np.complex128)
         tensors.append(tensor)
 
     state = MPS(length=length, tensors=tensors, physical_dimensions=[pdim] * length)
@@ -70,7 +70,7 @@ def test_apply_dissipation_two_site_canonical_0() -> None:
         # Create a random 2-element vector, normalize it, and reshape to (pdim, 1, 1)
         vec = rng.random(pdim).astype(complex)
         vec /= np.linalg.norm(vec)
-        tensor = vec.reshape(pdim, 1, 1)
+        tensor = np.asarray(vec.reshape(pdim, 1, 1), dtype=np.complex128)
         tensors.append(tensor)
 
     state = MPS(length=length, tensors=tensors, physical_dimensions=[pdim] * length)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -471,6 +471,38 @@ def test_density_matrix_get_state_at_elapsed_time() -> None:
     assert not np.isclose(rho[1, 1].real, np.exp(-gamma * sim_params.times[-1]), atol=1e-3)
 
 
+def test_density_matrix_get_state_preserves_metadata() -> None:
+    """Lindblad ``get_state`` copies lattice metadata onto ``result.output_state``."""
+    pdim = 2
+    initial_state = State(2, initial="zeros", representation="density_matrix", physical_dimensions=[pdim, pdim])
+    hamiltonian = Hamiltonian.ising(2, J=0.0, g=0.0)
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        elapsed_time=0.1,
+        dt=0.1,
+        get_state=True,
+    )
+    result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, None)
+    assert result.output_state is not None
+    assert result.output_state.length == 2
+    assert result.output_state.physical_dimensions == [pdim, pdim]
+    assert result.output_state.representation == "density_matrix"
+
+
+def test_density_matrix_without_get_state_leaves_output_state_empty() -> None:
+    """No ``output_state`` is stored when ``get_state`` is false for Lindblad runs."""
+    initial_state = State(1, initial="ones", representation="density_matrix")
+    hamiltonian = Hamiltonian.ising(1, J=0.0, g=0.0)
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        elapsed_time=0.1,
+        dt=0.1,
+        get_state=False,
+    )
+    result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, None)
+    assert result.output_state is None
+
+
 @pytest.mark.parametrize(
     "state",
     [

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -395,16 +395,44 @@ def test_analog_simulation_get_state() -> None:
         np.testing.assert_allclose(1, fidelity)
 
 
-def test_density_matrix_get_state_rejected() -> None:
-    """density_matrix evolution does not support returning an output state."""
+def test_density_matrix_get_state() -> None:
+    """density_matrix evolution returns the final density matrix when get_state=True."""
     psi = State(2, initial="zeros", representation="density_matrix")
     h = Hamiltonian.ising(2, J=1.0, g=0.5)
     sim_params = AnalogSimParams(
         observables=[Observable(Z(), 0)],
+        elapsed_time=0.1,
+        dt=0.1,
         get_state=True,
     )
-    with pytest.raises(ValueError, match=r"get_state=True is not supported for State\.representation='density_matrix'"):
-        Simulator(show_progress=False).run(psi, h, sim_params, None)
+    result = Simulator(show_progress=False).run(psi, h, sim_params, None)
+    assert result.output_state is not None
+    assert result.output_state.representation == "density_matrix"
+    rho = result.output_state.density_matrix
+    assert rho.shape == (4, 4)
+    assert np.isclose(np.trace(rho), 1.0)
+
+
+def test_density_matrix_get_state_noisy() -> None:
+    """Noisy Lindblad evolution still returns the exact ensemble-averaged density matrix."""
+    n_sites = 1
+    initial_state = State(n_sites, initial="ones", representation="density_matrix")
+    hamiltonian = Hamiltonian.ising(n_sites, J=0.0, g=0.0)
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    noise_model = NoiseModel(
+        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": sigma_minus}],
+    )
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        elapsed_time=1.0,
+        dt=0.1,
+        get_state=True,
+    )
+    result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, noise_model)
+    assert result.output_state is not None
+    rho = result.output_state.density_matrix
+    # Amplitude damping from |1>: rho_11 = exp(-gamma t)
+    assert np.isclose(rho[1, 1].real, np.exp(-1.0), atol=1e-4)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -419,20 +419,56 @@ def test_density_matrix_get_state_noisy() -> None:
     initial_state = State(n_sites, initial="ones", representation="density_matrix")
     hamiltonian = Hamiltonian.ising(n_sites, J=0.0, g=0.0)
     sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    gamma = 1.0
+    t = 1.0
     noise_model = NoiseModel(
-        processes=[{"name": "destroy", "sites": [0], "strength": 1.0, "matrix": sigma_minus}],
+        processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": sigma_minus}],
     )
     sim_params = AnalogSimParams(
         observables=[Observable(Z(), 0)],
-        elapsed_time=1.0,
+        elapsed_time=t,
         dt=0.1,
         get_state=True,
     )
     result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, noise_model)
     assert result.output_state is not None
     rho = result.output_state.density_matrix
-    # Amplitude damping from |1>: rho_11 = exp(-gamma t)
-    assert np.isclose(rho[1, 1].real, np.exp(-1.0), atol=1e-4)
+    expected = np.array(
+        [[1.0 - np.exp(-gamma * t), 0.0], [0.0, np.exp(-gamma * t)]],
+        dtype=np.complex128,
+    )
+    np.testing.assert_allclose(rho, expected, atol=1e-4)
+    assert np.isclose(np.trace(rho), 1.0)
+    assert np.allclose(rho.imag, 0.0, atol=1e-10)
+
+
+def test_density_matrix_get_state_at_elapsed_time() -> None:
+    """get_state returns rho at elapsed_time, not the overshot final grid point."""
+    n_sites = 1
+    initial_state = State(n_sites, initial="ones", representation="density_matrix")
+    hamiltonian = Hamiltonian.ising(n_sites, J=0.0, g=0.0)
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    gamma = 1.0
+    elapsed_time = 0.25
+    noise_model = NoiseModel(
+        processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": sigma_minus}],
+    )
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        elapsed_time=elapsed_time,
+        dt=0.1,
+        get_state=True,
+        sample_timesteps=False,
+    )
+    result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, noise_model)
+    assert result.output_state is not None
+    rho = result.output_state.density_matrix
+    expected = np.array(
+        [[1.0 - np.exp(-gamma * elapsed_time), 0.0], [0.0, np.exp(-gamma * elapsed_time)]],
+        dtype=np.complex128,
+    )
+    np.testing.assert_allclose(rho, expected, atol=1e-4)
+    assert not np.isclose(rho[1, 1].real, np.exp(-gamma * sim_params.times[-1]), atol=1e-3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR allows the user to return the final density matrix of the Lindblad equation with get_state. This feature previously worked for noiseless vector and mps simulation, however, it was not extended to the density matrix.

Compared to the other representations, the density matrix can always be returned since it is exact even if a noise model is added.

<!---
Replace `(issue)` with the issue number fixed by this pull request.
If this PR does not fix an issue, please remove the line.
-->

Fixes #(issue)

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
