### PR TITLE
State.representation set as sole backend selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ releases may include breaking changes.
 
 ### Changed
 
+- State.representation set as sole backend selector ([#519])
+  ([**@aaronleesander**])
+- added QR canonicalization before compression sweep for stability ([#518])
+  ([**@aaronleesander**])
 - combined WeakSimParams and StrongSimParams into DigitalSimParams ([#516])
   ([**@aaronleesander**])
 
@@ -225,6 +229,8 @@ changelogs._
 
 <!-- PR links -->
 
+[#519]: https://github.com/munich-quantum-toolkit/yaqs/pull/519
+[#518]: https://github.com/munich-quantum-toolkit/yaqs/pull/518
 [#516]: https://github.com/munich-quantum-toolkit/yaqs/pull/516
 [#514]: https://github.com/munich-quantum-toolkit/yaqs/pull/514
 [#508]: https://github.com/munich-quantum-toolkit/yaqs/pull/508

--- a/docs/examples/hamiltonians.md
+++ b/docs/examples/hamiltonians.md
@@ -21,18 +21,19 @@ argument to {meth}`~mqt.yaqs.Simulator.run`. Most models are built as
 materialises once at construction and can be reused across parameter sweeps.
 
 **Backend selection** is driven only by
-{class}`~mqt.yaqs.core.data_structures.state.State` representation — not by a
-second argument on Hamiltonian factories:
+{class}`~mqt.yaqs.core.data_structures.state.State` representation — not by how
+the Hamiltonian was constructed:
 
-| `State.representation` | Backend  | Hamiltonian form at `run` |
-| ---------------------- | -------- | ------------------------- |
-| `"mps"` (default)      | TJM      | MPO                       |
-| `"vector"`             | MCWF     | sparse (auto from MPO)    |
-| `"density_matrix"`     | Lindblad | sparse (auto from MPO)    |
+| `State.representation` | Backend  | Form materialized at `run` |
+| ---------------------- | -------- | -------------------------- |
+| `"mps"` (default)      | TJM      | MPO                        |
+| `"vector"`             | MCWF     | sparse                     |
+| `"density_matrix"`     | Lindblad | sparse                     |
 
-Preset factories such as `Hamiltonian.ising(...)` always build an MPO. The same
-instance works with all three state representations; `Simulator.run`
-materializes a sparse matrix for MCWF / Lindblad and caches it for reuse.
+Hamiltonian inputs (`tensors`, `matrix`, `sparse_matrix`, or a preset such as
+`Hamiltonian.ising(...)`) are **source data**, not backend choices. The same
+`Hamiltonian` instance works with all three state representations;
+`Simulator.run` converts and caches the required MPO or sparse form.
 
 This page covers the factory methods in the library. For open-system evolution
 after the Hamiltonian is defined, see {doc}`analog_simulation`. For choosing a
@@ -49,16 +50,16 @@ state representation, see {doc}`state_initialization` and
 Typical patterns:
 
 - **Preset classmethods** — `Hamiltonian.ising(...)`, `Hamiltonian.pauli(...)`,
-  etc. (always MPO; no `representation=` argument).
+  etc. (no `representation=` argument).
 - **Wrap an MPO** — `Hamiltonian.from_mpo(mpo)` after `MPO.bose_hubbard(...)` or
   a custom build.
-- **Manual data** — `Hamiltonian(tensors=...)` for TJM, or
-  `Hamiltonian(matrix=...)` / `sparse_matrix=...` for small-system MCWF /
-  Lindblad only (cannot drive TJM).
+- **Manual data** — `Hamiltonian(tensors=...)`, `Hamiltonian(matrix=...)`, or
+  `Hamiltonian(sparse_matrix=...)`. Any of these can drive TJM, MCWF, or
+  Lindblad once paired with the matching `State.representation`.
 
-Access the internal MPO with `H.mpo` when you need bond dimension or tensor
-cores. After a vector or density-matrix `run`, the cached sparse form is also
-available via `H.sparse_matrix` without losing `H.mpo`.
+Access the materialized MPO with `H.mpo` (after a TJM run or `H.ensure_mpo()`)
+and the sparse form with `H.sparse_matrix` (after an MCWF / Lindblad run or
+`H.ensure_sparse()`). Both can coexist on one instance.
 
 ## Built-in models (quick reference)
 
@@ -299,12 +300,12 @@ explicitly (see the factory docstring).
 For imported MPO cores or small-system dense operators:
 
 ```python
-# MPO tensor cores (rank-4 per site, already in MPO layout) — works with TJM
+# MPO tensor cores (rank-4 per site, already in MPO layout)
 H = Hamiltonian(tensors=my_cores)
 
-# Dense or sparse matrix — MCWF / Lindblad only (State.representation vector or
-# density_matrix). TJM requires an MPO / preset / tensors=.
+# Dense or sparse matrix — YAQS converts to MPO or sparse as needed at run time
 H = Hamiltonian(matrix=dense_h, physical_dimension=2)
+H = Hamiltonian(sparse_matrix=sparse_h, physical_dimension=2)
 ```
 
 ## Related topics

--- a/docs/examples/hamiltonians.md
+++ b/docs/examples/hamiltonians.md
@@ -35,6 +35,15 @@ Hamiltonian inputs (`tensors`, `matrix`, `sparse_matrix`, or a preset such as
 `Hamiltonian` instance works with all three state representations;
 `Simulator.run` converts and caches the required MPO or sparse form.
 
+```{warning}
+Selecting ``State.representation="mps"`` (TJM) calls
+{meth}`~mqt.yaqs.core.data_structures.hamiltonian.Hamiltonian.ensure_mpo`. For a
+``sparse_matrix`` source this densifies the operator before MPO factorization,
+allocating the full Hilbert-space matrix and risking out-of-memory failures on
+large systems. Prefer an MPO preset, ``Hamiltonian.from_mpo(...)``, or
+``tensors=`` when targeting TJM.
+```
+
 This page covers the factory methods in the library. For open-system evolution
 after the Hamiltonian is defined, see {doc}`analog_simulation`. For choosing a
 state representation, see {doc}`state_initialization` and
@@ -297,13 +306,14 @@ explicitly (see the factory docstring).
 
 ## Manual Hamiltonians
 
-For imported MPO cores or small-system dense operators:
+For imported MPO cores or small-system dense/sparse operators:
 
 ```python
-# MPO tensor cores (rank-4 per site, already in MPO layout)
+# MPO tensor cores (rank-4 per site, already in MPO layout) — preferred for TJM
 H = Hamiltonian(tensors=my_cores)
 
-# Dense or sparse matrix — YAQS converts to MPO or sparse as needed at run time
+# Dense or sparse matrix — YAQS converts to MPO or sparse as needed at run time.
+# sparse_matrix → TJM densifies; prefer tensors=/from_mpo/presets for large systems.
 H = Hamiltonian(matrix=dense_h, physical_dimension=2)
 H = Hamiltonian(sparse_matrix=sparse_h, physical_dimension=2)
 ```

--- a/docs/examples/hamiltonians.md
+++ b/docs/examples/hamiltonians.md
@@ -20,8 +20,24 @@ argument to {meth}`~mqt.yaqs.Simulator.run`. Most models are built as
 **matrix product operators (MPOs)** under the hood; the `Hamiltonian` wrapper
 materialises once at construction and can be reused across parameter sweeps.
 
+**Backend selection** is driven only by
+{class}`~mqt.yaqs.core.data_structures.state.State` representation — not by a
+second argument on Hamiltonian factories:
+
+| `State.representation` | Backend  | Hamiltonian form at `run` |
+| ---------------------- | -------- | ------------------------- |
+| `"mps"` (default)      | TJM      | MPO                       |
+| `"vector"`             | MCWF     | sparse (auto from MPO)    |
+| `"density_matrix"`     | Lindblad | sparse (auto from MPO)    |
+
+Preset factories such as `Hamiltonian.ising(...)` always build an MPO. The same
+instance works with all three state representations; `Simulator.run`
+materializes a sparse matrix for MCWF / Lindblad and caches it for reuse.
+
 This page covers the factory methods in the library. For open-system evolution
-after the Hamiltonian is defined, see {doc}`analog_simulation`.
+after the Hamiltonian is defined, see {doc}`analog_simulation`. For choosing a
+state representation, see {doc}`state_initialization` and
+{doc}`representation_comparison`.
 
 ## `Hamiltonian` versus `MPO`
 
@@ -33,14 +49,16 @@ after the Hamiltonian is defined, see {doc}`analog_simulation`.
 Typical patterns:
 
 - **Preset classmethods** — `Hamiltonian.ising(...)`, `Hamiltonian.pauli(...)`,
-  etc.
+  etc. (always MPO; no `representation=` argument).
 - **Wrap an MPO** — `Hamiltonian.from_mpo(mpo)` after `MPO.bose_hubbard(...)` or
   a custom build.
-- **Manual data** — `Hamiltonian(tensors=...)` or `Hamiltonian(matrix=...)` /
-  `sparse_matrix=...` for small dense/sparse backends (MCWF / Lindblad).
+- **Manual data** — `Hamiltonian(tensors=...)` for TJM, or
+  `Hamiltonian(matrix=...)` / `sparse_matrix=...` for small-system MCWF /
+  Lindblad only (cannot drive TJM).
 
 Access the internal MPO with `H.mpo` when you need bond dimension or tensor
-cores.
+cores. After a vector or density-matrix `run`, the cached sparse form is also
+available via `H.sparse_matrix` without losing `H.mpo`.
 
 ## Built-in models (quick reference)
 
@@ -281,10 +299,11 @@ explicitly (see the factory docstring).
 For imported MPO cores or small-system dense operators:
 
 ```python
-# MPO tensor cores (rank-4 per site, already in MPO layout)
+# MPO tensor cores (rank-4 per site, already in MPO layout) — works with TJM
 H = Hamiltonian(tensors=my_cores)
 
-# Dense matrix (MCWF / Lindblad when state is vector or density_matrix)
+# Dense or sparse matrix — MCWF / Lindblad only (State.representation vector or
+# density_matrix). TJM requires an MPO / preset / tensors=.
 H = Hamiltonian(matrix=dense_h, physical_dimension=2)
 ```
 

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -11,10 +11,9 @@ This module integrates the ensemble-averaged master equation (deterministic in r
 
     drho/dt = -i[H, rho] + sum_k ( L_k rho L_k^dag - 0.5 {L_k^dag L_k, rho} )
 
-MPS/MPO specify the initial pure state and Hamiltonian; the state is carried as a
-dense ``dim x dim`` matrix with ``dim = prod(physical_dimensions)``. With
-``noise_model=None`` (or zero strengths), the dissipator vanishes and evolution is
-unitary on rho.
+The state is carried as a dense ``dim x dim`` matrix with
+``dim = prod(physical_dimensions)``. With ``noise_model=None`` (or zero strengths),
+the dissipator vanishes and evolution is unitary on rho.
 
 Because ``H`` and the jump operators are time-independent, the generator is fixed.
 For small systems we precompute ``exp(L dt)`` where ``L`` is the Liouvillian
@@ -41,8 +40,6 @@ from .utils import _embed_observable_sparse, _embed_operator_sparse
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from ..core.data_structures.mpo import MPO
-    from ..core.data_structures.mps import MPS
     from ..core.data_structures.noise_model import NoiseModel
     from ..core.data_structures.simulation_parameters import AnalogSimParams
 
@@ -69,48 +66,30 @@ class LindbladContext:
 
 
 def preprocess_lindblad(
-    initial_state: MPS | None,
-    hamiltonian: MPO | None,
+    *,
+    rho_initial: NDArray[np.complex128],
+    h_sparse: scipy.sparse.spmatrix,
     noise_model: NoiseModel | None,
     sim_params: AnalogSimParams,
-    *,
-    rho_initial: NDArray[np.complex128] | None = None,
-    num_sites: int | None = None,
+    num_sites: int,
     physical_dimensions: int | list[int] | None = None,
-    h_sparse: scipy.sparse.spmatrix | None = None,
 ) -> LindbladContext:
     """Pre-compute operators and optional fixed-step propagator for Lindblad evolution.
 
     Args:
-        initial_state: The initial MPS state (converted to ``rho = |psi><psi|`` when no
-            ``rho_initial`` is passed), or ``None`` when ``rho_initial`` is supplied.
-        hamiltonian: The Hamiltonian MPO (ignored if ``h_sparse`` is set).
+        rho_initial: Density matrix (square) or flattened vector for vec(rho).
+        h_sparse: Sparse Hamiltonian on the full Hilbert space.
         noise_model: The noise model.
         sim_params: Simulation parameters.
-        rho_initial: Optional density matrix (square) or flattened vector for vec(rho).
-        num_sites: Number of lattice sites when ``initial_state`` is ``None``.
-        physical_dimensions: Per-site physical dimensions used to validate dense
-            density matrices and sparse Hamiltonian sizes. Defaults to qubits.
-        h_sparse: Pre-materialized sparse Hamiltonian (skips ``hamiltonian.to_sparse_matrix()``).
+        num_sites: Number of lattice sites.
+        physical_dimensions: Per-site physical dimensions. Defaults to qubits.
 
     Returns:
         LindbladContext ready for time evolution.
 
     Raises:
-        ValueError: If neither ``initial_state`` nor ``rho_initial`` is provided, or if
-            ``num_sites`` is missing when only ``rho_initial`` is given.
+        ValueError: If ``rho_initial`` or ``h_sparse`` has the wrong shape or zero trace.
     """
-    if initial_state is not None:
-        num_sites = initial_state.length
-        physical_dimensions = initial_state.physical_dimensions
-    elif rho_initial is not None:
-        if num_sites is None:
-            msg = "num_sites is required when preprocess_lindblad is called with rho_initial only."
-            raise ValueError(msg)
-    else:
-        msg = "preprocess_lindblad requires initial_state or rho_initial."
-        raise ValueError(msg)
-
     dim = math.prod(resolve_physical_dimensions(num_sites, physical_dimensions))
     site_dims = resolve_physical_dimensions(num_sites, physical_dimensions)
 
@@ -123,44 +102,30 @@ def preprocess_lindblad(
         )
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
-    # 1. Initial state as flattened vec(rho) (column-major order of the matrix).
-    if rho_initial is not None:
-        rho_arr = np.asarray(rho_initial, dtype=np.complex128)
-        if rho_arr.ndim == 2:
-            if rho_arr.shape != (dim, dim):
-                msg = f"rho_initial shape {rho_arr.shape} does not match ({dim}, {dim})."
-                raise ValueError(msg)
-            rho_mat = rho_arr
-        else:
-            if rho_arr.size != dim * dim:
-                msg = f"rho_initial size {rho_arr.size} does not match Hilbert dimension {dim * dim}."
-                raise ValueError(msg)
-            rho_mat = rho_arr.reshape(dim, dim, order="F")
-        trace = np.trace(rho_mat)
-        if np.isclose(trace, 0.0):
-            msg = "rho_initial must have non-zero trace."
+    rho_arr = np.asarray(rho_initial, dtype=np.complex128)
+    if rho_arr.ndim == 2:
+        if rho_arr.shape != (dim, dim):
+            msg = f"rho_initial shape {rho_arr.shape} does not match ({dim}, {dim})."
             raise ValueError(msg)
-        if not np.isclose(trace, 1.0):
-            rho_mat /= trace
-        rho_vec = np.asarray(rho_mat.flatten(order="F"), dtype=np.complex128)
+        rho_mat = rho_arr
     else:
-        assert initial_state is not None
-        psi = initial_state.to_vec()
-        rho_vec = np.asarray(np.outer(psi, psi.conj()).flatten(order="F"), dtype=np.complex128)
+        if rho_arr.size != dim * dim:
+            msg = f"rho_initial size {rho_arr.size} does not match Hilbert dimension {dim * dim}."
+            raise ValueError(msg)
+        rho_mat = rho_arr.reshape(dim, dim, order="F")
+    trace = np.trace(rho_mat)
+    if np.isclose(trace, 0.0):
+        msg = "rho_initial must have non-zero trace."
+        raise ValueError(msg)
+    if not np.isclose(trace, 1.0):
+        rho_mat /= trace
+    rho_vec = np.asarray(rho_mat.flatten(order="F"), dtype=np.complex128)
 
-    # 2. Hamiltonian as sparse matrix on the full Hilbert space.
-    if h_sparse is not None:
-        h_mat = scipy.sparse.csr_matrix(h_sparse)
-        if h_mat.shape != (dim, dim):
-            msg = f"h_sparse must have shape ({dim}, {dim}), got {h_mat.shape}."
-            raise ValueError(msg)
-    elif hamiltonian is not None:
-        h_mat = hamiltonian.to_sparse_matrix()
-    else:
-        msg = "preprocess_lindblad requires hamiltonian or h_sparse."
+    h_mat = scipy.sparse.csr_matrix(h_sparse)
+    if h_mat.shape != (dim, dim):
+        msg = f"h_sparse must have shape ({dim}, {dim}), got {h_mat.shape}."
         raise ValueError(msg)
 
-    # 3. Jump operators L_k = sqrt(gamma) * op on the full space.
     jump_ops: list[scipy.sparse.spmatrix] = []
     if noise_model is not None:
         for process in noise_model.processes:
@@ -172,14 +137,12 @@ def preprocess_lindblad(
 
     is_unitary = len(jump_ops) == 0
 
-    # 4. Precompute sum_k L_k^dag L_k for the dissipator anti-commutator (skipped if noiseless).
     l_dag_l_sum = scipy.sparse.csr_matrix((dim, dim), dtype=np.complex128)
     if jump_ops:
         for op in jump_ops:
             op_csr = cast("Any", op)
             l_dag_l_sum += op_csr.conj().T @ op_csr
 
-    # 5. Embed observables; MPS-only diagnostics are not traced on rho.
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
     for obs in sim_params.sorted_observables:
         if obs.gate.name in {"entropy", "schmidt_spectrum"}:
@@ -187,7 +150,6 @@ def preprocess_lindblad(
         else:
             embedded_observables.append(_embed_observable_sparse(obs, num_sites, physical_dimensions=site_dims))
 
-    # 6. Fixed-step propagator exp(L dt) when vec(rho) fits in memory (time-independent generator).
     step_propagator: NDArray[np.complex128] | None = None
     vec_dim = dim * dim
     if vec_dim <= MAX_LIOUVILLIAN_VECTOR_DIM:
@@ -446,25 +408,3 @@ def lindblad_evolve(ctx: LindbladContext) -> tuple[NDArray[np.float64], None, ND
         rho_mat = rho_vec.reshape((ctx.dim, ctx.dim), order="F")
         return obs, None, rho_mat
     return obs, None, None
-
-
-def lindblad(
-    args: tuple[int, MPS, NoiseModel | None, AnalogSimParams, MPO],
-) -> tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]:
-    """Run an exact Lindblad master-equation simulation.
-
-    Args:
-        args: A tuple containing:
-            - int: Trajectory identifier (unused; evolution is deterministic in rho).
-            - MPS: The initial state.
-            - NoiseModel | None: The noise model.
-            - AnalogSimParams: Simulation parameters.
-            - MPO: The Hamiltonian.
-
-    Returns:
-        tuple[NDArray[np.float64], None, NDArray[np.complex128] | None]: Observable data,
-        no diagnostics, and optional final density matrix when ``get_state`` is set.
-    """
-    _i, initial_state, noise_model, sim_params, hamiltonian = args
-    ctx = preprocess_lindblad(initial_state, hamiltonian, noise_model, sim_params)
-    return lindblad_evolve(ctx)

--- a/src/mqt/yaqs/analog/mcwf.py
+++ b/src/mqt/yaqs/analog/mcwf.py
@@ -8,8 +8,7 @@
 """Monte Carlo wavefunction (MCWF) evolution for ``representation='vector'``.
 
 This module implements a stochastic unraveling of the Lindblad master equation for
-small systems. MPS/MPO inputs are contracted to a dense state vector and sparse
-operators; the trajectory is evolved in Hilbert space (not in a tensor network).
+small systems. Evolution uses a dense state vector and sparse operators.
 
 Effective non-Hermitian dynamics between jumps:
 
@@ -42,8 +41,6 @@ from ..core.random_utils import make_trajectory_rng
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from ..core.data_structures.mpo import MPO
-    from ..core.data_structures.mps import MPS
     from ..core.data_structures.noise_model import NoiseModel
     from ..core.data_structures.simulation_parameters import AnalogSimParams
 
@@ -71,51 +68,33 @@ class MCWFContext:
 
 
 def preprocess_mcwf(
-    initial_state: MPS | None,
-    hamiltonian: MPO | None,
+    *,
+    psi_initial: NDArray[np.complex128],
+    h_sparse: scipy.sparse.spmatrix,
     noise_model: NoiseModel | None,
     sim_params: AnalogSimParams,
-    *,
-    psi_initial: NDArray[np.complex128] | None = None,
-    num_sites: int | None = None,
+    num_sites: int,
     physical_dimensions: int | list[int] | None = None,
-    h_sparse: scipy.sparse.spmatrix | None = None,
 ) -> MCWFContext:
     """Pre-compute dense operators and initial state for MCWF simulation.
 
-    Called once per :meth:`Simulator.run` before trajectory workers start (see
-    ``preprocess_mcwf`` in ``simulator.py``).
+    Called once per :meth:`Simulator.run` before trajectory workers start.
 
     Args:
-        initial_state: The initial MPS state, or ``None`` when ``psi_initial`` is supplied.
-        hamiltonian: The Hamiltonian MPO (ignored if ``h_sparse`` is set).
+        psi_initial: Dense state vector (unit norm applied here).
+        h_sparse: Sparse Hamiltonian on the full Hilbert space.
         noise_model: The noise model.
         sim_params: Simulation parameters.
-        psi_initial: Optional pre-encoded dense state vector (unit norm applied here).
-        num_sites: Number of lattice sites when ``initial_state`` is ``None``.
-        physical_dimensions: Per-site physical dimensions used to validate dense
-            vector and sparse Hamiltonian sizes. Defaults to qubits.
-        h_sparse: Pre-materialized sparse Hamiltonian (skips ``hamiltonian.to_sparse_matrix()``).
+        num_sites: Number of lattice sites.
+        physical_dimensions: Per-site physical dimensions. Defaults to qubits.
 
     Returns:
         MCWFContext containing dense arrays ready for trajectory simulation.
 
     Raises:
-        ValueError: If neither ``initial_state`` nor ``psi_initial`` is provided, if
-            ``num_sites`` is missing when only ``psi_initial`` is given, if
-            ``psi_initial`` has the wrong Hilbert-space size, or if ``psi_initial`` has zero norm.
+        ValueError: If ``psi_initial`` has the wrong Hilbert-space size or zero norm, or if
+            ``h_sparse`` has the wrong shape.
     """
-    if initial_state is not None:
-        num_sites = initial_state.length
-        physical_dimensions = initial_state.physical_dimensions
-    elif psi_initial is not None:
-        if num_sites is None:
-            msg = "num_sites is required when preprocess_mcwf is called with psi_initial only."
-            raise ValueError(msg)
-    else:
-        msg = "preprocess_mcwf requires initial_state or psi_initial."
-        raise ValueError(msg)
-
     dim = math.prod(resolve_physical_dimensions(num_sites, physical_dimensions))
     site_dims = resolve_physical_dimensions(num_sites, physical_dimensions)
 
@@ -127,35 +106,21 @@ def preprocess_mcwf(
         )
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
-    # 1. Initial state |psi> as dense vector.
-    if psi_initial is not None:
-        psi = np.asarray(psi_initial, dtype=np.complex128).reshape(-1)
-        if psi.size != dim:
-            msg = f"psi_initial size {psi.size} does not match Hilbert dimension {dim}."
-            raise ValueError(msg)
-        norm = np.linalg.norm(psi)
-        if np.isclose(norm, 0.0):
-            msg = "psi_initial must have non-zero norm."
-            raise ValueError(msg)
-        psi /= norm
-    else:
-        assert initial_state is not None
-        psi = initial_state.to_vec()
-        psi /= np.linalg.norm(psi)
+    psi = np.asarray(psi_initial, dtype=np.complex128).reshape(-1)
+    if psi.size != dim:
+        msg = f"psi_initial size {psi.size} does not match Hilbert dimension {dim}."
+        raise ValueError(msg)
+    norm = np.linalg.norm(psi)
+    if np.isclose(norm, 0.0):
+        msg = "psi_initial must have non-zero norm."
+        raise ValueError(msg)
+    psi /= norm
 
-    # 2. Hamiltonian as sparse matrix on the full Hilbert space.
-    if h_sparse is not None:
-        h_mat = scipy.sparse.csr_matrix(h_sparse)
-        if h_mat.shape != (dim, dim):
-            msg = f"h_sparse must have shape ({dim}, {dim}), got {h_mat.shape}."
-            raise ValueError(msg)
-    elif hamiltonian is not None:
-        h_mat = hamiltonian.to_sparse_matrix()
-    else:
-        msg = "preprocess_mcwf requires hamiltonian or h_sparse."
+    h_mat = scipy.sparse.csr_matrix(h_sparse)
+    if h_mat.shape != (dim, dim):
+        msg = f"h_sparse must have shape ({dim}, {dim}), got {h_mat.shape}."
         raise ValueError(msg)
 
-    # 3. Jump operators L_k = sqrt(gamma) * op embedded on the full space.
     jump_ops: list[scipy.sparse.spmatrix] = []
     if noise_model is not None:
         for process in noise_model.processes:
@@ -167,7 +132,6 @@ def preprocess_mcwf(
 
     is_unitary = len(jump_ops) == 0
 
-    # 4. Effective Hamiltonian for the no-jump evolution between stochastic events.
     heff = h_mat.copy()
     if jump_ops:
         sum_ldag_l = scipy.sparse.csr_matrix((dim, dim), dtype=complex)
@@ -176,7 +140,6 @@ def preprocess_mcwf(
             sum_ldag_l += op_csr.conj().T @ op_csr
         heff -= 0.5j * sum_ldag_l
 
-    # 5. Fixed-step propagator U_step = exp(-i H_eff dt) (time-independent H in YAQS).
     step_propagator: NDArray[np.complex128] | None = None
     if dim <= MAX_PRECOMPUTE_DIM:
         h_dense = heff.toarray()
@@ -185,7 +148,6 @@ def preprocess_mcwf(
         else:
             step_propagator = linalg.expm(-1j * sim_params.dt * h_dense)
 
-    # 6. Observables embedded on the full space; diagnostics are not defined on |psi>.
     embedded_observables: list[scipy.sparse.spmatrix | NDArray[np.complex128] | None] = []
     for obs in sim_params.sorted_observables:
         if obs.gate.name in {"entropy", "schmidt_spectrum"}:

--- a/src/mqt/yaqs/characterization/memory/shared/utils.py
+++ b/src/mqt/yaqs/characterization/memory/shared/utils.py
@@ -461,5 +461,12 @@ def make_mcwf_static_context(
     Returns:
         A backend-specific preprocessing context suitable for reuse across many worker calls.
     """
-    dummy_mps = MPS(length=operator.length, state="zeros")
-    return preprocess_mcwf(dummy_mps, operator, noise_model, sim_params)
+    psi0 = MPS(length=operator.length, state="zeros").to_vec()
+    return preprocess_mcwf(
+        psi_initial=psi0,
+        h_sparse=operator.to_sparse_matrix(),
+        noise_model=noise_model,
+        sim_params=sim_params,
+        num_sites=operator.length,
+        physical_dimensions=operator.physical_dimension,
+    )

--- a/src/mqt/yaqs/core/data_structures/hamiltonian.py
+++ b/src/mqt/yaqs/core/data_structures/hamiltonian.py
@@ -36,9 +36,11 @@ class Hamiltonian:
     ``sparse_matrix``. Materialization happens at construction; reuse the same instance across
     ``run`` loops.
 
-    Pair with :class:`~mqt.yaqs.core.data_structures.state.State`: TJM and ensembles need
-    ``representation="mpo"``; MCWF and Lindblad use a sparse matrix derived from the Hamiltonian
-    at ``run`` time when the state is dense.
+    Pair with :class:`~mqt.yaqs.core.data_structures.state.State`: the state's
+    ``representation`` selects the backend (``"mps"`` → TJM / MPO, ``"vector"`` → MCWF /
+    sparse, ``"density_matrix"`` → Lindblad / sparse). Preset factories always build an MPO;
+    :meth:`~mqt.yaqs.Simulator.run` materializes a sparse matrix when needed. Manual
+    ``matrix`` / ``sparse_matrix`` Hamiltonians cannot drive TJM.
     """
 
     def __init__(
@@ -315,36 +317,43 @@ class Hamiltonian:
 
     @property
     def mpo(self) -> MPO:
-        """MPO when encoded as ``"mpo"``.
+        """Cached MPO, if one has been materialized.
+
+        Remains available after :meth:`ensure_encoded` builds an additional sparse or
+        dense form for MCWF / Lindblad.
 
         Raises:
-            RuntimeError: If not encoded as ``"mpo"``.
+            RuntimeError: If no MPO has been materialized (e.g. dense/sparse-only init).
         """
-        if self._encoded_as != "mpo" or self._mpo is None:
+        if self._mpo is None:
             msg = f"MPO is not available for representation={self.representation!r}."
             raise RuntimeError(msg)
         return self._mpo
 
     @property
     def sparse_matrix(self) -> scipy.sparse.csr_matrix:
-        """Sparse matrix when encoded as ``"sparse"``.
+        """Cached sparse matrix, if one has been materialized.
+
+        Remains available after further :meth:`ensure_encoded` calls that build other forms.
 
         Raises:
-            RuntimeError: If not encoded as ``"sparse"``.
+            RuntimeError: If no sparse matrix has been materialized yet.
         """
-        if self._encoded_as != "sparse" or self._sparse_matrix is None:
+        if self._sparse_matrix is None:
             msg = f"Sparse matrix is not available for representation={self.representation!r}."
             raise RuntimeError(msg)
         return self._sparse_matrix
 
     @property
     def matrix(self) -> NDArray[np.complex128]:
-        """Dense matrix when encoded as ``"dense"``.
+        """Cached dense matrix, if one has been materialized.
+
+        Remains available after further :meth:`ensure_encoded` calls that build other forms.
 
         Raises:
-            RuntimeError: If not encoded as ``"dense"``.
+            RuntimeError: If no dense matrix has been materialized yet.
         """
-        if self._encoded_as != "dense" or self._matrix is None:
+        if self._matrix is None:
             msg = f"Dense matrix is not available for representation={self.representation!r}."
             raise RuntimeError(msg)
         return self._matrix

--- a/src/mqt/yaqs/core/data_structures/hamiltonian.py
+++ b/src/mqt/yaqs/core/data_structures/hamiltonian.py
@@ -15,10 +15,8 @@ import numpy as np
 import scipy.sparse
 
 from .hamiltonian_utils import (
-    Representation,
     attach_mpo,
     sparse_to_csr,
-    validate_representation,
 )
 from .mpo import MPO
 from .state_utils import infer_chain_length
@@ -26,28 +24,25 @@ from .state_utils import infer_chain_length
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-__all__ = ["Hamiltonian", "Representation"]
+__all__ = ["Hamiltonian"]
 
 
 class Hamiltonian:
     """Hamiltonian for :meth:`~mqt.yaqs.Simulator.run` (analog evolution).
 
     Build via classmethods (``ising``, ``pauli``, …) or pass ``tensors`` / ``matrix`` /
-    ``sparse_matrix``. Materialization happens at construction; reuse the same instance across
-    ``run`` loops.
+    ``sparse_matrix``. These choices describe **source data**, not the simulation backend.
 
     Pair with :class:`~mqt.yaqs.core.data_structures.state.State`: the state's
-    ``representation`` selects the backend (``"mps"`` → TJM / MPO, ``"vector"`` → MCWF /
-    sparse, ``"density_matrix"`` → Lindblad / sparse). Preset factories always build an MPO;
-    :meth:`~mqt.yaqs.Simulator.run` materializes a sparse matrix when needed. Manual
-    ``matrix`` / ``sparse_matrix`` Hamiltonians cannot drive TJM.
+    ``representation`` alone selects the backend (``"mps"`` → TJM / MPO, ``"vector"`` →
+    MCWF / sparse, ``"density_matrix"`` → Lindblad / sparse).
+    :meth:`~mqt.yaqs.Simulator.run` converts and caches the required MPO or sparse form.
     """
 
     def __init__(
         self,
         length: int | None = None,
         *,
-        representation: Representation | None = None,
         tensors: list[NDArray[np.complex128]] | None = None,
         matrix: NDArray[np.complex128] | None = None,
         sparse_matrix: scipy.sparse.spmatrix | None = None,
@@ -55,15 +50,14 @@ class Hamiltonian:
     ) -> None:
         """Build a Hamiltonian from manual tensor or matrix data.
 
-        For preset Hamiltonians use :meth:`ising`, :meth:`hamiltonian`, etc.
+        For preset Hamiltonians use :meth:`ising`, :meth:`heisenberg`, etc.
 
         Args:
             length: Number of sites. Inferred from ``len(tensors)`` or matrix dimension when omitted.
-            representation: Only for ambiguous cases; usually inferred from manual data.
-            tensors: MPO tensor cores; infers ``representation="mpo"``.
-            matrix: Dense operator matrix; infers ``representation="dense"``.
-            sparse_matrix: Sparse operator; infers ``representation="sparse"``.
-            physical_dimension: Local Hilbert-space dimension for MPO construction from ``tensors``.
+            tensors: MPO tensor cores.
+            matrix: Dense operator matrix.
+            sparse_matrix: Sparse operator.
+            physical_dimension: Local Hilbert-space dimension (uniform sites).
 
         Raises:
             ValueError: If no manual data is given, data are mutually exclusive, shapes are invalid,
@@ -82,9 +76,7 @@ class Hamiltonian:
         self._tensors: list[NDArray[np.complex128]] | None = None
         self._matrix: NDArray[np.complex128] | None = None
         self._sparse_matrix: scipy.sparse.csr_matrix | None = None
-        self.representation: Representation
         self._mpo: MPO | None = None
-        self._encoded_as: Representation | None = None
 
         if tensors is not None:
             if len(tensors) == 0:
@@ -96,10 +88,7 @@ class Hamiltonian:
                 raise ValueError(msg)
             self.length = n_sites if length is None else length
             self._tensors = [np.asarray(t, dtype=np.complex128) for t in tensors]
-            if representation is not None and representation != "mpo":
-                msg = "representation is inferred as 'mpo' from tensors=; omit representation=."
-                raise ValueError(msg)
-            self.representation = "mpo"
+            self.ensure_mpo()
         elif matrix is not None:
             mat = np.asarray(matrix, dtype=np.complex128)
             if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
@@ -115,10 +104,6 @@ class Hamiltonian:
                     raise ValueError(msg)
                 self.length = length
             self._matrix = mat
-            if representation is not None and representation != "dense":
-                msg = "representation is inferred as 'dense' from matrix=; omit representation=."
-                raise ValueError(msg)
-            self.representation = "dense"
         else:
             assert sparse_matrix is not None
             sparse = sparse_to_csr(sparse_matrix)
@@ -135,16 +120,10 @@ class Hamiltonian:
                     raise ValueError(msg)
                 self.length = length
             self._sparse_matrix = sparse
-            if representation is not None and representation != "sparse":
-                msg = "representation is inferred as 'sparse' from sparse_matrix=; omit representation=."
-                raise ValueError(msg)
-            self.representation = "sparse"
-
-        self._encode(self.representation)
 
     @classmethod
     def from_mpo(cls, mpo: MPO) -> Hamiltonian:
-        """Wrap an existing :class:`MPO` (already encoded as ``"mpo"``).
+        """Wrap an existing :class:`MPO`.
 
         Returns:
             A :class:`Hamiltonian` referencing ``mpo``.
@@ -169,7 +148,7 @@ class Hamiltonian:
         """Transverse-field Ising Hamiltonian (delegates to :meth:`MPO.ising`).
 
         Returns:
-            A :class:`Hamiltonian` with ``representation="mpo"``.
+            A :class:`Hamiltonian` wrapping the constructed MPO.
         """
         return cls.from_mpo(
             MPO.ising(
@@ -202,7 +181,7 @@ class Hamiltonian:
         """Heisenberg Hamiltonian (delegates to :meth:`MPO.heisenberg`).
 
         Returns:
-            A :class:`Hamiltonian` with ``representation="mpo"``.
+            A :class:`Hamiltonian` wrapping the constructed MPO.
         """
         return cls.from_mpo(
             MPO.heisenberg(
@@ -235,7 +214,7 @@ class Hamiltonian:
         """Pauli-string Hamiltonian from one- and two-body terms (delegates to :meth:`MPO.pauli`).
 
         Returns:
-            A :class:`Hamiltonian` with ``representation="mpo"``.
+            A :class:`Hamiltonian` wrapping the constructed MPO.
         """
         return cls.from_mpo(
             MPO.pauli(
@@ -262,7 +241,7 @@ class Hamiltonian:
         """1D Fermi-Hubbard Hamiltonian (delegates to :meth:`MPO.fermi_hubbard_1d`).
 
         Returns:
-            A :class:`Hamiltonian` with ``representation="mpo"``.
+            A :class:`Hamiltonian` wrapping the constructed MPO.
         """
         return cls.from_mpo(MPO.fermi_hubbard_1d(length, t=t, u=u, jordan_wigner=jordan_wigner))
 
@@ -280,7 +259,7 @@ class Hamiltonian:
         """Coupled transmon-resonator chain (delegates to :meth:`MPO.coupled_transmon`).
 
         Returns:
-            A :class:`Hamiltonian` with ``representation="mpo"``.
+            A :class:`Hamiltonian` wrapping the constructed MPO.
         """
         return cls.from_mpo(
             MPO.coupled_transmon(
@@ -294,39 +273,74 @@ class Hamiltonian:
             ),
         )
 
-    def _build_mpo(self) -> MPO:
-        """Build or return the MPO representation.
+    def ensure_mpo(self) -> Hamiltonian:
+        """Materialize and cache an MPO form (used by TJM / ``State.representation='mps'``).
+
+        Dense and sparse sources are converted via :meth:`MPO.from_matrix` (sparse is densified
+        only when this path is requested).
 
         Returns:
-            The materialized :class:`MPO`.
+            ``self`` for chaining.
 
         Raises:
-            ValueError: If this Hamiltonian was created from matrix data only.
+            ValueError: If no data is available to build an MPO.
         """
-        if self._mpo is None:
-            if self._matrix is not None or self._sparse_matrix is not None:
-                msg = "Cannot build an MPO from matrix or sparse_matrix data; use tensors= or a preset classmethod."
-                raise ValueError(msg)
-            if self._tensors is None:
-                msg = "No MPO specification available."
-                raise ValueError(msg)
+        if self._mpo is not None:
+            return self
+        if self._tensors is not None:
             mpo = MPO()
             mpo.custom([np.asarray(t, dtype=np.complex128) for t in self._tensors])
             self._mpo = mpo
-        return self._mpo
+            return self
+        if self._matrix is not None:
+            self._mpo = MPO.from_matrix(self._matrix, self.physical_dimension)
+            return self
+        if self._sparse_matrix is not None:
+            if self._matrix is None:
+                self._matrix = self._sparse_matrix.toarray()
+            self._mpo = MPO.from_matrix(self._matrix, self.physical_dimension)
+            return self
+        msg = "No Hamiltonian data available to build an MPO."
+        raise ValueError(msg)
+
+    def ensure_sparse(self) -> Hamiltonian:
+        """Materialize and cache a sparse matrix (used by MCWF / Lindblad).
+
+        Prefers the authoritative dense matrix when present so a later sparse
+        conversion after ``ensure_mpo()`` does not rebuild from a possibly
+        truncated MPO.
+
+        Returns:
+            ``self`` for chaining.
+
+        Raises:
+            ValueError: If no data is available to build a sparse matrix.
+        """
+        if self._sparse_matrix is not None:
+            return self
+        if self._matrix is not None:
+            self._sparse_matrix = scipy.sparse.csr_matrix(self._matrix)
+            return self
+        if self._mpo is not None:
+            self._sparse_matrix = sparse_to_csr(self._mpo.to_sparse_matrix())
+            return self
+        if self._tensors is not None:
+            self.ensure_mpo()
+            assert self._mpo is not None
+            self._sparse_matrix = sparse_to_csr(self._mpo.to_sparse_matrix())
+            return self
+        msg = "Cannot build sparse matrix from Hamiltonian specification."
+        raise ValueError(msg)
 
     @property
     def mpo(self) -> MPO:
         """Cached MPO, if one has been materialized.
 
-        Remains available after :meth:`ensure_encoded` builds an additional sparse or
-        dense form for MCWF / Lindblad.
-
         Raises:
-            RuntimeError: If no MPO has been materialized (e.g. dense/sparse-only init).
+            RuntimeError: If no MPO has been materialized yet; call :meth:`ensure_mpo`.
         """
         if self._mpo is None:
-            msg = f"MPO is not available for representation={self.representation!r}."
+            msg = "MPO is not available; call ensure_mpo() first."
             raise RuntimeError(msg)
         return self._mpo
 
@@ -334,13 +348,11 @@ class Hamiltonian:
     def sparse_matrix(self) -> scipy.sparse.csr_matrix:
         """Cached sparse matrix, if one has been materialized.
 
-        Remains available after further :meth:`ensure_encoded` calls that build other forms.
-
         Raises:
-            RuntimeError: If no sparse matrix has been materialized yet.
+            RuntimeError: If no sparse matrix has been materialized yet; call :meth:`ensure_sparse`.
         """
         if self._sparse_matrix is None:
-            msg = f"Sparse matrix is not available for representation={self.representation!r}."
+            msg = "Sparse matrix is not available; call ensure_sparse() first."
             raise RuntimeError(msg)
         return self._sparse_matrix
 
@@ -348,70 +360,16 @@ class Hamiltonian:
     def matrix(self) -> NDArray[np.complex128]:
         """Cached dense matrix, if one has been materialized.
 
-        Remains available after further :meth:`ensure_encoded` calls that build other forms.
-
         Raises:
             RuntimeError: If no dense matrix has been materialized yet.
         """
         if self._matrix is None:
-            msg = f"Dense matrix is not available for representation={self.representation!r}."
+            msg = "Dense matrix is not available."
             raise RuntimeError(msg)
         return self._matrix
 
-    def _encode(self, representation: Representation | None = None) -> Hamiltonian:
-        """Materialize internal storage for the requested representation.
-
-        Returns:
-            ``self`` for chaining.
-
-        Raises:
-            ValueError: If the requested representation cannot be built from the specification.
-        """
-        rep: Representation = self.representation if representation is None else validate_representation(representation)
-        if self._encoded_as == rep:
-            if rep == "mpo" and self._mpo is not None:
-                return self
-            if rep == "sparse" and self._sparse_matrix is not None:
-                return self
-            if rep == "dense" and self._matrix is not None:
-                return self
-
-        if rep == "mpo":
-            self._build_mpo()
-        elif rep == "sparse":
-            if self._sparse_matrix is None:
-                if self._mpo is not None:
-                    self._sparse_matrix = sparse_to_csr(self._mpo.to_sparse_matrix())
-                elif self._matrix is not None:
-                    self._sparse_matrix = scipy.sparse.csr_matrix(self._matrix)
-                else:
-                    msg = "Cannot build sparse matrix from Hamiltonian specification."
-                    raise ValueError(msg)
-        elif rep == "dense":
-            if self._matrix is None:
-                if self._sparse_matrix is not None:
-                    self._matrix = self._sparse_matrix.toarray()
-                elif self._mpo is not None:
-                    self._matrix = self._mpo.to_matrix()
-                else:
-                    msg = "Cannot build dense matrix from Hamiltonian specification."
-                    raise ValueError(msg)
-        else:
-            msg = f"Unknown representation: {rep!r}"
-            raise ValueError(msg)
-        self._encoded_as = rep
-        return self
-
-    def ensure_encoded(self, representation: Representation | None = None) -> Hamiltonian:
-        """Materialize ``representation`` if needed (used by :meth:`~mqt.yaqs.Simulator.run`).
-
-        Returns:
-            ``self`` for chaining.
-        """
-        return self._encode(representation)
-
     def to_matrix(self) -> NDArray[np.complex128]:
-        """Dense matrix (converts from cached MPO/sparse without changing :attr:`representation`).
+        """Dense matrix (converts from cached MPO/sparse without requiring prior encode).
 
         Returns:
             Dense Hamiltonian matrix on the full Hilbert space.
@@ -429,7 +387,9 @@ class Hamiltonian:
         raise RuntimeError(msg)
 
     def to_sparse_matrix(self) -> scipy.sparse.csr_matrix:
-        """Sparse matrix (converts from cached forms without changing :attr:`representation`).
+        """Sparse matrix (converts from cached forms; does not mutate caches).
+
+        Prefer :meth:`ensure_sparse` when the sparse form should be cached for reuse.
 
         Returns:
             Sparse Hamiltonian matrix on the full Hilbert space.

--- a/src/mqt/yaqs/core/data_structures/hamiltonian.py
+++ b/src/mqt/yaqs/core/data_structures/hamiltonian.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -25,6 +26,9 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 __all__ = ["Hamiltonian"]
+
+# Match preprocess_mcwf: warn when full Hilbert-space matrices become expensive.
+_LARGE_HILBERT_DIM = 2**14
 
 
 class Hamiltonian:
@@ -79,47 +83,83 @@ class Hamiltonian:
         self._mpo: MPO | None = None
 
         if tensors is not None:
-            if len(tensors) == 0:
-                msg = "tensors must be a non-empty list of MPO cores."
-                raise ValueError(msg)
-            n_sites = len(tensors)
-            if length is not None and length != n_sites:
-                msg = f"length={length} does not match len(tensors)={n_sites}."
-                raise ValueError(msg)
-            self.length = n_sites if length is None else length
-            self._tensors = [np.asarray(t, dtype=np.complex128) for t in tensors]
-            self.ensure_mpo()
+            self._init_from_tensors(tensors, length)
         elif matrix is not None:
-            mat = np.asarray(matrix, dtype=np.complex128)
-            if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
-                msg = "matrix must be a square 2-D array."
-                raise ValueError(msg)
-            hilbert_dim = mat.shape[0]
-            if length is None:
-                self.length = infer_chain_length(hilbert_dim, physical_dimension=physical_dimension)
-            else:
-                expected = physical_dimension**length
-                if hilbert_dim != expected:
-                    msg = f"matrix dimension {hilbert_dim} does not match physical_dimension**length={expected}."
-                    raise ValueError(msg)
-                self.length = length
-            self._matrix = mat
+            self._init_from_matrix(matrix, length)
         else:
             assert sparse_matrix is not None
-            sparse = sparse_to_csr(sparse_matrix)
-            hilbert_dim = sparse.shape[0]
-            if sparse.shape[0] != sparse.shape[1]:
-                msg = "sparse_matrix must be square."
+            self._init_from_sparse_matrix(sparse_matrix, length)
+
+    def _init_from_tensors(
+        self,
+        tensors: list[NDArray[np.complex128]],
+        length: int | None,
+    ) -> None:
+        """Validate and store MPO tensor cores, then materialize the MPO.
+
+        Raises:
+            ValueError: If ``tensors`` is empty or ``length`` disagrees with ``len(tensors)``.
+        """
+        if len(tensors) == 0:
+            msg = "tensors must be a non-empty list of MPO cores."
+            raise ValueError(msg)
+        n_sites = len(tensors)
+        if length is not None and length != n_sites:
+            msg = f"length={length} does not match len(tensors)={n_sites}."
+            raise ValueError(msg)
+        self.length = n_sites if length is None else length
+        self._tensors = [np.asarray(t, dtype=np.complex128) for t in tensors]
+        self.ensure_mpo()
+
+    def _init_from_matrix(
+        self,
+        matrix: NDArray[np.complex128],
+        length: int | None,
+    ) -> None:
+        """Validate and store a dense Hamiltonian matrix.
+
+        Raises:
+            ValueError: If ``matrix`` is not square or disagrees with ``length``.
+        """
+        mat = np.asarray(matrix, dtype=np.complex128)
+        if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
+            msg = "matrix must be a square 2-D array."
+            raise ValueError(msg)
+        hilbert_dim = mat.shape[0]
+        if length is None:
+            self.length = infer_chain_length(hilbert_dim, physical_dimension=self.physical_dimension)
+        else:
+            expected = self.physical_dimension**length
+            if hilbert_dim != expected:
+                msg = f"matrix dimension {hilbert_dim} does not match physical_dimension**length={expected}."
                 raise ValueError(msg)
-            if length is None:
-                self.length = infer_chain_length(hilbert_dim, physical_dimension=physical_dimension)
-            else:
-                expected = physical_dimension**length
-                if hilbert_dim != expected:
-                    msg = f"sparse_matrix dimension {hilbert_dim} does not match physical_dimension**length={expected}."
-                    raise ValueError(msg)
-                self.length = length
-            self._sparse_matrix = sparse
+            self.length = length
+        self._matrix = mat
+
+    def _init_from_sparse_matrix(
+        self,
+        sparse_matrix: scipy.sparse.spmatrix,
+        length: int | None,
+    ) -> None:
+        """Validate and store a sparse Hamiltonian matrix.
+
+        Raises:
+            ValueError: If ``sparse_matrix`` is not square or disagrees with ``length``.
+        """
+        sparse = sparse_to_csr(sparse_matrix)
+        hilbert_dim = sparse.shape[0]
+        if sparse.shape[0] != sparse.shape[1]:
+            msg = "sparse_matrix must be square."
+            raise ValueError(msg)
+        if length is None:
+            self.length = infer_chain_length(hilbert_dim, physical_dimension=self.physical_dimension)
+        else:
+            expected = self.physical_dimension**length
+            if hilbert_dim != expected:
+                msg = f"sparse_matrix dimension {hilbert_dim} does not match physical_dimension**length={expected}."
+                raise ValueError(msg)
+            self.length = length
+        self._sparse_matrix = sparse
 
     @classmethod
     def from_mpo(cls, mpo: MPO) -> Hamiltonian:
@@ -273,11 +313,24 @@ class Hamiltonian:
             ),
         )
 
+    @staticmethod
+    def _warn_large_hilbert_dim(dim: int, *, action: str) -> None:
+        """Emit the same large-system RuntimeWarning used by ``preprocess_mcwf``."""
+        if dim <= _LARGE_HILBERT_DIM:
+            return
+        msg = (
+            f"Hilbert-space dimension {dim} is large when {action}. "
+            "This may be very slow or run out of memory. "
+            "Prefer an MPO preset, Hamiltonian.from_mpo(...), or tensors= for large TJM runs."
+        )
+        warnings.warn(msg, RuntimeWarning, stacklevel=3)
+
     def ensure_mpo(self) -> Hamiltonian:
         """Materialize and cache an MPO form (used by TJM / ``State.representation='mps'``).
 
         Dense and sparse sources are converted via :meth:`MPO.from_matrix` (sparse is densified
-        only when this path is requested).
+        only when this path is requested). Large Hilbert-space conversions emit a
+        ``RuntimeWarning`` matching the ``preprocess_mcwf`` threshold.
 
         Returns:
             ``self`` for chaining.
@@ -293,11 +346,16 @@ class Hamiltonian:
             self._mpo = mpo
             return self
         if self._matrix is not None:
+            self._warn_large_hilbert_dim(self._matrix.shape[0], action="factorizing a dense matrix into an MPO")
             self._mpo = MPO.from_matrix(self._matrix, self.physical_dimension)
             return self
         if self._sparse_matrix is not None:
+            dim = self._sparse_matrix.shape[0]
             if self._matrix is None:
+                self._warn_large_hilbert_dim(dim, action="densifying a sparse matrix to build an MPO")
                 self._matrix = self._sparse_matrix.toarray()
+            else:
+                self._warn_large_hilbert_dim(dim, action="factorizing a dense matrix into an MPO")
             self._mpo = MPO.from_matrix(self._matrix, self.physical_dimension)
             return self
         msg = "No Hamiltonian data available to build an MPO."

--- a/src/mqt/yaqs/core/data_structures/hamiltonian_utils.py
+++ b/src/mqt/yaqs/core/data_structures/hamiltonian_utils.py
@@ -9,32 +9,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING
 
 import scipy.sparse
 
 if TYPE_CHECKING:
     from .hamiltonian import Hamiltonian
     from .mpo import MPO
-
-Representation = Literal["mpo", "sparse", "dense"]
-
-_ALLOWED_REPRESENTATIONS = frozenset({"mpo", "sparse", "dense"})
-
-
-def validate_representation(value: str) -> Representation:
-    """Validate and return a Hamiltonian representation label.
-
-    Returns:
-        A valid ``"mpo"``, ``"sparse"``, or ``"dense"`` label.
-
-    Raises:
-        ValueError: If ``value`` is not ``"mpo"``, ``"sparse"``, or ``"dense"``.
-    """
-    if value not in _ALLOWED_REPRESENTATIONS:
-        msg = f"Invalid representation {value!r}. Allowed values are 'mpo', 'sparse', or 'dense'."
-        raise ValueError(msg)
-    return cast("Representation", value)
 
 
 def sparse_to_csr(matrix: scipy.sparse.spmatrix) -> scipy.sparse.csr_matrix:
@@ -48,10 +29,8 @@ def attach_mpo(wrapped: Hamiltonian, mpo: MPO) -> None:
     """Initialize ``wrapped`` from an existing MPO (factory helper for :meth:`Hamiltonian.from_mpo`)."""
     wrapped.length = mpo.length
     wrapped.physical_dimension = mpo.physical_dimension
-    wrapped.representation = "mpo"
     # Private fields: wrapped is a fresh Hamiltonian from __new__; attach_mpo is the sole initializer.
     wrapped._tensors = None  # ruff:ignore[private-member-access]
     wrapped._matrix = None  # ruff:ignore[private-member-access]
     wrapped._sparse_matrix = None  # ruff:ignore[private-member-access]
     wrapped._mpo = mpo  # ruff:ignore[private-member-access]
-    wrapped._encoded_as = "mpo"  # ruff:ignore[private-member-access]

--- a/src/mqt/yaqs/memory_characterizer.py
+++ b/src/mqt/yaqs/memory_characterizer.py
@@ -143,7 +143,7 @@ def _require_hamiltonian(hamiltonian: Hamiltonian) -> MPO:
     if not isinstance(hamiltonian, Hamiltonian):
         msg = "Pass a Hamiltonian; use Hamiltonian.ising(...) or Hamiltonian(...)."
         raise TypeError(msg)
-    hamiltonian.ensure_encoded("mpo")
+    hamiltonian.ensure_mpo()
     return hamiltonian.mpo
 
 

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -63,7 +63,6 @@ import numpy as np
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .core.data_structures.hamiltonian import Representation
     from .core.data_structures.mpo import MPO
     from .core.data_structures.mps import MPS
     from .core.parallel_utils import MPContext
@@ -246,31 +245,14 @@ def _materialized_mps(state: State) -> MPS | None:
         return None
 
 
-def _hamiltonian_backend_target(state_rep: str) -> str:
-    """Internal storage target for ``Hamiltonian`` given ``State.representation``.
-
-    Returns:
-        ``"sparse"`` for vector or density-matrix states, otherwise ``"mpo"``.
-    """
-    if state_rep in {"vector", "density_matrix"}:
-        return "sparse"
-    return "mpo"
-
-
 def _validate_state_hamiltonian_pairing(state: State, hamiltonian: Hamiltonian) -> None:
     """Check ``State`` and ``Hamiltonian`` can be evolved together.
 
     Raises:
-        ValueError: If representations or lengths are incompatible.
+        ValueError: If lengths are incompatible.
     """
     if state.length != hamiltonian.length:
         msg = f"State.length={state.length} does not match Hamiltonian.length={hamiltonian.length}."
-        raise ValueError(msg)
-    if state.representation == "mps" and hamiltonian.representation != "mpo":
-        msg = (
-            "TJM simulation requires Hamiltonian.representation='mpo'. "
-            "Use State.representation='vector' or 'density_matrix' for matrix Hamiltonians."
-        )
         raise ValueError(msg)
 
 
@@ -278,16 +260,16 @@ def _prepare_hamiltonian_for_run(
     hamiltonian: Hamiltonian,
     state_rep: str,
 ) -> tuple[MPO | None, Any]:
-    """Ensure ``hamiltonian`` is encoded for the backend matching ``state_rep``.
+    """Ensure ``hamiltonian`` is converted for the backend matching ``state_rep``.
 
     Returns:
         ``(mpo, h_sparse)`` with one entry set for the active backend.
     """
-    target = _hamiltonian_backend_target(state_rep)
-    hamiltonian.ensure_encoded(cast("Representation", target))
-    if target == "mpo":
-        return hamiltonian.mpo, None
-    return None, hamiltonian.sparse_matrix
+    if state_rep in {"vector", "density_matrix"}:
+        hamiltonian.ensure_sparse()
+        return None, hamiltonian.sparse_matrix
+    hamiltonian.ensure_mpo()
+    return hamiltonian.mpo, None
 
 
 def _prepare_result_observables(
@@ -687,7 +669,7 @@ class Simulator:
             if any(spec.representation != "mps" for spec in initial_state_list):
                 msg = "list[State] analog ensemble currently supports only State.representation='mps'."
                 raise ValueError(msg)
-            operator.ensure_encoded("mpo")
+            operator.ensure_mpo()
             for spec in initial_state_list:
                 spec.ensure_encoded("mps")
                 _validate_state_hamiltonian_pairing(spec, operator)
@@ -740,27 +722,23 @@ class Simulator:
 
         if state_rep == "vector":
             ctx = preprocess_mcwf(
-                None,
-                None,
-                noise_model,
-                worker_params,
                 psi_initial=initial_state.vector,
+                h_sparse=h_sparse,
+                noise_model=noise_model,
+                sim_params=worker_params,
                 num_sites=initial_state.length,
                 physical_dimensions=initial_state.physical_dimensions,
-                h_sparse=h_sparse,
             )
             payload = {"ctx": ctx}
             worker_fn = _mcwf_worker
         elif state_rep == "density_matrix":
             lindblad_ctx = preprocess_lindblad(
-                None,
-                None,
-                noise_model,
-                worker_params,
                 rho_initial=initial_state.density_matrix,
+                h_sparse=h_sparse,
+                noise_model=noise_model,
+                sim_params=worker_params,
                 num_sites=initial_state.length,
                 physical_dimensions=initial_state.physical_dimensions,
-                h_sparse=h_sparse,
             )
             payload = {"ctx": lindblad_ctx}
             worker_fn = _lindblad_ctx_worker

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -740,12 +740,12 @@ class Simulator:
 
         if state_rep == "vector":
             ctx = preprocess_mcwf(
-                mps,
-                mpo_op,
+                None,
+                None,
                 noise_model,
                 worker_params,
-                psi_initial=None if mps is not None else initial_state.vector,
-                num_sites=initial_state.length if mps is None else None,
+                psi_initial=initial_state.vector,
+                num_sites=initial_state.length,
                 physical_dimensions=initial_state.physical_dimensions,
                 h_sparse=h_sparse,
             )
@@ -753,8 +753,8 @@ class Simulator:
             worker_fn = _mcwf_worker
         elif state_rep == "density_matrix":
             lindblad_ctx = preprocess_lindblad(
-                mps,
-                mpo_op,
+                None,
+                None,
                 noise_model,
                 worker_params,
                 rho_initial=initial_state.density_matrix,

--- a/tests/analog/test_analog_tjm.py
+++ b/tests/analog/test_analog_tjm.py
@@ -263,7 +263,14 @@ def test_lowering_jump_probability_matches_mcwf_after_dissipation(
     hamiltonian = _zero_hamiltonian_mpo(length)
     noise_model = _lowering_noise_model(length)
     sim_params = AnalogSimParams(elapsed_time=0.0, dt=dt, max_bond_dim=64, svd_threshold=1e-10)
-    ctx = preprocess_mcwf(state, hamiltonian, noise_model, sim_params)
+    ctx = preprocess_mcwf(
+        psi_initial=state.to_vec(),
+        h_sparse=hamiltonian.to_sparse_matrix(),
+        noise_model=noise_model,
+        sim_params=sim_params,
+        num_sites=state.length,
+        physical_dimensions=state.physical_dimensions,
+    )
 
     p_mcwf = _mcwf_jump_probability(state, ctx)
     p_tjm = _tjm_jump_probability_after_dissipation(state, noise_model, dt, sim_params)
@@ -288,7 +295,15 @@ def test_lowering_jump_probability_stable_over_repeated_no_jump_steps(
     hamiltonian = hamiltonian_factory(length)
     noise_model = _lowering_noise_model(length)
     sim_params = AnalogSimParams(elapsed_time=0.0, dt=dt, max_bond_dim=64, svd_threshold=1e-10)
-    ctx = preprocess_mcwf(MPS(length, state="ones"), hamiltonian, noise_model, sim_params)
+    initial = MPS(length, state="ones")
+    ctx = preprocess_mcwf(
+        psi_initial=initial.to_vec(),
+        h_sparse=hamiltonian.to_sparse_matrix(),
+        noise_model=noise_model,
+        sim_params=sim_params,
+        num_sites=initial.length,
+        physical_dimensions=initial.physical_dimensions,
+    )
 
     state = MPS(length, state="ones")
     state.normalize("B")

--- a/tests/analog/test_ensemble.py
+++ b/tests/analog/test_ensemble.py
@@ -166,6 +166,25 @@ def test_unitary_ensemble_clears_multi_time_outputs_when_feature_disabled() -> N
     assert result_off.multi_time_times is None
 
 
+def test_list_mps_analog_ensemble_accepts_dense_hamiltonian() -> None:
+    """MPS ensembles auto-convert dense Hamiltonians to MPO."""
+    length = 2
+    dense = Hamiltonian.ising(length, J=0.2, g=0.1).to_matrix()
+    hamiltonian = Hamiltonian(matrix=dense)
+    states = [
+        State(length, initial="zeros", representation="mps"),
+        State(length, initial="ones", representation="mps"),
+    ]
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        elapsed_time=0.1,
+        dt=0.1,
+    )
+    result = Simulator(parallel=False, show_progress=False).run(states, hamiltonian, sim_params, noise_model=None)
+    assert len(result.expectation_values) == 1
+    _ = hamiltonian.mpo
+
+
 def test_list_mps_analog_ensemble_rejects_non_mps_representation() -> None:
     """List-of-MPS analog ensemble only supports the mps representation path."""
     length = 2

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -26,7 +26,6 @@ from mqt.yaqs import (
 )
 from mqt.yaqs.analog.lindblad import (
     MAX_LIOUVILLIAN_VECTOR_DIM,
-    lindblad,
     lindblad_evolve,
     preprocess_lindblad,
 )
@@ -196,7 +195,16 @@ def test_lindblad_zero_strength_noise_runs_via_simulator() -> None:
     obs = Observable("z", sites=[0])
     sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, observables=[obs])
 
-    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    psi_vec = psi.to_vec()
+    rho = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     assert len(ctx.jump_ops) == 0
     assert ctx.is_unitary
     dim = 2**n_sites
@@ -237,7 +245,16 @@ def test_preprocess_lindblad_sets_propagator_small_system() -> None:
         elapsed_time=0.1,
         observables=[Observable("z", sites=[0])],
     )
-    ctx = preprocess_lindblad(psi, h, None, sim_params)
+    psi_vec = psi.to_vec()
+    rho = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=None,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     vec_dim = (2**n_sites) ** 2
     assert vec_dim <= MAX_LIOUVILLIAN_VECTOR_DIM
     assert ctx.step_propagator is not None
@@ -254,7 +271,16 @@ def test_lindblad_noisy_small_system_has_propagator() -> None:
         h.tensors[i] *= 0.0
     noise = NoiseModel(processes=[{"name": "pauli_z", "sites": [0], "strength": 0.2}])
     sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, observables=[])
-    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    psi_vec = psi.to_vec()
+    rho = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     assert not ctx.is_unitary
     assert ctx.step_propagator is not None
 
@@ -312,7 +338,16 @@ def test_lindblad_propagator_records_all_timepoints() -> None:
         dt=0.05,
         sample_timesteps=True,
     )
-    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    psi_vec = psi.to_vec()
+    rho = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     assert ctx.step_propagator is not None
 
     state = State(n_sites, initial="ones", representation="density_matrix")
@@ -346,7 +381,16 @@ def test_lindblad_ode_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
         get_state=True,
     )
 
-    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    psi_vec = psi.to_vec()
+    rho = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     assert ctx.step_propagator is None
 
     state = State(n_sites, initial="ones", representation="density_matrix")
@@ -379,7 +423,16 @@ def test_lindblad_evolve_get_state_false_returns_no_matrix() -> None:
         get_state=False,
         sample_timesteps=False,
     )
-    ctx = preprocess_lindblad(psi, h, noise, sim_params)
+    psi_vec = psi.to_vec()
+    rho0 = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho0,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     obs, diag, rho = lindblad_evolve(ctx)
     assert obs.shape == (1, 1)
     assert diag is None
@@ -397,7 +450,16 @@ def test_rho_vec_at_elapsed_time_returns_initial_state_at_zero() -> None:
         dt=0.1,
         get_state=True,
     )
-    ctx = preprocess_lindblad(psi, h, None, sim_params)
+    psi_vec = psi.to_vec()
+    rho = np.outer(psi_vec, psi_vec.conj())
+    ctx = preprocess_lindblad(
+        rho_initial=rho,
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=None,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     rho_vec = lindblad_mod._rho_vec_at_elapsed_time(ctx)
     np.testing.assert_allclose(rho_vec, ctx.rho_initial)
 
@@ -406,7 +468,6 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
     """Fractional elapsed times use an extra ``expm(L * remainder)`` after full ``dt`` steps."""
     n_sites = 1
     initial_state = State(n_sites, initial="ones", representation="density_matrix")
-    psi = MPS(n_sites, state="ones")
     h = MPO.identity(n_sites)
     for i in range(len(h.tensors)):
         h.tensors[i] *= 0.0
@@ -425,12 +486,12 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
         get_state=True,
     )
     ctx = preprocess_lindblad(
-        psi,
-        hamiltonian.mpo,
-        noise,
-        sim_params,
         rho_initial=initial_state.density_matrix,
+        h_sparse=hamiltonian.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
         num_sites=n_sites,
+        physical_dimensions=initial_state.physical_dimensions,
     )
     assert ctx.step_propagator is not None
     rho_vec = lindblad_mod._rho_vec_at_elapsed_time(ctx)
@@ -440,30 +501,3 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
         dtype=np.complex128,
     )
     np.testing.assert_allclose(rho, expected, atol=1e-4)
-
-
-def test_lindblad_entry_point_returns_density_matrix() -> None:
-    """The ``lindblad`` worker entry point forwards ``get_state`` output."""
-    n_sites = 1
-    psi = MPS(n_sites, state="ones")
-    h = MPO.identity(n_sites)
-    for i in range(len(h.tensors)):
-        h.tensors[i] *= 0.0
-    noise = NoiseModel(
-        processes=[
-            {"name": "destroy", "sites": [0], "strength": 1.0, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
-        ],
-    )
-    sim_params = AnalogSimParams(
-        observables=[Observable("z", sites=[0])],
-        elapsed_time=0.2,
-        dt=0.1,
-        get_state=True,
-        sample_timesteps=False,
-    )
-    obs, diag, rho = lindblad((0, psi, noise, sim_params, h))
-    assert obs.shape == (1, 1)
-    assert diag is None
-    assert rho is not None
-    assert rho.shape == (2, 2)
-    assert np.isclose(np.trace(rho), 1.0)

--- a/tests/analog/test_mcwf.py
+++ b/tests/analog/test_mcwf.py
@@ -173,7 +173,14 @@ def test_mcwf_zero_strength_noise() -> None:
 
     sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, observables=[Observable("z", sites=[0])])
 
-    ctx = preprocess_mcwf(psi, h, noise, sim_params)
+    ctx = preprocess_mcwf(
+        psi_initial=psi.to_vec(),
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     assert len(ctx.jump_ops) == 0
     assert ctx.is_unitary
     dim = 2**n_sites
@@ -187,7 +194,14 @@ def test_preprocess_mcwf_rejects_mismatched_h_sparse_shape() -> None:
     sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, observables=[])
     bad_h = scipy.sparse.eye(8, format="csr")
     with pytest.raises(ValueError, match=r"h_sparse must have shape \(4, 4\)"):
-        preprocess_mcwf(psi, None, None, sim_params, h_sparse=bad_h)
+        preprocess_mcwf(
+            psi_initial=psi.to_vec(),
+            h_sparse=bad_h,
+            noise_model=None,
+            sim_params=sim_params,
+            num_sites=psi.length,
+            physical_dimensions=psi.physical_dimensions,
+        )
 
 
 def test_preprocess_mcwf_sets_propagator_small_system() -> None:
@@ -200,7 +214,14 @@ def test_preprocess_mcwf_sets_propagator_small_system() -> None:
         elapsed_time=0.1,
         observables=[Observable("z", sites=[0])],
     )
-    ctx = preprocess_mcwf(psi, h, None, sim_params)
+    ctx = preprocess_mcwf(
+        psi_initial=psi.to_vec(),
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=None,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     dim = 2**n_sites
     assert dim <= MAX_PRECOMPUTE_DIM
     assert ctx.step_propagator is not None
@@ -217,7 +238,14 @@ def test_mcwf_noisy_system_has_propagator() -> None:
         h.tensors[i] *= 0.0
     noise = NoiseModel(processes=[{"name": "pauli_z", "sites": [0], "strength": 0.2}])
     sim_params = AnalogSimParams(dt=0.1, elapsed_time=0.1, observables=[])
-    ctx = preprocess_mcwf(psi, h, noise, sim_params)
+    ctx = preprocess_mcwf(
+        psi_initial=psi.to_vec(),
+        h_sparse=h.to_sparse_matrix(),
+        noise_model=noise,
+        sim_params=sim_params,
+        num_sites=psi.length,
+        physical_dimensions=psi.physical_dimensions,
+    )
     assert not ctx.is_unitary
     assert ctx.step_propagator is not None
 

--- a/tests/analog/test_representation_ordering.py
+++ b/tests/analog/test_representation_ordering.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+import scipy.sparse
 
 from mqt.yaqs import AnalogSimParams, Hamiltonian, NoiseModel, Observable, Simulator, State
 from mqt.yaqs.core.data_structures.mps import MPS
@@ -96,3 +97,62 @@ def test_noisy_short_step_mps_vs_mcwf(
     )
     vec_val = float(sim.run(State(vector=psi.copy()), hamiltonian, params, noise).expectation_values[0][-1])
     assert mps_val == pytest.approx(vec_val, abs=1e-6)
+
+
+def test_heisenberg_noiseless_agrees_across_representations() -> None:
+    """Heisenberg preset works with mps, vector, and density_matrix without H.representation."""
+    length = 3
+    sim = Simulator(show_progress=False)
+    hamiltonian = Hamiltonian.heisenberg(length, Jx=1.0, Jy=0.5, Jz=0.3, h=0.1)
+    assert hamiltonian.representation == "mpo"
+
+    init = State(length, initial="x+")
+    psi = np.asarray(init.mps.to_vec(), dtype=np.complex128)
+    rho = np.outer(psi, psi.conj())
+    tensors = [np.asarray(t, dtype=np.complex128).copy() for t in init.mps.tensors]
+
+    obs_list = [Observable("z", s) for s in range(length)] + [Observable("x", 0)]
+    params_mps = AnalogSimParams(observables=obs_list, elapsed_time=0.4, dt=0.05, max_bond_dim=32, svd_threshold=1e-10)
+    params_dense = AnalogSimParams(observables=obs_list, elapsed_time=0.4, dt=0.05, num_traj=1)
+
+    z_x_mps = sim.run(State(length, tensors=[t.copy() for t in tensors]), hamiltonian, params_mps, None)
+    z_x_vec = sim.run(State(vector=psi.copy()), hamiltonian, params_dense, None)
+    z_x_rho = sim.run(State(density_matrix=rho.copy()), hamiltonian, params_dense, None)
+
+    assert hamiltonian.representation == "mpo"
+    _ = hamiltonian.mpo
+    _ = hamiltonian.sparse_matrix
+
+    for idx in range(len(obs_list)):
+        mps_val = float(z_x_mps.expectation_values[idx][-1])
+        vec_val = float(z_x_vec.expectation_values[idx][-1])
+        rho_val = float(z_x_rho.expectation_values[idx][-1])
+        assert vec_val == pytest.approx(rho_val, abs=1e-8), f"obs {idx} vector vs density_matrix"
+        assert mps_val == pytest.approx(vec_val, abs=1e-5), f"obs {idx} mps vs vector"
+
+
+@pytest.mark.parametrize("hamiltonian_kind", ["dense", "sparse"])
+def test_matrix_hamiltonian_runs_on_vector_and_density_matrix(hamiltonian_kind: str) -> None:
+    """User-supplied dense/sparse Hamiltonians evolve under MCWF and Lindblad."""
+    length = 2
+    ref = Hamiltonian.ising(length, J=1.0, g=0.5)
+    dense = np.asarray(ref.to_matrix(), dtype=np.complex128)
+    hamiltonian = (
+        Hamiltonian(matrix=dense.copy())
+        if hamiltonian_kind == "dense"
+        else Hamiltonian(sparse_matrix=scipy.sparse.csr_matrix(dense))
+    )
+    assert hamiltonian.representation == ("dense" if hamiltonian_kind == "dense" else "sparse")
+
+    sim = Simulator(show_progress=False)
+    obs = Observable("z", sites=[0])
+    params = AnalogSimParams(observables=[obs], elapsed_time=0.3, dt=0.05, num_traj=1)
+
+    state_vec = State(length, initial="zeros", representation="vector")
+    state_rho = State(length, initial="zeros", representation="density_matrix")
+    vec_val = float(sim.run(state_vec, hamiltonian, params, None).expectation_values[0][-1])
+    rho_val = float(sim.run(state_rho, hamiltonian, params, None).expectation_values[0][-1])
+    assert vec_val == pytest.approx(rho_val, abs=1e-8)
+
+    with pytest.raises(ValueError, match=r"TJM simulation requires Hamiltonian\.representation='mpo'"):
+        sim.run(State(length, initial="zeros", representation="mps"), hamiltonian, params, None)

--- a/tests/analog/test_representation_ordering.py
+++ b/tests/analog/test_representation_ordering.py
@@ -5,7 +5,7 @@
 #
 # Licensed under the MIT License
 
-"""Cross-representation qubit-ordering regression tests."""
+"""Cross-representation Hamiltonian source and backend regression tests."""
 
 from __future__ import annotations
 
@@ -46,7 +46,7 @@ def test_haar_embedded_observables_match_mps(haar_state: tuple[MPS, np.ndarray, 
             assert mps_val == pytest.approx(embed_val, abs=1e-9), f"{name} site {site}"
 
 
-def test_noiseless_evolution_agrees_across_representations(
+def test_noiseless_evolution_agrees_across_backends(
     haar_state: tuple[MPS, np.ndarray, np.ndarray, list[np.ndarray]],
 ) -> None:
     """MPS, MCWF, and Lindblad paths agree on noiseless Ising observables."""
@@ -99,12 +99,60 @@ def test_noisy_short_step_mps_vs_mcwf(
     assert mps_val == pytest.approx(vec_val, abs=1e-6)
 
 
-def test_heisenberg_noiseless_agrees_across_representations() -> None:
-    """Heisenberg preset works with mps, vector, and density_matrix without H.representation."""
+def _final_obs(
+    sim: Simulator,
+    state: State,
+    hamiltonian: Hamiltonian,
+    params: AnalogSimParams,
+) -> float:
+    return float(sim.run(state, hamiltonian, params, None).expectation_values[0][-1])
+
+
+@pytest.mark.parametrize("source", ["preset", "dense", "sparse"])
+def test_hamiltonian_source_runs_on_all_state_representations(source: str) -> None:
+    """Preset, dense, and sparse Hamiltonians work with mps, vector, and density_matrix."""
+    length = 2
+    ref = Hamiltonian.ising(length, J=1.0, g=0.5)
+    dense = np.asarray(ref.to_matrix(), dtype=np.complex128)
+    if source == "preset":
+        hamiltonian = Hamiltonian.ising(length, J=1.0, g=0.5)
+    elif source == "dense":
+        hamiltonian = Hamiltonian(matrix=dense.copy())
+    else:
+        hamiltonian = Hamiltonian(sparse_matrix=scipy.sparse.csr_matrix(dense))
+
+    sim = Simulator(show_progress=False)
+    obs = Observable("z", sites=[0])
+    params_mps = AnalogSimParams(observables=[obs], elapsed_time=0.3, dt=0.05, max_bond_dim=16, svd_threshold=1e-10)
+    params_dense = AnalogSimParams(observables=[obs], elapsed_time=0.3, dt=0.05, num_traj=1)
+
+    init = State(length, initial="zeros")
+    psi = np.asarray(init.mps.to_vec(), dtype=np.complex128)
+    rho = np.outer(psi, psi.conj())
+    tensors = [np.asarray(t, dtype=np.complex128).copy() for t in init.mps.tensors]
+
+    mps_val = _final_obs(sim, State(length, tensors=[t.copy() for t in tensors]), hamiltonian, params_mps)
+    vec_val = _final_obs(sim, State(vector=psi.copy()), hamiltonian, params_dense)
+    rho_val = _final_obs(sim, State(density_matrix=rho.copy()), hamiltonian, params_dense)
+
+    assert vec_val == pytest.approx(rho_val, abs=1e-8)
+    assert mps_val == pytest.approx(vec_val, abs=1e-5)
+
+    # Cache reuse: both forms remain available and agree numerically.
+    hamiltonian.ensure_mpo()
+    hamiltonian.ensure_sparse()
+    np.testing.assert_allclose(
+        hamiltonian.mpo.to_matrix(),
+        hamiltonian.sparse_matrix.toarray(),
+        atol=1e-10,
+    )
+
+
+def test_heisenberg_noiseless_agrees_across_backends() -> None:
+    """Heisenberg preset works with mps, vector, and density_matrix."""
     length = 3
     sim = Simulator(show_progress=False)
     hamiltonian = Hamiltonian.heisenberg(length, Jx=1.0, Jy=0.5, Jz=0.3, h=0.1)
-    assert hamiltonian.representation == "mpo"
 
     init = State(length, initial="x+")
     psi = np.asarray(init.mps.to_vec(), dtype=np.complex128)
@@ -119,10 +167,6 @@ def test_heisenberg_noiseless_agrees_across_representations() -> None:
     z_x_vec = sim.run(State(vector=psi.copy()), hamiltonian, params_dense, None)
     z_x_rho = sim.run(State(density_matrix=rho.copy()), hamiltonian, params_dense, None)
 
-    assert hamiltonian.representation == "mpo"
-    _ = hamiltonian.mpo
-    _ = hamiltonian.sparse_matrix
-
     for idx in range(len(obs_list)):
         mps_val = float(z_x_mps.expectation_values[idx][-1])
         vec_val = float(z_x_vec.expectation_values[idx][-1])
@@ -131,28 +175,28 @@ def test_heisenberg_noiseless_agrees_across_representations() -> None:
         assert mps_val == pytest.approx(vec_val, abs=1e-5), f"obs {idx} mps vs vector"
 
 
-@pytest.mark.parametrize("hamiltonian_kind", ["dense", "sparse"])
-def test_matrix_hamiltonian_runs_on_vector_and_density_matrix(hamiltonian_kind: str) -> None:
-    """User-supplied dense/sparse Hamiltonians evolve under MCWF and Lindblad."""
+def test_single_hamiltonian_reused_across_all_backends() -> None:
+    """One Hamiltonian instance can be reused across mps, vector, and density_matrix runs."""
     length = 2
-    ref = Hamiltonian.ising(length, J=1.0, g=0.5)
-    dense = np.asarray(ref.to_matrix(), dtype=np.complex128)
-    hamiltonian = (
-        Hamiltonian(matrix=dense.copy())
-        if hamiltonian_kind == "dense"
-        else Hamiltonian(sparse_matrix=scipy.sparse.csr_matrix(dense))
-    )
-    assert hamiltonian.representation == ("dense" if hamiltonian_kind == "dense" else "sparse")
-
+    hamiltonian = Hamiltonian.ising(length, J=1.0, g=0.5)
     sim = Simulator(show_progress=False)
     obs = Observable("z", sites=[0])
-    params = AnalogSimParams(observables=[obs], elapsed_time=0.3, dt=0.05, num_traj=1)
+    params_mps = AnalogSimParams(observables=[obs], elapsed_time=0.2, dt=0.05, max_bond_dim=16)
+    params_dense = AnalogSimParams(observables=[obs], elapsed_time=0.2, dt=0.05, num_traj=1)
 
-    state_vec = State(length, initial="zeros", representation="vector")
-    state_rho = State(length, initial="zeros", representation="density_matrix")
-    vec_val = float(sim.run(state_vec, hamiltonian, params, None).expectation_values[0][-1])
-    rho_val = float(sim.run(state_rho, hamiltonian, params, None).expectation_values[0][-1])
+    init = State(length, initial="zeros")
+    psi = np.asarray(init.mps.to_vec(), dtype=np.complex128)
+    rho = np.outer(psi, psi.conj())
+    tensors = [np.asarray(t, dtype=np.complex128).copy() for t in init.mps.tensors]
+
+    mps_val = _final_obs(sim, State(length, tensors=tensors), hamiltonian, params_mps)
+    vec_val = _final_obs(sim, State(vector=psi), hamiltonian, params_dense)
+    rho_val = _final_obs(sim, State(density_matrix=rho), hamiltonian, params_dense)
+
     assert vec_val == pytest.approx(rho_val, abs=1e-8)
-
-    with pytest.raises(ValueError, match=r"TJM simulation requires Hamiltonian\.representation='mpo'"):
-        sim.run(State(length, initial="zeros", representation="mps"), hamiltonian, params, None)
+    assert mps_val == pytest.approx(vec_val, abs=1e-5)
+    np.testing.assert_allclose(
+        hamiltonian.mpo.to_matrix(),
+        hamiltonian.sparse_matrix.toarray(),
+        atol=1e-10,
+    )

--- a/tests/core/data_structures/test_hamiltonian.py
+++ b/tests/core/data_structures/test_hamiltonian.py
@@ -295,6 +295,23 @@ def test_ensure_encoded_sparse_from_dense_hamiltonian() -> None:
     np.testing.assert_allclose(h.sparse_matrix.toarray(), np.eye(4))
 
 
+def test_cached_forms_remain_available_after_ensure_encoded() -> None:
+    """Accessors return any materialized form, not only the last ensure_encoded target."""
+    h = Hamiltonian.ising(2, J=1.0, g=0.5)
+    mpo = h.mpo
+    assert h.representation == "mpo"
+
+    h.ensure_encoded("sparse")
+    assert h.representation == "mpo"
+    assert h.mpo is mpo
+    np.testing.assert_allclose(h.sparse_matrix.toarray(), mpo.to_sparse_matrix().toarray())
+
+    h.ensure_encoded("dense")
+    assert h.mpo is mpo
+    np.testing.assert_allclose(h.matrix, mpo.to_matrix(), atol=1e-12)
+    np.testing.assert_allclose(h.sparse_matrix.toarray(), mpo.to_sparse_matrix().toarray(), atol=1e-12)
+
+
 def test_hamiltonian_mpo_property_unavailable_for_dense_init() -> None:
     """Mpo property raises when only dense matrix is materialized."""
     h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))

--- a/tests/core/data_structures/test_hamiltonian.py
+++ b/tests/core/data_structures/test_hamiltonian.py
@@ -5,12 +5,11 @@
 #
 # Licensed under the MIT License
 
-# ruff:file-ignore[private-member-access] -- white-box tests exercise private Hamiltonian encoders
-
 """Tests for :class:`mqt.yaqs.core.data_structures.hamiltonian.Hamiltonian`."""
 
 from __future__ import annotations
 
+import inspect
 from unittest.mock import patch
 
 import numpy as np
@@ -25,12 +24,8 @@ from mqt.yaqs.core.data_structures.mpo import MPO
 def _blank_hamiltonian(**attrs: object) -> Hamiltonian:
     """Construct an uninitialized Hamiltonian for error-path tests.
 
-    Args:
-        **attrs: Keyword attributes to set on the returned instance (``name=value``).
-
     Returns:
         A Hamiltonian instance with ``attrs`` set via :func:`setattr`.
-
     """
     h = Hamiltonian.__new__(Hamiltonian)
     for name, value in attrs.items():
@@ -62,11 +57,9 @@ def test_hamiltonian_tensors_length_mismatch() -> None:
         Hamiltonian(tensors=list(mpo.tensors), length=3)
 
 
-def test_hamiltonian_tensors_rejects_conflicting_representation() -> None:
-    """representation= must not contradict tensors=."""
-    mpo = MPO.ising(2, J=1.0, g=0.5)
-    with pytest.raises(ValueError, match="inferred as 'mpo' from tensors="):
-        Hamiltonian(tensors=list(mpo.tensors), representation="sparse")
+def test_hamiltonian_rejects_representation_kwarg() -> None:
+    """representation= is no longer a public constructor argument."""
+    assert "representation" not in inspect.signature(Hamiltonian.__init__).parameters
 
 
 def test_hamiltonian_from_manual_tensors() -> None:
@@ -77,7 +70,6 @@ def test_hamiltonian_from_manual_tensors() -> None:
         rng.random(size=(2, 1, 2, 2)).astype(np.complex128),
     ]
     h = Hamiltonian(tensors=tensors)
-    assert h.representation == "mpo"
     assert h.mpo.length == 2
 
 
@@ -99,13 +91,6 @@ def test_hamiltonian_rejects_nonpositive_physical_dimension() -> None:
         Hamiltonian(matrix=np.eye(4, dtype=np.complex128), physical_dimension=0)
 
 
-def test_hamiltonian_sparse_rejects_conflicting_representation() -> None:
-    """representation= must not contradict sparse_matrix=."""
-    sparse = scipy.sparse.eye(4, dtype=np.complex128, format="csr")
-    with pytest.raises(ValueError, match="inferred as 'sparse' from sparse_matrix="):
-        Hamiltonian(sparse_matrix=sparse, representation="dense")
-
-
 def test_hamiltonian_sparse_explicit_length() -> None:
     """Sparse matrix init accepts an explicit length."""
     sparse = scipy.sparse.eye(4, dtype=np.complex128, format="csr")
@@ -124,12 +109,12 @@ def test_hamiltonian_coupled_transmon_factory() -> None:
         anharmonicity=0.2,
         coupling=0.1,
     )
-    assert h.representation == "mpo"
     assert h.length == 4
+    assert h.mpo.length == 4
 
 
 def test_hamiltonian_matrix_property_unavailable_for_mpo() -> None:
-    """Matrix property raises for MPO-only Hamiltonian."""
+    """Matrix property raises for MPO-only Hamiltonian until densified."""
     h = Hamiltonian.ising(2, J=1.0, g=0.5)
     with pytest.raises(RuntimeError, match="Dense matrix is not available"):
         _ = h.matrix
@@ -138,47 +123,46 @@ def test_hamiltonian_matrix_property_unavailable_for_mpo() -> None:
 def test_to_sparse_matrix_raises_without_data() -> None:
     """to_sparse_matrix raises when no backing data exists."""
     h = _blank_hamiltonian(
-        representation="mpo",
-        _encoded_as=None,
         _matrix=None,
         _mpo=None,
         _sparse_matrix=None,
+        _tensors=None,
     )
     with pytest.raises(RuntimeError, match="no materialized data"):
         h.to_sparse_matrix()
 
 
-def test_encode_sparse_raises_without_data() -> None:
-    """_encode('sparse') fails when no specification is available."""
+def test_ensure_sparse_raises_without_data() -> None:
+    """ensure_sparse fails when no specification is available."""
     h = _blank_hamiltonian(
-        representation="mpo",
-        _encoded_as=None,
         _matrix=None,
         _mpo=None,
         _sparse_matrix=None,
+        _tensors=None,
     )
     with pytest.raises(ValueError, match="Cannot build sparse matrix"):
-        h._encode("sparse")
+        h.ensure_sparse()
 
 
-def test_encode_dense_raises_without_data() -> None:
-    """_encode('dense') fails when no specification is available."""
+def test_ensure_mpo_raises_without_data() -> None:
+    """ensure_mpo fails when no specification is available."""
     h = _blank_hamiltonian(
-        representation="dense",
-        _encoded_as=None,
         _matrix=None,
         _mpo=None,
         _sparse_matrix=None,
+        _tensors=None,
+        physical_dimension=2,
+        length=1,
     )
-    with pytest.raises(ValueError, match="Cannot build dense matrix"):
-        h._encode("dense")
+    with pytest.raises(ValueError, match="No Hamiltonian data available to build an MPO"):
+        h.ensure_mpo()
 
 
-def test_ensure_encoded_mpo_idempotent_when_already_materialized() -> None:
-    """ensure_encoded('mpo') returns early when MPO is already cached."""
+def test_ensure_mpo_idempotent_when_already_materialized() -> None:
+    """ensure_mpo returns early when MPO is already cached."""
     h = Hamiltonian.ising(2, J=1.0, g=0.5)
     mpo = h.mpo
-    h.ensure_encoded("mpo")
+    h.ensure_mpo()
     assert h.mpo is mpo
 
 
@@ -186,12 +170,6 @@ def test_hamiltonian_matrix_not_square() -> None:
     """Dense matrix must be square."""
     with pytest.raises(ValueError, match="square 2-D"):
         Hamiltonian(matrix=np.ones((2, 3), dtype=np.complex128))
-
-
-def test_hamiltonian_matrix_rejects_conflicting_representation() -> None:
-    """representation= must not contradict matrix=."""
-    with pytest.raises(ValueError, match="inferred as 'dense' from matrix="):
-        Hamiltonian(matrix=np.eye(2, dtype=np.complex128), representation="mpo")
 
 
 def test_hamiltonian_sparse_not_square() -> None:
@@ -209,10 +187,9 @@ def test_hamiltonian_sparse_coo_converted_to_csr() -> None:
 
 
 def test_hamiltonian_dense_matrix_init() -> None:
-    """matrix= infers dense representation and length from Hilbert dimension."""
+    """matrix= stores dense data and infers length from Hilbert dimension."""
     mat = np.eye(4, dtype=np.complex128)
     h = Hamiltonian(matrix=mat)
-    assert h.representation == "dense"
     assert h.length == 2
     np.testing.assert_allclose(h.matrix, mat)
 
@@ -220,14 +197,12 @@ def test_hamiltonian_dense_matrix_init() -> None:
 def test_hamiltonian_ising_encoded_at_init() -> None:
     """Preset classmethod encodes MPO at construction."""
     h = Hamiltonian.ising(3, J=1.0, g=0.5)
-    assert h.representation == "mpo"
     assert h.mpo.length == 3
 
 
 def test_hamiltonian_heisenberg_factory() -> None:
     """Heisenberg preset builds a valid MPO-backed Hamiltonian."""
     h = Hamiltonian.heisenberg(2, Jx=1.0, Jy=0.5, Jz=0.3, h=0.1)
-    assert h.representation == "mpo"
     assert h.mpo.length == 2
 
 
@@ -244,8 +219,8 @@ def test_hamiltonian_pauli_factory() -> None:
 def test_hamiltonian_fermi_hubbard_factory() -> None:
     """Fermi-Hubbard preset builds a Hamiltonian."""
     h = Hamiltonian.fermi_hubbard_1d(2, t=1.0, u=0.5)
-    assert h.representation == "mpo"
     assert h.length == 2
+    assert h.mpo.length == 2
 
 
 def test_hamiltonian_from_mpo() -> None:
@@ -256,21 +231,20 @@ def test_hamiltonian_from_mpo() -> None:
 
 
 def test_hamiltonian_sparse_matrix_init() -> None:
-    """sparse_matrix= infers sparse representation."""
+    """sparse_matrix= stores sparse data at construction."""
     dim = 4
     sparse = scipy.sparse.eye(dim, dtype=np.complex128, format="csr")
     h = Hamiltonian(sparse_matrix=sparse)
-    assert h.representation == "sparse"
     np.testing.assert_allclose(h.sparse_matrix.toarray(), sparse.toarray())
 
 
-def test_ensure_encoded_mpo_to_sparse_cached() -> None:
+def test_ensure_sparse_from_mpo_cached() -> None:
     """Converting MPO to sparse once caches sparse_matrix for later runs."""
     h = Hamiltonian.ising(2, J=1.0, g=0.5)
     mpo = h.mpo
     with patch.object(MPO, "to_sparse_matrix", wraps=mpo.to_sparse_matrix) as mock_sparse:
-        h.ensure_encoded("sparse")
-        h.ensure_encoded("sparse")
+        h.ensure_sparse()
+        h.ensure_sparse()
     assert mock_sparse.call_count == 1
     np.testing.assert_allclose(
         h.sparse_matrix.toarray(),
@@ -278,38 +252,39 @@ def test_ensure_encoded_mpo_to_sparse_cached() -> None:
     )
 
 
-def test_ensure_encoded_dense_from_mpo() -> None:
-    """MPO Hamiltonian can materialize dense matrix without changing representation."""
-    h = Hamiltonian.ising(2, J=1.0, g=0.5)
-    assert h.representation == "mpo"
-    h.ensure_encoded("dense")
-    dense = h.matrix
-    assert dense.shape == (4, 4)
-    assert h.representation == "mpo"
-
-
-def test_ensure_encoded_sparse_from_dense_hamiltonian() -> None:
-    """Dense-init Hamiltonian can encode sparse for MCWF backends."""
+def test_ensure_sparse_from_dense_hamiltonian() -> None:
+    """Dense-init Hamiltonian can materialize sparse for MCWF backends."""
     h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))
-    h.ensure_encoded("sparse")
+    h.ensure_sparse()
     np.testing.assert_allclose(h.sparse_matrix.toarray(), np.eye(4))
 
 
-def test_cached_forms_remain_available_after_ensure_encoded() -> None:
-    """Accessors return any materialized form, not only the last ensure_encoded target."""
+def test_ensure_mpo_from_dense_and_sparse() -> None:
+    """Dense and sparse sources convert to MPO via MPO.from_matrix."""
+    dense = Hamiltonian.ising(2, J=1.0, g=0.5).to_matrix()
+    h_dense = Hamiltonian(matrix=dense.copy())
+    h_dense.ensure_mpo()
+    np.testing.assert_allclose(h_dense.mpo.to_matrix(), dense, atol=1e-10)
+
+    h_sparse = Hamiltonian(sparse_matrix=scipy.sparse.csr_matrix(dense))
+    h_sparse.ensure_mpo()
+    np.testing.assert_allclose(h_sparse.mpo.to_matrix(), dense, atol=1e-10)
+    # Sparse→MPO densifies and caches the dense form.
+    np.testing.assert_allclose(h_sparse.matrix, dense, atol=1e-10)
+
+
+def test_cached_forms_remain_available_after_conversions() -> None:
+    """Accessors return any materialized form after ensure_mpo / ensure_sparse."""
     h = Hamiltonian.ising(2, J=1.0, g=0.5)
     mpo = h.mpo
-    assert h.representation == "mpo"
 
-    h.ensure_encoded("sparse")
-    assert h.representation == "mpo"
+    h.ensure_sparse()
     assert h.mpo is mpo
     np.testing.assert_allclose(h.sparse_matrix.toarray(), mpo.to_sparse_matrix().toarray())
 
-    h.ensure_encoded("dense")
+    dense = h.to_matrix()
     assert h.mpo is mpo
-    np.testing.assert_allclose(h.matrix, mpo.to_matrix(), atol=1e-12)
-    np.testing.assert_allclose(h.sparse_matrix.toarray(), mpo.to_sparse_matrix().toarray(), atol=1e-12)
+    np.testing.assert_allclose(dense, mpo.to_matrix(), atol=1e-12)
 
 
 def test_hamiltonian_mpo_property_unavailable_for_dense_init() -> None:
@@ -327,7 +302,7 @@ def test_hamiltonian_sparse_property_unavailable_for_mpo_init() -> None:
 
 
 def test_to_matrix_from_mpo_and_sparse() -> None:
-    """to_matrix converts from MPO or sparse without changing representation."""
+    """to_matrix converts from MPO or sparse."""
     h_mpo = Hamiltonian.ising(2, J=1.0, g=0.5)
     ref = h_mpo.mpo.to_matrix()
     np.testing.assert_allclose(h_mpo.to_matrix(), ref, atol=1e-10)
@@ -350,33 +325,6 @@ def test_to_sparse_matrix_from_mpo_only() -> None:
     np.testing.assert_allclose(sparse.toarray(), h.mpo.to_sparse_matrix().toarray())
 
 
-def test_ensure_encoded_dense_idempotent() -> None:
-    """ensure_encoded('dense') is a no-op when a dense matrix is already cached."""
-    h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))
-    cached = h.matrix.copy()
-    h.ensure_encoded("dense")
-    np.testing.assert_allclose(h.matrix, cached)
-
-
-def test_ensure_encoded_dense_from_sparse_init() -> None:
-    """Sparse-init Hamiltonian can materialize a dense matrix on demand."""
-    h = Hamiltonian(sparse_matrix=scipy.sparse.eye(4, dtype=np.complex128))
-    h.ensure_encoded("dense")
-    np.testing.assert_allclose(h.matrix, np.eye(4))
-
-
-def test_build_mpo_raises_without_tensors() -> None:
-    """_build_mpo fails when no tensor specification exists."""
-    h = _blank_hamiltonian(
-        _mpo=None,
-        _tensors=None,
-        _matrix=None,
-        _sparse_matrix=None,
-    )
-    with pytest.raises(ValueError, match="No MPO specification available"):
-        h._build_mpo()
-
-
 def test_to_sparse_matrix_from_dense() -> None:
     """to_sparse_matrix converts from dense matrix storage."""
     h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))
@@ -387,25 +335,17 @@ def test_to_sparse_matrix_from_dense() -> None:
 def test_to_matrix_raises_without_data() -> None:
     """to_matrix raises when no backing data exists."""
     h = _blank_hamiltonian(
-        representation="mpo",
-        _encoded_as=None,
         _matrix=None,
         _mpo=None,
         _sparse_matrix=None,
+        _tensors=None,
     )
     with pytest.raises(RuntimeError, match="no materialized data"):
         h.to_matrix()
 
 
-def test_build_mpo_raises_for_matrix_only() -> None:
-    """Cannot build MPO from dense-only specification."""
-    h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))
-    with pytest.raises(ValueError, match="Cannot build an MPO from matrix"):
-        h._build_mpo()
-
-
-def test_run_rejects_mpo_hamiltonian_with_mps_state() -> None:
-    """TJM requires Hamiltonian stored as MPO."""
+def test_run_accepts_dense_hamiltonian_with_mps_state() -> None:
+    """TJM materializes an MPO from a dense-source Hamiltonian."""
     dim = 4
     mat = np.eye(dim, dtype=np.complex128)
     h = Hamiltonian(matrix=mat)
@@ -415,9 +355,9 @@ def test_run_rejects_mpo_hamiltonian_with_mps_state() -> None:
         elapsed_time=0.1,
         dt=0.1,
     )
-    sim = Simulator(show_progress=False)
-    with pytest.raises(ValueError, match=r"TJM simulation requires Hamiltonian\.representation='mpo'"):
-        sim.run(state, h, params, None)
+    result = Simulator(show_progress=False).run(state, h, params, None)
+    assert result.expectation_values[0].shape[0] >= 1
+    _ = h.mpo
 
 
 def test_run_hamiltonian_length_mismatch() -> None:
@@ -432,6 +372,54 @@ def test_run_hamiltonian_length_mismatch() -> None:
     sim = Simulator(show_progress=False)
     with pytest.raises(ValueError, match=r"does not match Hamiltonian\.length"):
         sim.run(state, h, params, None)
+
+
+def test_ensure_sparse_prefers_dense_source_after_ensure_mpo() -> None:
+    """After ensure_mpo, ensure_sparse still uses the original dense matrix."""
+    dense = Hamiltonian.ising(2, J=1.0, g=0.5).to_matrix()
+    # Perturb off-diagonals so an approximate MPO conversion can differ.
+    dense = dense.copy()
+    dense[0, 3] += 0.37
+    dense[3, 0] += 0.37
+    h = Hamiltonian(matrix=dense.copy())
+    h.ensure_mpo()
+    mpo = h.mpo
+    with patch.object(MPO, "to_sparse_matrix", wraps=mpo.to_sparse_matrix) as mock_sparse:
+        h.ensure_sparse()
+    assert mock_sparse.call_count == 0
+    np.testing.assert_allclose(h.sparse_matrix.toarray(), dense)
+
+
+@pytest.mark.parametrize("order", ["mps_then_vector", "vector_then_mps"])
+def test_dense_hamiltonian_run_order_preserves_source_fidelity(order: str) -> None:
+    """Dense-source fidelity is independent of MPS vs vector run order."""
+    length = 2
+    dense = Hamiltonian.ising(length, J=1.0, g=0.5).to_matrix().copy()
+    dense[0, 3] += 0.21
+    dense[3, 0] += 0.21
+    hamiltonian = Hamiltonian(matrix=dense.copy())
+    sim = Simulator(show_progress=False)
+    obs = Observable("z", sites=[0])
+    params_mps = AnalogSimParams(observables=[obs], elapsed_time=0.2, dt=0.05, max_bond_dim=16, svd_threshold=1e-10)
+    params_vec = AnalogSimParams(observables=[obs], elapsed_time=0.2, dt=0.05, num_traj=1)
+
+    state_mps = State(length, initial="zeros", representation="mps")
+    state_vec = State(length, initial="zeros", representation="vector")
+    state_rho = State(length, initial="zeros", representation="density_matrix")
+
+    if order == "mps_then_vector":
+        mps_val = float(sim.run(state_mps, hamiltonian, params_mps, None).expectation_values[0][-1])
+        vec_val = float(sim.run(state_vec, hamiltonian, params_vec, None).expectation_values[0][-1])
+        rho_val = float(sim.run(state_rho, hamiltonian, params_vec, None).expectation_values[0][-1])
+    else:
+        vec_val = float(sim.run(state_vec, hamiltonian, params_vec, None).expectation_values[0][-1])
+        rho_val = float(sim.run(state_rho, hamiltonian, params_vec, None).expectation_values[0][-1])
+        mps_val = float(sim.run(state_mps, hamiltonian, params_mps, None).expectation_values[0][-1])
+
+    assert vec_val == pytest.approx(rho_val, abs=1e-8)
+    assert mps_val == pytest.approx(vec_val, abs=1e-4)
+    np.testing.assert_allclose(hamiltonian.sparse_matrix.toarray(), dense)
+    np.testing.assert_allclose(hamiltonian.matrix, dense)
 
 
 def test_to_sparse_matrix_called_once_across_two_runs() -> None:

--- a/tests/core/data_structures/test_hamiltonian.py
+++ b/tests/core/data_structures/test_hamiltonian.py
@@ -17,6 +17,7 @@ import pytest
 import scipy.sparse
 
 from mqt.yaqs import AnalogSimParams, Observable, Simulator, State
+from mqt.yaqs.core.data_structures import hamiltonian as hamiltonian_mod
 from mqt.yaqs.core.data_structures.hamiltonian import Hamiltonian
 from mqt.yaqs.core.data_structures.mpo import MPO
 
@@ -420,6 +421,24 @@ def test_dense_hamiltonian_run_order_preserves_source_fidelity(order: str) -> No
     assert mps_val == pytest.approx(vec_val, abs=1e-4)
     np.testing.assert_allclose(hamiltonian.sparse_matrix.toarray(), dense)
     np.testing.assert_allclose(hamiltonian.matrix, dense)
+
+
+def test_ensure_mpo_warns_before_large_dense_factorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Large dense→MPO conversion emits the preprocess_mcwf-style RuntimeWarning."""
+    monkeypatch.setattr(hamiltonian_mod, "_LARGE_HILBERT_DIM", 2)
+    h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))
+    with pytest.warns(RuntimeWarning, match="factorizing a dense matrix into an MPO"):
+        h.ensure_mpo()
+    assert h.mpo.length == 2
+
+
+def test_ensure_mpo_warns_before_large_sparse_densification(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Large sparse→MPO conversion warns before densifying."""
+    monkeypatch.setattr(hamiltonian_mod, "_LARGE_HILBERT_DIM", 2)
+    h = Hamiltonian(sparse_matrix=scipy.sparse.eye(4, dtype=np.complex128, format="csr"))
+    with pytest.warns(RuntimeWarning, match="densifying a sparse matrix to build an MPO"):
+        h.ensure_mpo()
+    assert h.mpo.length == 2
 
 
 def test_to_sparse_matrix_called_once_across_two_runs() -> None:

--- a/tests/core/data_structures/test_hamiltonian_utils.py
+++ b/tests/core/data_structures/test_hamiltonian_utils.py
@@ -10,15 +10,10 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 import scipy.sparse
 
 from mqt.yaqs.core.data_structures.hamiltonian import Hamiltonian
-from mqt.yaqs.core.data_structures.hamiltonian_utils import (
-    attach_mpo,
-    sparse_to_csr,
-    validate_representation,
-)
+from mqt.yaqs.core.data_structures.hamiltonian_utils import attach_mpo, sparse_to_csr
 from mqt.yaqs.core.data_structures.mpo import MPO
 
 
@@ -35,22 +30,10 @@ def test_sparse_to_csr_converts_coo() -> None:
     assert isinstance(out, scipy.sparse.csr_matrix)
 
 
-def test_validate_representation_accepts_known() -> None:
-    """Known representation labels are returned unchanged."""
-    assert validate_representation("mpo") == "mpo"
-
-
-def test_validate_representation_rejects_unknown() -> None:
-    """Invalid representation labels raise ValueError."""
-    with pytest.raises(ValueError, match=r"Invalid representation 'bad'"):
-        validate_representation("bad")
-
-
 def test_attach_mpo_initializes_wrapped_hamiltonian() -> None:
     """attach_mpo wires an existing MPO into a blank Hamiltonian instance."""
     mpo = MPO.ising(2, J=1.0, g=0.5)
     wrapped = Hamiltonian.__new__(Hamiltonian)
     attach_mpo(wrapped, mpo)
     assert wrapped.mpo is mpo
-    assert wrapped.representation == "mpo"
     assert wrapped.length == 2

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1471,8 +1471,8 @@ def test_analog_run_rejects_non_state_initial_state() -> None:
         sim.run(cast(Any, MPS(2, state="zeros")), h, params, None)  # ruff:ignore[runtime-cast-value]  # cast is required to exercise the runtime TypeError guard for non-State initial states
 
 
-def test_analog_run_rejects_matrix_hamiltonian_with_mps_state() -> None:
-    """TJM requires Hamiltonian.representation='mpo'."""
+def test_analog_run_accepts_matrix_hamiltonian_with_mps_state() -> None:
+    """TJM auto-converts dense Hamiltonians to MPO."""
     state = State(2, initial="zeros")
     h = Hamiltonian(matrix=np.eye(4, dtype=np.complex128))
     params = AnalogSimParams(
@@ -1480,8 +1480,8 @@ def test_analog_run_rejects_matrix_hamiltonian_with_mps_state() -> None:
         elapsed_time=0.1,
         dt=0.1,
     )
-    with pytest.raises(ValueError, match=r"TJM simulation requires Hamiltonian\.representation='mpo'"):
-        Simulator(show_progress=False).run(state, h, params, None)
+    result = Simulator(show_progress=False).run(state, h, params, None)
+    assert result.expectation_values[0].shape[0] >= 1
 
 
 def test_no_output_error() -> None:


### PR DESCRIPTION
## Description

This PR makes `State.representation` the sole selector of the analog simulation backend. Hamiltonians are automatically converted and cached as MPO or sparse form as required.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
