### PR TITLE
added trapped-ion hamiltonian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- added an MPO constructor for static one- and two-ion trapped-ion Hamiltonians in the position basis ([#476]) ([**@linusschulte**])
 - extended get_state functionality to Lindblad ([#475]) ([**@aaronleesander**])
 - extended EquivalenceChecker output to include entropy and the resulting diff data structure ([#364]) ([**@yiranwang-phys**])
 - OpenQASM2 and 3 files can now be read directly by the Simulator and EquivalenceChecker ([#464]) ([**@Marerido**])
@@ -45,6 +46,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Fixed
 
+- fixed vector analog simulation for non-qubit local dimensions ([#476]) ([@linusschulte])
 - fixed NoiseModel factor order when two-site indices are normalized ([#396]) ([**@aleramos119**])
 - refactored observable handling in simulator to preserve user order ([#447]) ([**@aaronleesander**])
 - added tests to ensure qubit ordering matches Qiskit ([#446]) ([**@aaronleesander**])
@@ -140,6 +142,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#476]: https://github.com/munich-quantum-toolkit/yaqs/pull/476
 [#475]: https://github.com/munich-quantum-toolkit/yaqs/pull/475
 [#467]: https://github.com/munich-quantum-toolkit/yaqs/pull/467
 [#465]: https://github.com/munich-quantum-toolkit/yaqs/pull/465
@@ -204,6 +207,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 [**@Marerido**]: https://github.com/Marerido
 [**@yiranwang-phys**]: https://github.com/yiranwang-phys
 [**@aleramos119**]: https://github.com/aleramos119
+[**@linusschulte**]: https://github.com/linusschulte
 
 <!-- General links -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Fixed
 
-- fixed vector analog simulation for non-qubit local dimensions ([#476]) ([@linusschulte])
+- fixed vector and Lindblad analog simulation for non-qubit local dimensions ([#476]) ([**@linusschulte**])
 - fixed NoiseModel factor order when two-site indices are normalized ([#396]) ([**@aleramos119**])
 - refactored observable handling in simulator to preserve user order ([#447]) ([**@aaronleesander**])
 - added tests to ensure qubit ordering matches Qiskit ([#446]) ([**@aaronleesander**])

--- a/docs/examples/trapped_ion.md
+++ b/docs/examples/trapped_ion.md
@@ -1,0 +1,76 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  number_source_lines: true
+  execution_timeout: 300
+---
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+%config InlineBackend.figure_formats = ['svg']
+```
+
+# Trapped-Ion Position-Grid Emulation
+
+This example builds a static single-ion Hamiltonian with
+{meth}`~mqt.yaqs.core.data_structures.mpo.MPO.trapped_ion`. Each ion is one MPO
+site, and the local basis is a finite position grid. The Hamiltonian contains a
+finite-difference kinetic term and a harmonic trap.
+
+We initialize a displaced harmonic-oscillator ground-state wavepacket in a static
+central well. In the continuum limit, its center follows
+$\langle x(t)\rangle = x_0 \cos(\omega t)$, so after half a trap period it reaches
+the opposite turning point.
+
+## Static central well
+
+```{code-cell} ipython3
+import numpy as np
+
+from mqt.yaqs import AnalogSimParams, Hamiltonian, MPO, Simulator, State
+
+omega = 1.0
+initial_displacement = 1.0
+half_period = np.pi / omega
+
+positions = np.linspace(-8.0, 8.0, 33)
+grid_dim = len(positions)
+
+initial_grid_state = np.exp(-0.5 * (positions - initial_displacement) ** 2).astype(np.complex128)
+initial_grid_state /= np.linalg.norm(initial_grid_state)
+
+hamiltonian = Hamiltonian.from_mpo(MPO.trapped_ion(positions, masses=[1.0], omega=omega))
+state = State(length=1, vector=initial_grid_state, physical_dimensions=[grid_dim])
+
+params = AnalogSimParams(
+    observables=[],
+    elapsed_time=half_period,
+    dt=half_period / 16,
+    max_bond_dim=None,
+    svd_threshold=1e-12,
+    krylov_tol=1e-12,
+    preset="exact",
+    get_state=True,
+    sample_timesteps=False,
+)
+
+result = Simulator(parallel=False, show_progress=False).run(state, hamiltonian, params)
+assert result.output_state is not None
+final_state = result.output_state.vector
+final_x = float(np.sum(positions * np.abs(final_state) ** 2))
+
+print(f"Initial <x>       = {initial_displacement:.6f}")
+print(f"Final <x> at T/2  = {final_x:.6f}")
+print(f"Continuum target  = {-initial_displacement:.6f}")
+```
+
+The final value is close to $-x_0$ but not exact because the simulation uses a
+finite grid and a finite-difference kinetic operator.
+
+## Related topics
+
+- {doc}`transmon_emulation` — another mixed-dimensional hardware model
+- {doc}`analog_simulation` — analog time evolution and noise models
+- {doc}`state_initialization` — custom `physical_dimensions` and manual vectors

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ flowchart LR
 | Scheduled jumps at fixed times                           | {doc}`examples/scheduled_jumps`           |
 | Fermi–Hubbard MPO and analog evolution                   | {doc}`examples/fermi_hubbard_mpo`         |
 | Transmon–resonator SWAP (noiseless vs noisy)             | {doc}`examples/transmon_emulation`        |
+| Trapped-ion position-grid dynamics                       | {doc}`examples/trapped_ion`               |
 | Process tensor tomography                                | {doc}`examples/process_tomography`        |
 | Custom gate translation from Qiskit                      | {doc}`examples/custom_gates`              |
 
@@ -98,6 +99,7 @@ examples/scheduled_jumps
 examples/ensemble_evolution
 examples/representation_comparison
 examples/transmon_emulation
+examples/trapped_ion
 examples/fermi_hubbard_mpo
 examples/process_tomography
 ```

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -12,8 +12,9 @@ This module integrates the ensemble-averaged master equation (deterministic in r
     drho/dt = -i[H, rho] + sum_k ( L_k rho L_k^dag - 0.5 {L_k^dag L_k, rho} )
 
 MPS/MPO specify the initial pure state and Hamiltonian; the state is carried as a
-dense ``dim x dim`` matrix with ``dim = 2^N``. With ``noise_model=None`` (or zero
-strengths), the dissipator vanishes and evolution is unitary on rho.
+dense ``dim x dim`` matrix with ``dim = prod(physical_dimensions)``. With
+``noise_model=None`` (or zero strengths), the dissipator vanishes and evolution is
+unitary on rho.
 
 Because ``H`` and the jump operators are time-independent, the generator is fixed.
 For small systems we precompute ``exp(L dt)`` where ``L`` is the Liouvillian
@@ -32,6 +33,10 @@ import numpy as np
 import scipy.sparse
 from scipy.integrate import solve_ivp
 
+from ..core import linalg
+from ..core.data_structures.state_utils import resolve_physical_dimensions
+from .utils import _embed_observable_sparse, _embed_operator_sparse
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
@@ -39,9 +44,6 @@ if TYPE_CHECKING:
     from ..core.data_structures.mps import MPS
     from ..core.data_structures.noise_model import NoiseModel
     from ..core.data_structures.simulation_parameters import AnalogSimParams
-
-from ..core import linalg
-from .utils import _embed_observable_sparse, _embed_operator_sparse
 
 # Maximum length of vec(rho) = dim**2 for storing dense exp(L * dt).
 # vec_dim=4096 corresponds to N=6 qubits (propagator ~256 MB); N=7+ uses ODE fallback.
@@ -73,6 +75,7 @@ def preprocess_lindblad(
     *,
     rho_initial: NDArray[np.complex128] | None = None,
     num_sites: int | None = None,
+    physical_dimensions: int | list[int] | None = None,
     h_sparse: scipy.sparse.spmatrix | None = None,
 ) -> LindbladContext:
     """Pre-compute operators and optional fixed-step propagator for Lindblad evolution.
@@ -85,6 +88,8 @@ def preprocess_lindblad(
         sim_params: Simulation parameters.
         rho_initial: Optional density matrix (square) or flattened vector for vec(rho).
         num_sites: Number of lattice sites when ``initial_state`` is ``None``.
+        physical_dimensions: Per-site physical dimensions used to validate dense
+            density matrices and sparse Hamiltonian sizes. Defaults to qubits.
         h_sparse: Pre-materialized sparse Hamiltonian (skips ``hamiltonian.to_sparse_matrix()``).
 
     Returns:
@@ -96,6 +101,7 @@ def preprocess_lindblad(
     """
     if initial_state is not None:
         num_sites = initial_state.length
+        physical_dimensions = initial_state.physical_dimensions
     elif rho_initial is not None:
         if num_sites is None:
             msg = "num_sites is required when preprocess_lindblad is called with rho_initial only."
@@ -104,11 +110,11 @@ def preprocess_lindblad(
         msg = "preprocess_lindblad requires initial_state or rho_initial."
         raise ValueError(msg)
 
-    dim = 2**num_sites
+    dim = int(np.prod(resolve_physical_dimensions(num_sites, physical_dimensions), dtype=np.int64))
 
-    if num_sites > 10:
+    if dim > 2**10:
         msg = (
-            f"System size {num_sites} exceeds the recommended limit (10) for representation='density_matrix'. "
+            f"Hilbert-space dimension {dim} exceeds the recommended limit (2^10) for representation='density_matrix'. "
             "Density-matrix evolution uses dense-like scaling (2^2N elements). "
             "Simulation may be very slow or run out of memory. "
             "Consider using representation='mps' for larger systems."
@@ -143,6 +149,9 @@ def preprocess_lindblad(
     # 2. Hamiltonian as sparse matrix on the full Hilbert space.
     if h_sparse is not None:
         h_mat = scipy.sparse.csr_matrix(h_sparse)
+        if h_mat.shape != (dim, dim):
+            msg = f"h_sparse must have shape ({dim}, {dim}), got {h_mat.shape}."
+            raise ValueError(msg)
     elif hamiltonian is not None:
         h_mat = hamiltonian.to_sparse_matrix()
     else:

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -25,6 +25,7 @@ or ``'vector'`` for larger lattices.
 
 from __future__ import annotations
 
+import math
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
@@ -110,7 +111,7 @@ def preprocess_lindblad(
         msg = "preprocess_lindblad requires initial_state or rho_initial."
         raise ValueError(msg)
 
-    dim = int(np.prod(resolve_physical_dimensions(num_sites, physical_dimensions), dtype=np.int64))
+    dim = math.prod(resolve_physical_dimensions(num_sites, physical_dimensions))
 
     if dim > 2**10:
         msg = (

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -34,6 +34,7 @@ import numpy as np
 import scipy.sparse
 
 from ..core import linalg
+from ..core.data_structures.state_utils import resolve_physical_dimensions
 from ..core.methods.matrix_exponential import expm_arnoldi, expm_krylov
 from ..core.random_utils import make_trajectory_rng
 
@@ -76,6 +77,7 @@ def preprocess_mcwf(
     *,
     psi_initial: NDArray[np.complex128] | None = None,
     num_sites: int | None = None,
+    physical_dimensions: int | list[int] | None = None,
     h_sparse: scipy.sparse.spmatrix | None = None,
 ) -> MCWFContext:
     """Pre-compute dense operators and initial state for MCWF simulation.
@@ -90,6 +92,8 @@ def preprocess_mcwf(
         sim_params: Simulation parameters.
         psi_initial: Optional pre-encoded dense state vector (unit norm applied here).
         num_sites: Number of lattice sites when ``initial_state`` is ``None``.
+        physical_dimensions: Per-site physical dimensions used to validate dense
+            vector and sparse Hamiltonian sizes. Defaults to qubits.
         h_sparse: Pre-materialized sparse Hamiltonian (skips ``hamiltonian.to_sparse_matrix()``).
 
     Returns:
@@ -102,6 +106,7 @@ def preprocess_mcwf(
     """
     if initial_state is not None:
         num_sites = initial_state.length
+        physical_dimensions = initial_state.physical_dimensions
     elif psi_initial is not None:
         if num_sites is None:
             msg = "num_sites is required when preprocess_mcwf is called with psi_initial only."
@@ -110,11 +115,11 @@ def preprocess_mcwf(
         msg = "preprocess_mcwf requires initial_state or psi_initial."
         raise ValueError(msg)
 
-    dim = 2**num_sites
+    dim = int(np.prod(resolve_physical_dimensions(num_sites, physical_dimensions), dtype=np.int64))
 
-    if num_sites > 14:
+    if dim > 2**14:
         msg = (
-            f"System size {num_sites} is too large for representation='vector' even with sparse matrices. "
+            f"Hilbert-space dimension {dim} is large for representation='vector' even with sparse matrices. "
             "Simulation may be very slow or run out of memory. "
             "Consider using representation='mps' for larger systems."
         )

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -26,6 +26,7 @@ store ``U_step``. For larger lattices use ``representation='mps'`` instead.
 
 from __future__ import annotations
 
+import math
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
@@ -115,7 +116,7 @@ def preprocess_mcwf(
         msg = "preprocess_mcwf requires initial_state or psi_initial."
         raise ValueError(msg)
 
-    dim = int(np.prod(resolve_physical_dimensions(num_sites, physical_dimensions), dtype=np.int64))
+    dim = math.prod(resolve_physical_dimensions(num_sites, physical_dimensions))
 
     if dim > 2**14:
         msg = (

--- a/src/mqt/yaqs/core/data_structures/mpo.py
+++ b/src/mqt/yaqs/core/data_structures/mpo.py
@@ -19,7 +19,7 @@ import scipy.sparse
 from numpy.typing import NDArray
 
 from .. import linalg
-from ..libraries.gate_library import BaseGate, Destroy
+from ..libraries.gate_library import Destroy
 from .mpo_utils import (
     contract_mpo_site_with_mpo_site,
     contract_mpo_site_with_mps_site,
@@ -29,6 +29,9 @@ from .mpo_utils import (
 from .mps import MPS
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..libraries.gate_library import BaseGate
     from ..methods.decompositions import TruncMode
     from .simulation_parameters import StrongSimParams, WeakSimParams
 
@@ -53,6 +56,7 @@ class MPO:
     - ``MPO.ising(...)`` / ``MPO.heisenberg(...)``: qubit Pauli Hamiltonians.
     - ``MPO.pauli(...)``: generic one-/two-body Pauli interactions.
     - ``MPO.fermi_hubbard_1d(...)``: 1D Fermi-Hubbard (fermionic or Jordan-Wigner Pauli).
+    - ``MPO.trapped_ions_position_grid(...)``: one or two trapped ions on a position grid.
     - ``MPO.coupled_transmon(...)``: alternating qubit/resonator chain MPO.
     - ``from_pauli_sum(...)``: in-place build from a sum of Pauli-string terms.
     - ``MPO.identity(...)``: identity operator.
@@ -594,6 +598,157 @@ class MPO:
         # Backward-compat: single attribute even though dims alternate.
         mpo.physical_dimension = local_dim
 
+        assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
+        return mpo
+
+    @classmethod
+    def trapped_ions_position_grid(
+        cls,
+        positions: NDArray[np.float64],
+        masses: Sequence[float],
+        omega: float,
+        *,
+        trap_center: float = 0.0,
+        hbar: float = 1.0,
+        coulomb_strength: float = 0.0,
+        softening_length: float | None = None,
+        coulomb_cutoff: float = 1e-12,
+        max_bond_dim: int | None = None,
+    ) -> MPO:
+        r"""Construct a static one- or two-ion Hamiltonian on a uniform position grid.
+
+        Each ion is one MPO site whose local basis consists of the supplied position-grid
+        points. The Hamiltonian is:
+
+        H = sum_i[-hbar^2/(2*m_i) * d^2/dx_i^2 + (1/2)*m_i*omega^2*(x_i - q)^2]
+            + g / sqrt((x_1 - x_2)^2 + a^2)
+
+        The kinetic energy uses a centered second-order finite difference. For two ions, 
+        an SVD of the diagonal Coulomb coefficient matrix produces the MPO interaction 
+        channels. Discarding singular values according to ``coulomb_cutoff`` or 
+        ``max_bond_dim`` approximates only the Coulomb term.
+
+        Args:
+            positions: Uniformly spaced one-dimensional position grid.
+            masses: One or two positive ion masses. Each ion becomes one MPO site.
+            omega: Non-negative harmonic trap angular frequency.
+            trap_center: Center ``q`` of the static harmonic trap.
+            hbar: Positive reduced Planck constant.
+            coulomb_strength: Coulomb prefactor ``g``. Must be zero for one ion.
+            softening_length: Positive short-distance regularizer ``a`` to avoid Coulomb 
+                singularity. Defaults to the grid spacing for two ions.
+            coulomb_cutoff: Relative SVD cutoff. Singular values no larger than this
+                fraction of the largest one are discarded. Set to zero for the exact
+                grid interaction.
+            max_bond_dim: Optional cap on the total MPO bond dimension. For two ions,
+                two channels are reserved for the local Hamiltonians.
+
+        Returns:
+            MPO for the static trapped-ion Hamiltonian in energy units.
+
+        Raises:
+            ValueError: If the grid or physical parameters are invalid, if the number of
+                masses is not one or two, or if ``max_bond_dim`` is too small.
+
+        Notes:
+            YAQS time evolution applies ``exp(-1j * dt * H)``. When using dimensional
+            quantities, rescale the returned MPO to represent ``H / hbar`` or measure
+            time and energy in compatible units.
+        """
+        grid = np.asarray(positions, dtype=np.float64)
+        if grid.ndim != 1 or grid.size < 3:
+            msg = "positions must be a one-dimensional grid with at least three points."
+            raise ValueError(msg)
+        if not np.all(np.isfinite(grid)):
+            msg = "positions must contain only finite values."
+            raise ValueError(msg)
+        spacings = np.diff(grid)
+        if np.any(spacings <= 0.0) or not np.allclose(spacings, spacings[0], rtol=1e-12, atol=1e-15):
+            msg = "positions must be strictly increasing and uniformly spaced."
+            raise ValueError(msg)
+
+        ion_masses = np.asarray(masses, dtype=np.float64)
+        if ion_masses.ndim != 1 or ion_masses.size not in {1, 2}:
+            msg = "masses must contain exactly one or two ion masses."
+            raise ValueError(msg)
+        if not np.all(np.isfinite(ion_masses)) or np.any(ion_masses <= 0.0):
+            msg = "masses must contain only finite positive values."
+            raise ValueError(msg)
+        if not np.isfinite(omega) or omega < 0.0:
+            msg = "omega must be finite and non-negative."
+            raise ValueError(msg)
+        if not np.isfinite(trap_center):
+            msg = "trap_center must be finite."
+            raise ValueError(msg)
+        if not np.isfinite(hbar) or hbar <= 0.0:
+            msg = "hbar must be finite and positive."
+            raise ValueError(msg)
+        if not np.isfinite(coulomb_strength):
+            msg = "coulomb_strength must be finite."
+            raise ValueError(msg)
+        if not np.isfinite(coulomb_cutoff) or not 0.0 <= coulomb_cutoff < 1.0:
+            msg = "coulomb_cutoff must be finite and satisfy 0 <= coulomb_cutoff < 1."
+            raise ValueError(msg)
+        if max_bond_dim is not None and max_bond_dim < 2:
+            msg = "max_bond_dim must be at least 2."
+            raise ValueError(msg)
+        if ion_masses.size == 1 and coulomb_strength:
+            msg = "coulomb_strength must be zero for a one-ion Hamiltonian."
+            raise ValueError(msg)
+
+        d = grid.size
+        dx = float(spacings[0])
+
+        def local_hamiltonian(mass: float) -> ComplexTensor:
+            kinetic_diagonal = np.full(d, hbar**2 / (mass * dx**2), dtype=np.float64)
+            kinetic_off_diagonal = np.full(d - 1, -(hbar**2 / (2.0 * mass * dx**2)), dtype=np.float64)
+            kinetic = (
+                np.diag(kinetic_diagonal) + np.diag(kinetic_off_diagonal, k=-1) + np.diag(kinetic_off_diagonal, k=1)
+            )
+            potential = 0.5 * mass * omega**2 * (grid - trap_center) ** 2
+            return np.asarray(kinetic + np.diag(potential), dtype=np.complex128)
+
+        local_terms = [local_hamiltonian(float(mass)) for mass in ion_masses]
+        mpo = cls()
+        mpo.length = int(ion_masses.size)
+        mpo.physical_dimension = d
+
+        if ion_masses.size == 1:
+            mpo.tensors = [local_terms[0][:, :, None, None]]
+            assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
+            return mpo
+
+        if softening_length is None:
+            softening_length = dx
+        if not np.isfinite(softening_length) or softening_length <= 0.0:
+            msg = "softening_length must be finite and positive."
+            raise ValueError(msg)
+
+        distance = grid[:, None] - grid[None, :]
+        coulomb = coulomb_strength / np.sqrt(distance**2 + softening_length**2)
+        u, singular_values, vh = linalg.svd(coulomb, full_matrices=False)
+        if not singular_values[0]:
+            rank = 0
+        else:
+            rank = int(np.count_nonzero(singular_values > coulomb_cutoff * singular_values[0]))
+        if max_bond_dim is not None:
+            rank = min(rank, max_bond_dim - 2)
+
+        bond_dimension = rank + 2
+        identity = np.eye(d, dtype=np.complex128)
+        left = np.zeros((d, d, 1, bond_dimension), dtype=np.complex128)
+        right = np.zeros((d, d, bond_dimension, 1), dtype=np.complex128)
+        left[:, :, 0, 0] = local_terms[0]
+        right[:, :, 0, 0] = identity
+        left[:, :, 0, 1] = identity
+        right[:, :, 1, 0] = local_terms[1]
+
+        for alpha in range(rank):
+            scale = math.sqrt(float(singular_values[alpha]))
+            left[:, :, 0, alpha + 2] = np.diag(scale * u[:, alpha])
+            right[:, :, alpha + 2, 0] = np.diag(scale * vh[alpha, :])
+
+        mpo.tensors = [left, right]
         assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
         return mpo
 

--- a/src/mqt/yaqs/core/data_structures/mpo.py
+++ b/src/mqt/yaqs/core/data_structures/mpo.py
@@ -712,6 +712,17 @@ class MPO:
     ) -> tuple[NDArray[np.float64], NDArray[np.float64], float, float]:
         """Validate trapped-ion position-grid inputs and return normalized parameters.
 
+        Args:
+            positions: Uniformly spaced one-dimensional position grid.
+            masses: One or two positive ion masses.
+            omega: Non-negative harmonic trap angular frequency.
+            trap_center: Center position of the harmonic trap.
+            hbar: Positive reduced Planck constant.
+            coulomb_strength: Softened Coulomb prefactor. Must be zero for one ion.
+            softening_length: Positive Coulomb softening length, or ``None`` to use the grid spacing.
+            coulomb_cutoff: Relative SVD cutoff for Coulomb channels.
+            max_bond_dim: Optional integer cap on the total MPO bond dimension.
+
         Returns:
             Tuple containing the validated grid, ion masses, grid spacing, and resolved
             softening length.
@@ -758,16 +769,24 @@ class MPO:
             msg = "coulomb_strength must be zero for a one-ion Hamiltonian."
             raise ValueError(msg)
         if ion_masses.size == 1:
-            if max_bond_dim is not None and max_bond_dim < 1:
-                msg = "max_bond_dim must be at least 1 for a one-ion Hamiltonian."
-                raise ValueError(msg)
+            if max_bond_dim is not None:
+                if not isinstance(max_bond_dim, int) or isinstance(max_bond_dim, bool):
+                    msg = "max_bond_dim must be an integer."
+                    raise ValueError(msg)
+                if max_bond_dim < 1:
+                    msg = "max_bond_dim must be at least 1 for a one-ion Hamiltonian."
+                    raise ValueError(msg)
             resolved_softening = spacings[0] if softening_length is None else softening_length
             return grid, ion_masses, float(spacings[0]), float(resolved_softening)
 
         dx = float(spacings[0])
-        if max_bond_dim is not None and max_bond_dim < 2:
-            msg = "max_bond_dim must be at least 2 for a two-ion Hamiltonian."
-            raise ValueError(msg)
+        if max_bond_dim is not None:
+            if not isinstance(max_bond_dim, int) or isinstance(max_bond_dim, bool):
+                msg = "max_bond_dim must be an integer."
+                raise ValueError(msg)
+            if max_bond_dim < 2:
+                msg = "max_bond_dim must be at least 2 for a two-ion Hamiltonian."
+                raise ValueError(msg)
         if softening_length is None:
             softening_length = dx
         if not np.isfinite(softening_length) or softening_length <= 0.0:
@@ -785,6 +804,14 @@ class MPO:
         dx: float,
     ) -> list[ComplexTensor]:
         """Construct finite-difference kinetic plus harmonic-potential local terms.
+
+        Args:
+            grid: Uniform one-dimensional position grid.
+            ion_masses: Validated positive ion masses.
+            omega: Non-negative harmonic trap angular frequency.
+            trap_center: Center position of the harmonic trap.
+            hbar: Positive reduced Planck constant.
+            dx: Uniform grid spacing.
 
         Returns:
             Local Hamiltonian matrix for each ion mass.
@@ -810,6 +837,13 @@ class MPO:
         max_bond_dim: int | None,
     ) -> list[tuple[ComplexTensor, ComplexTensor]]:
         """Factorize the softened Coulomb grid into diagonal MPO interaction channels.
+
+        Args:
+            grid: Uniform one-dimensional position grid.
+            coulomb_strength: Softened Coulomb prefactor.
+            softening_length: Positive Coulomb softening length.
+            coulomb_cutoff: Relative SVD cutoff for Coulomb channels.
+            max_bond_dim: Optional integer cap on the total MPO bond dimension.
 
         Returns:
             Pairs of diagonal left/right MPO channel matrices for the retained SVD terms.

--- a/src/mqt/yaqs/core/data_structures/mpo.py
+++ b/src/mqt/yaqs/core/data_structures/mpo.py
@@ -623,9 +623,9 @@ class MPO:
         H = sum_i[-hbar^2/(2*m_i) * d^2/dx_i^2 + (1/2)*m_i*omega^2*(x_i - q)^2]
             + g / sqrt((x_1 - x_2)^2 + a^2)
 
-        The kinetic energy uses a centered second-order finite difference. For two ions, 
-        an SVD of the diagonal Coulomb coefficient matrix produces the MPO interaction 
-        channels. Discarding singular values according to ``coulomb_cutoff`` or 
+        The kinetic energy uses a centered second-order finite difference. For two ions,
+        an SVD of the diagonal Coulomb coefficient matrix produces the MPO interaction
+        channels. Discarding singular values according to ``coulomb_cutoff`` or
         ``max_bond_dim`` approximates only the Coulomb term.
 
         Args:
@@ -635,7 +635,7 @@ class MPO:
             trap_center: Center ``q`` of the static harmonic trap.
             hbar: Positive reduced Planck constant.
             coulomb_strength: Coulomb prefactor ``g``. Must be zero for one ion.
-            softening_length: Positive short-distance regularizer ``a`` to avoid Coulomb 
+            softening_length: Positive short-distance regularizer ``a`` to avoid Coulomb
                 singularity. Defaults to the grid spacing for two ions.
             coulomb_cutoff: Relative SVD cutoff. Singular values no larger than this
                 fraction of the largest one are discarded. Set to zero for the exact

--- a/src/mqt/yaqs/core/data_structures/mpo.py
+++ b/src/mqt/yaqs/core/data_structures/mpo.py
@@ -56,7 +56,7 @@ class MPO:
     - ``MPO.ising(...)`` / ``MPO.heisenberg(...)``: qubit Pauli Hamiltonians.
     - ``MPO.pauli(...)``: generic one-/two-body Pauli interactions.
     - ``MPO.fermi_hubbard_1d(...)``: 1D Fermi-Hubbard (fermionic or Jordan-Wigner Pauli).
-    - ``MPO.trapped_ions_position_grid(...)``: one or two trapped ions on a position grid.
+    - ``MPO.trapped_ion(...)``: one or two trapped ions on a position grid.
     - ``MPO.coupled_transmon(...)``: alternating qubit/resonator chain MPO.
     - ``from_pauli_sum(...)``: in-place build from a sum of Pauli-string terms.
     - ``MPO.identity(...)``: identity operator.
@@ -602,7 +602,7 @@ class MPO:
         return mpo
 
     @classmethod
-    def trapped_ions_position_grid(
+    def trapped_ion(
         cls,
         positions: NDArray[np.float64],
         masses: Sequence[float],
@@ -646,14 +646,79 @@ class MPO:
         Returns:
             MPO for the static trapped-ion Hamiltonian in energy units.
 
-        Raises:
-            ValueError: If the grid or physical parameters are invalid, if the number of
-                masses is not one or two, or if ``max_bond_dim`` is too small.
-
         Notes:
             YAQS time evolution applies ``exp(-1j * dt * H)``. When using dimensional
             quantities, rescale the returned MPO to represent ``H / hbar`` or measure
             time and energy in compatible units.
+        """
+        grid, ion_masses, dx, resolved_softening_length = cls._validate_trapped_ions_position_grid_inputs(
+            positions,
+            masses,
+            omega,
+            trap_center,
+            hbar,
+            coulomb_strength,
+            softening_length,
+            coulomb_cutoff,
+            max_bond_dim,
+        )
+        local_terms = cls._trapped_ions_position_grid_local_terms(grid, ion_masses, omega, trap_center, hbar, dx)
+
+        mpo = cls()
+        mpo.length = int(ion_masses.size)
+        mpo.physical_dimension = int(grid.size)
+
+        if ion_masses.size == 1:
+            mpo.tensors = [local_terms[0][:, :, None, None]]
+            assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
+            return mpo
+
+        coulomb_channels = cls._trapped_ions_position_grid_coulomb_channels(
+            grid,
+            coulomb_strength,
+            resolved_softening_length,
+            coulomb_cutoff,
+            max_bond_dim,
+        )
+        d = grid.size
+        bond_dimension = len(coulomb_channels) + 2
+        identity = np.eye(d, dtype=np.complex128)
+        left = np.zeros((d, d, 1, bond_dimension), dtype=np.complex128)
+        right = np.zeros((d, d, bond_dimension, 1), dtype=np.complex128)
+        left[:, :, 0, 0] = local_terms[0]
+        right[:, :, 0, 0] = identity
+        left[:, :, 0, 1] = identity
+        right[:, :, 1, 0] = local_terms[1]
+
+        for alpha, (left_channel, right_channel) in enumerate(coulomb_channels, start=2):
+            left[:, :, 0, alpha] = left_channel
+            right[:, :, alpha, 0] = right_channel
+
+        mpo.tensors = [left, right]
+        assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
+        return mpo
+
+    @staticmethod
+    def _validate_trapped_ions_position_grid_inputs(
+        positions: NDArray[np.float64],
+        masses: Sequence[float],
+        omega: float,
+        trap_center: float,
+        hbar: float,
+        coulomb_strength: float,
+        softening_length: float | None,
+        coulomb_cutoff: float,
+        max_bond_dim: int | None,
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64], float, float]:
+        """Validate trapped-ion position-grid inputs and return normalized parameters.
+
+        Returns:
+            Tuple containing the validated grid, ion masses, grid spacing, and resolved
+            softening length.
+
+        Raises:
+            ValueError: If the grid or physical parameters are invalid, if the number of
+                masses is not one or two, or if ``max_bond_dim`` is too small.
         """
         grid = np.asarray(positions, dtype=np.float64)
         if grid.ndim != 1 or grid.size < 3:
@@ -689,41 +754,66 @@ class MPO:
         if not np.isfinite(coulomb_cutoff) or not 0.0 <= coulomb_cutoff < 1.0:
             msg = "coulomb_cutoff must be finite and satisfy 0 <= coulomb_cutoff < 1."
             raise ValueError(msg)
-        if max_bond_dim is not None and max_bond_dim < 2:
-            msg = "max_bond_dim must be at least 2."
-            raise ValueError(msg)
         if ion_masses.size == 1 and coulomb_strength:
             msg = "coulomb_strength must be zero for a one-ion Hamiltonian."
             raise ValueError(msg)
+        if ion_masses.size == 1:
+            if max_bond_dim is not None and max_bond_dim < 1:
+                msg = "max_bond_dim must be at least 1 for a one-ion Hamiltonian."
+                raise ValueError(msg)
+            resolved_softening = spacings[0] if softening_length is None else softening_length
+            return grid, ion_masses, float(spacings[0]), float(resolved_softening)
 
-        d = grid.size
         dx = float(spacings[0])
+        if max_bond_dim is not None and max_bond_dim < 2:
+            msg = "max_bond_dim must be at least 2 for a two-ion Hamiltonian."
+            raise ValueError(msg)
+        if softening_length is None:
+            softening_length = dx
+        if not np.isfinite(softening_length) or softening_length <= 0.0:
+            msg = "softening_length must be finite and positive."
+            raise ValueError(msg)
+        return grid, ion_masses, dx, float(softening_length)
 
-        def local_hamiltonian(mass: float) -> ComplexTensor:
+    @staticmethod
+    def _trapped_ions_position_grid_local_terms(
+        grid: NDArray[np.float64],
+        ion_masses: NDArray[np.float64],
+        omega: float,
+        trap_center: float,
+        hbar: float,
+        dx: float,
+    ) -> list[ComplexTensor]:
+        """Construct finite-difference kinetic plus harmonic-potential local terms.
+
+        Returns:
+            Local Hamiltonian matrix for each ion mass.
+        """
+        d = grid.size
+        local_terms: list[ComplexTensor] = []
+        for mass in ion_masses:
             kinetic_diagonal = np.full(d, hbar**2 / (mass * dx**2), dtype=np.float64)
             kinetic_off_diagonal = np.full(d - 1, -(hbar**2 / (2.0 * mass * dx**2)), dtype=np.float64)
             kinetic = (
                 np.diag(kinetic_diagonal) + np.diag(kinetic_off_diagonal, k=-1) + np.diag(kinetic_off_diagonal, k=1)
             )
             potential = 0.5 * mass * omega**2 * (grid - trap_center) ** 2
-            return np.asarray(kinetic + np.diag(potential), dtype=np.complex128)
+            local_terms.append(np.asarray(kinetic + np.diag(potential), dtype=np.complex128))
+        return local_terms
 
-        local_terms = [local_hamiltonian(float(mass)) for mass in ion_masses]
-        mpo = cls()
-        mpo.length = int(ion_masses.size)
-        mpo.physical_dimension = d
+    @staticmethod
+    def _trapped_ions_position_grid_coulomb_channels(
+        grid: NDArray[np.float64],
+        coulomb_strength: float,
+        softening_length: float,
+        coulomb_cutoff: float,
+        max_bond_dim: int | None,
+    ) -> list[tuple[ComplexTensor, ComplexTensor]]:
+        """Factorize the softened Coulomb grid into diagonal MPO interaction channels.
 
-        if ion_masses.size == 1:
-            mpo.tensors = [local_terms[0][:, :, None, None]]
-            assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
-            return mpo
-
-        if softening_length is None:
-            softening_length = dx
-        if not np.isfinite(softening_length) or softening_length <= 0.0:
-            msg = "softening_length must be finite and positive."
-            raise ValueError(msg)
-
+        Returns:
+            Pairs of diagonal left/right MPO channel matrices for the retained SVD terms.
+        """
         distance = grid[:, None] - grid[None, :]
         coulomb = coulomb_strength / np.sqrt(distance**2 + softening_length**2)
         u, singular_values, vh = linalg.svd(coulomb, full_matrices=False)
@@ -734,23 +824,14 @@ class MPO:
         if max_bond_dim is not None:
             rank = min(rank, max_bond_dim - 2)
 
-        bond_dimension = rank + 2
-        identity = np.eye(d, dtype=np.complex128)
-        left = np.zeros((d, d, 1, bond_dimension), dtype=np.complex128)
-        right = np.zeros((d, d, bond_dimension, 1), dtype=np.complex128)
-        left[:, :, 0, 0] = local_terms[0]
-        right[:, :, 0, 0] = identity
-        left[:, :, 0, 1] = identity
-        right[:, :, 1, 0] = local_terms[1]
-
+        channels: list[tuple[ComplexTensor, ComplexTensor]] = []
         for alpha in range(rank):
             scale = math.sqrt(float(singular_values[alpha]))
-            left[:, :, 0, alpha + 2] = np.diag(scale * u[:, alpha])
-            right[:, :, alpha + 2, 0] = np.diag(scale * vh[alpha, :])
-
-        mpo.tensors = [left, right]
-        assert mpo.check_if_valid_mpo(), "MPO initialized wrong"
-        return mpo
+            channels.append((
+                np.asarray(np.diag(scale * u[:, alpha]), dtype=np.complex128),
+                np.asarray(np.diag(scale * vh[alpha, :]), dtype=np.complex128),
+            ))
+        return channels
 
     @classmethod
     def identity(cls, length: int, physical_dimension: int = 2) -> MPO:

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from .core.data_structures.hamiltonian import Representation
     from .core.data_structures.mpo import MPO
     from .core.data_structures.mps import MPS
+    from .parallel_utils import MPContext
 
 # Optional: extra control over threadpools inside worker processes.
 # We keep references as optionals, set by a guarded import.
@@ -114,7 +115,7 @@ from .core.data_structures.simulation_parameters import (
     _prepare_observable_ordering,
 )
 from .core.data_structures.state import State
-from .parallel_utils import MPContext, available_cpus, get_parallel_context, limit_worker_threads
+from .parallel_utils import available_cpus, get_parallel_context, limit_worker_threads
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -424,9 +425,15 @@ def _store_final_mps(result: Result, final_mps: MPS | None) -> None:
         result.output_state = State.from_mps(final_mps)
 
 
-def _store_mcwf_final_state(result: Result, psi: np.ndarray | None) -> None:
+def _store_mcwf_final_state(
+    result: Result,
+    psi: np.ndarray | None,
+    *,
+    length: int | None = None,
+    physical_dimensions: list[int] | int | None = None,
+) -> None:
     if psi is not None:
-        result.output_state = State(vector=psi)
+        result.output_state = State(length=length, vector=psi, physical_dimensions=physical_dimensions)
 
 
 def _store_lindblad_final_state(
@@ -841,6 +848,7 @@ class Simulator:
                 worker_params,
                 psi_initial=None if mps is not None else initial_state.vector,
                 num_sites=initial_state.length if mps is None else None,
+                physical_dimensions=initial_state.physical_dimensions,
                 h_sparse=h_sparse,
             )
             payload = {"ctx": ctx}
@@ -923,7 +931,12 @@ class Simulator:
                         final_mps = cast("MPS", traj_final)
 
         if state_rep == "vector":
-            _store_mcwf_final_state(result, final_psi)
+            _store_mcwf_final_state(
+                result,
+                final_psi,
+                length=initial_state.length,
+                physical_dimensions=initial_state.physical_dimensions,
+            )
         elif state_rep == "density_matrix":
             _store_lindblad_final_state(
                 result,

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -433,6 +433,19 @@ def _store_mcwf_final_state(
     length: int | None = None,
     physical_dimensions: list[int] | int | None = None,
 ) -> None:
+    """Store the final MCWF state vector on ``result.output_state``.
+
+    If ``psi`` is not ``None``, this function stores a vector
+    :class:`~mqt.yaqs.core.data_structures.state.State` on ``result.output_state``
+    while preserving the original lattice length and local dimensions.
+
+    Args:
+        result: Output container for the simulation run.
+        psi: Final state vector, or ``None`` when ``get_state`` is ``False``.
+        length: Number of lattice sites from the initial state. Passed through so
+            non-qubit vector states do not need to infer a qubit chain length.
+        physical_dimensions: Per-site physical dimensions from the initial state.
+    """
     if psi is not None:
         result.output_state = State(length=length, vector=psi, physical_dimensions=physical_dimensions)
 
@@ -857,6 +870,7 @@ class Simulator:
                 worker_params,
                 rho_initial=initial_state.density_matrix,
                 num_sites=initial_state.length,
+                physical_dimensions=initial_state.physical_dimensions,
                 h_sparse=h_sparse,
             )
             payload = {"ctx": lindblad_ctx}

--- a/tests/core/data_structures/test_mpo.py
+++ b/tests/core/data_structures/test_mpo.py
@@ -24,6 +24,8 @@ from mqt.yaqs.core.data_structures.simulation_parameters import Observable, Stro
 from mqt.yaqs.core.libraries.gate_library import Destroy, GateLibrary, Id, Z
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from numpy.typing import NDArray
 
 # ---- single-qubit ops ----
@@ -178,6 +180,26 @@ def _bose_hubbard_dense(length: int, local_dim: int, omega: float, hopping_j: fl
         H += -hopping_j * embed(op_list2)  # noqa: N806
 
     return H
+
+
+def _position_grid_local_hamiltonian(
+    positions: np.ndarray,
+    mass: float,
+    omega: float,
+    trap_center: float,
+    hbar: float,
+) -> np.ndarray:
+    """Construct the dense one-ion finite-difference Hamiltonian used as a test reference.
+
+    Returns:
+        Dense local Hamiltonian in the position-grid basis.
+    """
+    d = positions.size
+    dx = positions[1] - positions[0]
+    second_derivative = (np.diag(np.ones(d - 1), k=-1) - 2.0 * np.eye(d) + np.diag(np.ones(d - 1), k=1)) / dx**2
+    kinetic = -(hbar**2 / (2.0 * mass)) * second_derivative
+    potential = np.diag(0.5 * mass * omega**2 * (positions - trap_center) ** 2)
+    return kinetic + potential
 
 
 def _embed_local_ops(length: int, local_dim: int, site_ops: list[np.ndarray]) -> np.ndarray:
@@ -398,6 +420,106 @@ def test_bose_hubbard_correct_operator() -> None:
     H_dense = _bose_hubbard_dense(length, local_dim, omega, J, U)  # noqa: N806
     H_mpo = mpo.to_matrix()  # noqa: N806
     np.testing.assert_allclose(H_mpo, H_dense, atol=1e-8)
+
+
+def test_trapped_ions_position_grid_one_ion() -> None:
+    """Verify the one-ion position-grid MPO against a dense finite-difference reference."""
+    positions = np.linspace(-1.5, 1.5, 5)
+    mass = 1.7
+    omega = 0.8
+    trap_center = 0.2
+    hbar = 0.9
+
+    mpo = MPO.trapped_ions_position_grid(
+        positions,
+        [mass],
+        omega,
+        trap_center=trap_center,
+        hbar=hbar,
+    )
+
+    expected = _position_grid_local_hamiltonian(positions, mass, omega, trap_center, hbar)
+    assert mpo.length == 1
+    assert mpo.physical_dimension == positions.size
+    assert mpo.tensors[0].shape == (positions.size, positions.size, 1, 1)
+    np.testing.assert_allclose(mpo.to_matrix(), expected, atol=1e-12)
+
+
+def test_trapped_ions_position_grid_two_ions() -> None:
+    """Verify the exact two-ion MPO including its softened Coulomb interaction."""
+    positions = np.linspace(-1.0, 1.0, 4)
+    masses = [1.2, 1.8]
+    omega = 0.7
+    trap_center = -0.1
+    hbar = 0.85
+    coulomb_strength = 0.6
+    softening_length = 0.3
+
+    mpo = MPO.trapped_ions_position_grid(
+        positions,
+        masses,
+        omega,
+        trap_center=trap_center,
+        hbar=hbar,
+        coulomb_strength=coulomb_strength,
+        softening_length=softening_length,
+        coulomb_cutoff=0.0,
+    )
+
+    h1 = _position_grid_local_hamiltonian(positions, masses[0], omega, trap_center, hbar)
+    h2 = _position_grid_local_hamiltonian(positions, masses[1], omega, trap_center, hbar)
+    identity = np.eye(positions.size)
+    distance = positions[:, None] - positions[None, :]
+    coulomb = coulomb_strength / np.sqrt(distance**2 + softening_length**2)
+    expected = np.kron(h1, identity) + np.kron(identity, h2) + np.diag(coulomb.ravel())
+
+    assert mpo.length == 2
+    assert mpo.physical_dimension == positions.size
+    assert mpo.tensors[0].shape[3] == positions.size + 2
+    assert mpo.tensors[1].shape[2] == positions.size + 2
+    np.testing.assert_allclose(mpo.to_matrix(), expected, atol=1e-11)
+    np.testing.assert_allclose(mpo.to_matrix(), mpo.to_matrix().conj().T, atol=1e-12)
+
+
+def test_trapped_ions_position_grid_coulomb_truncation() -> None:
+    """Verify that max_bond_dim caps Coulomb channels while retaining local terms."""
+    positions = np.linspace(-2.0, 2.0, 6)
+    mpo = MPO.trapped_ions_position_grid(
+        positions,
+        [1.0, 1.0],
+        0.5,
+        coulomb_strength=0.4,
+        max_bond_dim=4,
+    )
+
+    assert mpo.tensors[0].shape[3] == 4
+    assert mpo.tensors[1].shape[2] == 4
+    np.testing.assert_allclose(mpo.to_matrix(), mpo.to_matrix().conj().T, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"positions": np.array([0.0, 1.0]), "masses": [1.0], "omega": 1.0}, "at least three"),
+        ({"positions": np.array([0.0, 1.0, 3.0]), "masses": [1.0], "omega": 1.0}, "uniformly spaced"),
+        ({"positions": np.arange(3.0), "masses": [], "omega": 1.0}, "exactly one or two"),
+        ({"positions": np.arange(3.0), "masses": [-1.0], "omega": 1.0}, "finite positive"),
+        ({"positions": np.arange(3.0), "masses": [1.0], "omega": -1.0}, "non-negative"),
+        (
+            {"positions": np.arange(3.0), "masses": [1.0], "omega": 1.0, "coulomb_strength": 1.0},
+            "must be zero",
+        ),
+        (
+            {"positions": np.arange(3.0), "masses": [1.0, 1.0], "omega": 1.0, "softening_length": 0.0},
+            "finite and positive",
+        ),
+        ({"positions": np.arange(3.0), "masses": [1.0, 1.0], "omega": 1.0, "max_bond_dim": 1}, "at least 2"),
+    ],
+)
+def test_trapped_ions_position_grid_validation(kwargs: dict[str, Any], match: str) -> None:
+    """Reject malformed trapped-ion grids and physical parameters."""
+    with pytest.raises(ValueError, match=match):
+        MPO.trapped_ions_position_grid(**kwargs)
 
 
 def test_fermi_hubbard_1d_correct_operator() -> None:

--- a/tests/core/data_structures/test_mpo.py
+++ b/tests/core/data_structures/test_mpo.py
@@ -535,6 +535,10 @@ def test_trapped_ion_coulomb_truncation() -> None:
             "finite and positive",
         ),
         ({"positions": np.arange(3.0), "masses": [1.0, 1.0], "omega": 1.0, "max_bond_dim": 1}, "at least 2"),
+        (
+            {"positions": np.arange(3.0), "masses": [1.0, 1.0], "omega": 1.0, "max_bond_dim": 4.0},
+            "must be an integer",
+        ),
     ],
 )
 def test_trapped_ion_validation(kwargs: dict[str, Any], match: str) -> None:

--- a/tests/core/data_structures/test_mpo.py
+++ b/tests/core/data_structures/test_mpo.py
@@ -191,6 +191,13 @@ def _position_grid_local_hamiltonian(
 ) -> np.ndarray:
     """Construct the dense one-ion finite-difference Hamiltonian used as a test reference.
 
+    Args:
+        positions: One-dimensional numpy array containing the uniform position grid.
+        mass: Ion mass used in the kinetic and harmonic potential terms.
+        omega: Harmonic trap angular frequency.
+        trap_center: Center position of the harmonic trap.
+        hbar: Reduced Planck constant used in the kinetic prefactor.
+
     Returns:
         Dense local Hamiltonian in the position-grid basis.
     """
@@ -422,7 +429,7 @@ def test_bose_hubbard_correct_operator() -> None:
     np.testing.assert_allclose(H_mpo, H_dense, atol=1e-8)
 
 
-def test_trapped_ions_position_grid_one_ion() -> None:
+def test_trapped_ion_one_ion() -> None:
     """Verify the one-ion position-grid MPO against a dense finite-difference reference."""
     positions = np.linspace(-1.5, 1.5, 5)
     mass = 1.7
@@ -430,12 +437,13 @@ def test_trapped_ions_position_grid_one_ion() -> None:
     trap_center = 0.2
     hbar = 0.9
 
-    mpo = MPO.trapped_ions_position_grid(
+    mpo = MPO.trapped_ion(
         positions,
         [mass],
         omega,
         trap_center=trap_center,
         hbar=hbar,
+        max_bond_dim=1,
     )
 
     expected = _position_grid_local_hamiltonian(positions, mass, omega, trap_center, hbar)
@@ -445,7 +453,7 @@ def test_trapped_ions_position_grid_one_ion() -> None:
     np.testing.assert_allclose(mpo.to_matrix(), expected, atol=1e-12)
 
 
-def test_trapped_ions_position_grid_two_ions() -> None:
+def test_trapped_ion_two_ions() -> None:
     """Verify the exact two-ion MPO including its softened Coulomb interaction."""
     positions = np.linspace(-1.0, 1.0, 4)
     masses = [1.2, 1.8]
@@ -455,7 +463,7 @@ def test_trapped_ions_position_grid_two_ions() -> None:
     coulomb_strength = 0.6
     softening_length = 0.3
 
-    mpo = MPO.trapped_ions_position_grid(
+    mpo = MPO.trapped_ion(
         positions,
         masses,
         omega,
@@ -481,20 +489,33 @@ def test_trapped_ions_position_grid_two_ions() -> None:
     np.testing.assert_allclose(mpo.to_matrix(), mpo.to_matrix().conj().T, atol=1e-12)
 
 
-def test_trapped_ions_position_grid_coulomb_truncation() -> None:
-    """Verify that max_bond_dim caps Coulomb channels while retaining local terms."""
+def test_trapped_ion_coulomb_truncation() -> None:
+    """Verify that max_bond_dim retains the leading Coulomb SVD channels."""
     positions = np.linspace(-2.0, 2.0, 6)
-    mpo = MPO.trapped_ions_position_grid(
+    omega = 0.5
+    coulomb_strength = 0.4
+    softening_length = positions[1] - positions[0]
+    mpo = MPO.trapped_ion(
         positions,
         [1.0, 1.0],
-        0.5,
-        coulomb_strength=0.4,
+        omega,
+        coulomb_strength=coulomb_strength,
         max_bond_dim=4,
     )
 
     assert mpo.tensors[0].shape[3] == 4
     assert mpo.tensors[1].shape[2] == 4
-    np.testing.assert_allclose(mpo.to_matrix(), mpo.to_matrix().conj().T, atol=1e-12)
+
+    local_h = _position_grid_local_hamiltonian(positions, 1.0, omega, 0.0, 1.0)
+    identity = np.eye(positions.size)
+    dense_coulomb = mpo.to_matrix() - np.kron(local_h, identity) - np.kron(identity, local_h)
+    truncated_coulomb = np.diag(dense_coulomb).reshape(positions.size, positions.size)
+
+    distance = positions[:, None] - positions[None, :]
+    exact_coulomb = coulomb_strength / np.sqrt(distance**2 + softening_length**2)
+    u, singular_values, vh = np.linalg.svd(exact_coulomb, full_matrices=False)
+    expected_rank_2 = u[:, :2] @ np.diag(singular_values[:2]) @ vh[:2, :]
+    np.testing.assert_allclose(truncated_coulomb, expected_rank_2, atol=1e-12)
 
 
 @pytest.mark.parametrize(
@@ -516,10 +537,10 @@ def test_trapped_ions_position_grid_coulomb_truncation() -> None:
         ({"positions": np.arange(3.0), "masses": [1.0, 1.0], "omega": 1.0, "max_bond_dim": 1}, "at least 2"),
     ],
 )
-def test_trapped_ions_position_grid_validation(kwargs: dict[str, Any], match: str) -> None:
+def test_trapped_ion_validation(kwargs: dict[str, Any], match: str) -> None:
     """Reject malformed trapped-ion grids and physical parameters."""
     with pytest.raises(ValueError, match=match):
-        MPO.trapped_ions_position_grid(**kwargs)
+        MPO.trapped_ion(**kwargs)
 
 
 def test_fermi_hubbard_1d_correct_operator() -> None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -395,6 +395,54 @@ def test_analog_simulation_get_state() -> None:
         np.testing.assert_allclose(1, fidelity)
 
 
+def test_trapped_ion_position_grid_vector_and_mps_simulation_agree() -> None:
+    """Noiseless vector and MPS evolution agree for a displaced ion in a static harmonic well."""
+    initial_displacement = 1.0
+    omega = 1.0
+    half_period = np.pi / omega
+
+    positions = np.linspace(-8.0, 8.0, 33)
+    grid_dim = len(positions)
+    initial_grid_state = np.exp(-0.5 * (positions - initial_displacement) ** 2).astype(np.complex128)
+    initial_grid_state /= np.linalg.norm(initial_grid_state)
+
+    hamiltonian = Hamiltonian.from_mpo(MPO.trapped_ions_position_grid(positions, masses=[1.0], omega=omega))
+    sim_params = AnalogSimParams(
+        observables=[],
+        elapsed_time=half_period,
+        dt=half_period / 16,
+        num_traj=1,
+        max_bond_dim=None,
+        svd_threshold=1e-12,
+        krylov_tol=1e-12,
+        order=2,
+        preset="exact",
+        get_state=True,
+        sample_timesteps=False,
+    )
+
+    vector_state = State(length=1, vector=initial_grid_state, physical_dimensions=[grid_dim])
+    mps_state = State(length=1, tensors=[initial_grid_state.reshape(grid_dim, 1, 1)], physical_dimensions=[grid_dim])
+
+    vector_result = Simulator(parallel=False, show_progress=False).run(vector_state, hamiltonian, sim_params, None)
+    mps_result = Simulator(parallel=False, show_progress=False).run(mps_state, hamiltonian, sim_params, None)
+
+    assert vector_result.output_state is not None
+    assert mps_result.output_state is not None
+    vector_final = vector_result.output_state.vector
+    mps_final = mps_result.output_state.mps.to_vec()
+    overlap = np.vdot(vector_final, mps_final)
+
+    np.testing.assert_allclose(np.abs(overlap) ** 2, 1.0, atol=1e-12)
+    # A displaced harmonic-oscillator ground state reaches the opposite turning point
+    # after half a trap period. The tolerance accounts for the finite grid/discretized kinetic operator.
+    np.testing.assert_allclose(
+        float(np.sum(positions * np.abs(vector_final) ** 2)),
+        -initial_displacement,
+        atol=3e-2,
+    )
+
+
 def test_density_matrix_get_state() -> None:
     """density_matrix evolution returns the final density matrix when get_state=True."""
     psi = State(2, initial="zeros", representation="density_matrix")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numba
 import numpy as np
 import pytest
+import scipy.sparse
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import Pauli, Statevector
 
@@ -405,7 +406,7 @@ def test_trapped_ion_position_grid_vector_and_mps_simulation_agree() -> None:
     initial_grid_state = np.exp(-0.5 * (positions - initial_displacement) ** 2).astype(np.complex128)
     initial_grid_state /= np.linalg.norm(initial_grid_state)
 
-    hamiltonian = Hamiltonian.from_mpo(MPO.trapped_ions_position_grid(positions, masses=[1.0], omega=omega))
+    hamiltonian = Hamiltonian.from_mpo(MPO.trapped_ion(positions, masses=[1.0], omega=omega))
     sim_params = AnalogSimParams(
         observables=[],
         elapsed_time=half_period,
@@ -487,6 +488,44 @@ def test_density_matrix_get_state_noisy() -> None:
     np.testing.assert_allclose(rho, expected, atol=1e-4)
     assert np.isclose(np.trace(rho), 1.0)
     assert np.allclose(rho.imag, 0.0, atol=1e-10)
+
+
+def test_density_matrix_non_qubit_physical_dimension() -> None:
+    """Lindblad density-matrix evolution supports non-qubit local dimensions."""
+    physical_dimension = 3
+    rho_initial = np.zeros((physical_dimension, physical_dimension), dtype=np.complex128)
+    rho_initial[2, 2] = 1.0
+    initial_state = State(length=1, density_matrix=rho_initial, physical_dimensions=[physical_dimension])
+    hamiltonian = Hamiltonian(
+        sparse_matrix=scipy.sparse.csr_matrix((physical_dimension, physical_dimension), dtype=np.complex128),
+        length=1,
+        physical_dimension=physical_dimension,
+    )
+
+    lowering_21 = np.zeros((physical_dimension, physical_dimension), dtype=np.complex128)
+    lowering_21[1, 2] = 1.0
+    gamma = 0.7
+    elapsed_time = 0.4
+    noise_model = NoiseModel(
+        processes=[{"name": "qutrit_decay_2_to_1", "sites": [0], "strength": gamma, "matrix": lowering_21}],
+    )
+    sim_params = AnalogSimParams(
+        observables=[],
+        elapsed_time=elapsed_time,
+        dt=0.1,
+        get_state=True,
+    )
+
+    result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, noise_model)
+
+    assert result.output_state is not None
+    assert result.output_state.length == 1
+    assert result.output_state.physical_dimensions == [physical_dimension]
+    rho = result.output_state.density_matrix
+    expected = np.zeros_like(rho)
+    expected[1, 1] = 1.0 - np.exp(-gamma * elapsed_time)
+    expected[2, 2] = np.exp(-gamma * elapsed_time)
+    np.testing.assert_allclose(rho, expected, atol=1e-4)
 
 
 def test_density_matrix_get_state_at_elapsed_time() -> None:


### PR DESCRIPTION
Added trapped-ion Hamiltonian for one or two ions in a harmonic potential well under Coulomb repulsion.

## Description

Added MPO construction for finite-difference-based trapped-ion motional hamiltonian in `mpo.py`. Spatial discretization and physical parameters can be adjusted. Tests in `test_mpo.py` assert compliance between returned mpo.to_matrix() and a naive matrix implementation. Sanity checks were performed to ensure expected physical breathing and sloshing waveform behavior (not committed).

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are focused and relevant to this change.
- [X] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

> Assisted by ChatGPT Codex 5.5 via VS Code Codex Plugin

- [X] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [X] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
