### PR TITLE
🐛 fix the CZ and CPhase generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ releases may include breaking changes.
 
 ### Fixed
 
+- fixed the CZ and CPhase generators used on the TDVP gate application path
+  ([#526]) ([**@Pouri96**])
 - fixed TJM jump selection to align processes with site-sweep probabilities
   ([#506]) ([**@Pouri96**])
 
@@ -239,6 +241,7 @@ for previous changelogs._
 [#516]: https://github.com/munich-quantum-toolkit/yaqs/pull/516
 [#514]: https://github.com/munich-quantum-toolkit/yaqs/pull/514
 [#508]: https://github.com/munich-quantum-toolkit/yaqs/pull/508
+[#526]: https://github.com/munich-quantum-toolkit/yaqs/pull/526
 [#506]: https://github.com/munich-quantum-toolkit/yaqs/pull/506
 [#288]: https://github.com/munich-quantum-toolkit/yaqs/pull/288
 [#482]: https://github.com/munich-quantum-toolkit/yaqs/pull/482

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -1211,10 +1211,10 @@ class CZ(BaseGate):
 
         self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
-        # Generator: π/4 * ((I - Z) ⊗ (I - X))
+        # Generator: π/4 * ((I - Z) ⊗ (I - Z))
         self.generator = [
             (np.pi / 4) * np.array([[0, 0], [0, 2]], dtype=np.complex128),
-            np.array([[1, -1], [-1, 1]], dtype=np.complex128),
+            np.array([[0, 0], [0, 2]], dtype=np.complex128),
         ]
         self.mpo_tensors = extend_gate(self.tensor, self.sites)
         if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
@@ -1273,7 +1273,11 @@ class CPhase(BaseGate):
 
         self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
-        self.generator = [(self.theta / 2) * np.array([[1, 0], [0, -1]]), np.array([[1, 0], [0, 0]])]
+        # Generator: -θ * (P1 ⊗ P1)
+        self.generator = [
+            -self.theta * np.array([[0, 0], [0, 1]], dtype=np.complex128),
+            np.array([[0, 0], [0, 1]], dtype=np.complex128),
+        ]
         self.mpo_tensors = extend_gate(self.tensor, self.sites)
 
 

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from scipy.linalg import expm
 
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.simulation_parameters import Observable
@@ -525,6 +526,58 @@ def test_gate_constructor() -> None:
     # Test for non-square matrix
     with pytest.raises(ValueError, match="Matrix must be square"):
         BaseGate(non_square_matrix)
+
+
+def _generator_gate_names() -> list[str]:
+    """Names of GateLibrary classes that define a product-form generator.
+
+    Returns:
+        The gate names, discovered dynamically so newly added gates are covered.
+    """
+    names = []
+    for name in sorted(dir(GateLibrary)):
+        cls = getattr(GateLibrary, name)
+        if not isinstance(cls, type) or not issubclass(cls, BaseGate):
+            continue
+        for args in ((), ([0.7],)):
+            try:
+                gate = cls(*args)
+                break
+            except (TypeError, ValueError, AttributeError, IndexError):
+                continue
+        else:
+            continue
+        try:
+            gate.set_sites(*range(gate.interaction))
+        except (TypeError, ValueError):
+            continue
+        if getattr(gate, "generator", None) is not None:
+            names.append(name)
+    return names
+
+
+def test_generator_gate_discovery() -> None:
+    """The generator sweep covers at least the known generator-carrying gates."""
+    assert {"cx", "cz", "cp", "rxx", "ryy", "rzz"}.issubset(set(_generator_gate_names()))
+
+
+@pytest.mark.parametrize("name", _generator_gate_names())
+def test_gate_generator_matches_matrix(name: str) -> None:
+    """Exponentiating the product-form generator reproduces the gate matrix exactly.
+
+    The generator is consumed on the TDVP window path, so a wrong generator silently
+    applies a different gate there while the matrix-based paths stay correct.
+    """
+    cls = getattr(GateLibrary, name)
+    try:
+        gate = cls()
+    except (TypeError, IndexError):
+        gate = cls([0.7])
+    gate.set_sites(*range(gate.interaction))
+    kron = np.asarray(gate.generator[0], dtype=np.complex128)
+    for factor in gate.generator[1:]:
+        kron = np.kron(kron, np.asarray(factor, dtype=np.complex128))
+    assert_allclose(expm(-1j * kron), gate.matrix, atol=1e-12)
 
 
 def test_set_sites() -> None:


### PR DESCRIPTION

## The issue: 

- The `CZ` gate class carries CX's generator: exponentiating the stored product factors reproduces the **CX** matrix exactly, not CZ. On the TDVP gate application path a `cz` is therefore silently simulated as a `cx`. 

- `h(0..3); cz(0, 3)` under `gate_mode="tdvp"` produces the state of the **cx** circuit with fidelity 1.0000 (0.25 to the correct state). The `CPhase` generator `[(θ/2)·Z, P0]` does not reproduce CP under any global phase.

Both defects date to the commit that introduced the gate-class hierarchy (`c633050e`, March 2025) and are present in every release. They stayed hidden because no test exercises `cz` or `cp` on a generator path: nearest-neighbor `tdvp`, `swaps`, and `mpo` route through TEBD/MPO, which use the (correct) matrix.

## The solution:
This PR sets the CZ generator to `(π/4)·(I−Z)⊗(I−Z)` and the CPhase generator to `−θ·(P1⊗P1)`, both of which exponentiate to the gate matrix exactly, and adds a regression test that dynamically discovers every generator-carrying gate in the library and asserts `expm(-i·kron(factors)) == matrix` — so any future gate with a generator is covered automatically.

After the fix, the long-range `cz` example above no longer produces the cx-circuit state (fidelity to it drops to 0.25) and converges to the exact cz state with `tdvp_sweeps` (0.9990 at 4 sweeps), i.e. the usual windowed-2TDVP substep behaviour.
