### PR TITLE
added QR canonicalization before compression sweep for stability

### DIFF
--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -843,17 +843,21 @@ class MPS:
         max_bond_dim: int | None = None,
         trunc_mode: TruncMode = "discarded_weight",
     ) -> None:
-        """Compress in place via left-to-center and right-to-left two-site SVD sweeps.
+        """Compress in place by right-canonicalizing, then truncating left-to-right.
+
+        Truncating while establishing a mixed gauge from a non-canonical product
+        state (e.g. after uncapped MPO-MPS multiplication) is not equivalent to the optimal
+        sequential SVD of the state and can leave large, θ-independent residuals.
+        The procedure here is:
+
+        1. Restore a right-canonical gauge with QR (no bond-dimension cap).
+        2. Sweep left-to-right with truncated SVD at each bond.
+        3. Restore the original orthogonality center without further truncation.
 
         Args:
             threshold: SVD truncation threshold (e.g. ``sim_params.svd_threshold``).
             max_bond_dim: Optional cap on bond dimension.
             trunc_mode: ``"discarded_weight"`` or ``"relative"``.
-
-        Notes:
-            When the gauge is unknown, the sweep center is inferred via
-            :meth:`check_canonical_form`. After compression,
-            :attr:`orthogonality_center` is set to the sweep center used.
         """
         if self.length == 1:
             return
@@ -862,9 +866,12 @@ class MPS:
             orth_center = self._orthogonality_center
         else:
             canonical = self.check_canonical_form()
-            orth_center = canonical[0] if canonical and canonical[0] >= 0 else self.length - 1
+            orth_center = canonical[0] if canonical and canonical[0] >= 0 else self.length // 2
 
-        for site in range(orth_center):
+        # Right-canonical form without χ truncation (center at site 0).
+        self.set_canonical_form(0, decomposition="QR")
+
+        for site in range(self.length - 1):
             left_tensor = self.tensors[site]
             right_tensor = self.tensors[site + 1]
             merged = merge_two_site(left_tensor, right_tensor)
@@ -878,26 +885,14 @@ class MPS:
             )
             self.tensors[site] = left_new
             self.tensors[site + 1] = right_new
+            self._orthogonality_center = site + 1
 
-        self.flip_network()
-        orth_flipped = self.length - 1 - orth_center
-        for site in range(orth_flipped):
-            left_tensor = self.tensors[site]
-            right_tensor = self.tensors[site + 1]
-            merged = merge_two_site(left_tensor, right_tensor)
-            left_new, right_new = split_two_site(
-                merged,
-                [left_tensor.shape[0], right_tensor.shape[0]],
-                svd_distribution="right",
-                trunc_mode=trunc_mode,
-                threshold=threshold,
-                max_bond_dim=max_bond_dim,
-            )
-            self.tensors[site] = left_new
-            self.tensors[site + 1] = right_new
-        self.flip_network()
-
-        self._orthogonality_center = orth_center
+        # Restore the caller's center without additional truncation.
+        assert self._orthogonality_center is not None
+        while self._orthogonality_center < orth_center:
+            self.shift_orthogonality_center_right(self._orthogonality_center, "QR")
+        while self._orthogonality_center > orth_center:
+            self.shift_orthogonality_center_left(self._orthogonality_center, "QR")
 
     def scalar_product(self, other: MPS, sites: int | list[int] | None = None) -> np.complex128:
         """Compute the scalar (inner) product between two Matrix Product States (MPS).

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -1160,6 +1160,29 @@ def test_truncate_reduces_bond_dimensions_and_truncates() -> None:
         assert bond_right <= 3
 
 
+def test_compress_canonicalizes_unknown_gauge_before_truncating() -> None:
+    """Compression of a non-canonical MPS should not retain a gauge-dependent residual."""
+    local_rng = np.random.default_rng(42)
+    shapes = [(2, 1, 4), (2, 4, 4), (2, 4, 4), (2, 4, 1)]
+    tensors = [
+        np.asarray(
+            local_rng.normal(size=shape) + 1j * local_rng.normal(size=shape),
+            dtype=np.complex128,
+        )
+        for shape in shapes
+    ]
+    mps = MPS(length=4, tensors=tensors)
+    before = mps.to_vec()
+    assert mps.orthogonality_center is None
+
+    mps.compress(threshold=1e-14, max_bond_dim=2)
+
+    relative_residual = np.linalg.norm(before - mps.to_vec()) / np.linalg.norm(before)
+    assert relative_residual < 0.1
+    assert mps.orthogonality_center == 2
+    assert mps.check_canonical_form() == [2]
+
+
 def test_compress_single_site_returns_immediately() -> None:
     """``compress`` is a no-op on a one-site MPS."""
     mps = MPS(1, state="zeros")


### PR DESCRIPTION
## Description

This PR fixes MPS.compress so it QR-canonicalizes before applying truncated SVD, avoiding large gauge-dependent residuals when compressing non-canonical states (this was noticed after MPO–MPS multiplication with no bond dimension cap).

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
