### PR TITLE
hardened stability of noise model, timestep selection, and RNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- hardened stability of noise model, timestep selection, and RNG ([#527])
+  ([**@aaronleesander**])
 - State.representation set as sole backend selector ([#519])
   ([**@aaronleesander**])
 - added QR canonicalization before compression sweep for stability ([#518])
@@ -235,6 +237,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#527]: https://github.com/munich-quantum-toolkit/yaqs/pull/527
 [#497]: https://github.com/munich-quantum-toolkit/yaqs/pull/497
 [#519]: https://github.com/munich-quantum-toolkit/yaqs/pull/519
 [#518]: https://github.com/munich-quantum-toolkit/yaqs/pull/518

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,6 +27,19 @@ Calls such as `AnalogSimParams(elapsed_time=0.25, dt=0.1)` now raise a
 `ValueError`. Use a divisible step size or duration instead; fractional final
 steps are not supported.
 
+### Breaking: seeded stochastic RNG streams no longer use `base_seed + traj_idx`
+
+When `random_seed` is set, trajectory jump draws, order-2 measurement-copy
+jumps, and static noise-model disorder sampling each use distinct
+`numpy.random.SeedSequence` coordinates (stream tags), instead of
+`base_seed + traj_idx`.
+
+This removes aliasing between pairs such as `(base_seed=0, traj_idx=1)` and
+`(base_seed=1, traj_idx=0)`, and stops order-2 `sample()` calls from advancing
+the trajectory jump stream.
+**Bit-identical replay of older seeded runs is not preserved.** Re-record any
+baselines that depend on exact sample paths.
+
 ### Breaking: unified circuit parameters as `DigitalSimParams`
 
 Circuit simulation now uses a single {class}`~mqt.yaqs.DigitalSimParams` type.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,27 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Breaking: analog durations must contain a whole number of fixed time steps
+
+`AnalogSimParams` now requires a finite, positive `dt` and a finite,
+non-negative `elapsed_time` that is an integer multiple of `dt`. Analog backends
+execute only full `dt` steps; rejecting fractional grids prevents the reported
+final timestamp from disagreeing with the physically evolved duration.
+
+Choose an integer step count and derive the duration from it:
+
+```python
+from mqt.yaqs import AnalogSimParams
+
+num_steps = 3
+dt = 0.1
+params = AnalogSimParams(elapsed_time=num_steps * dt, dt=dt)
+```
+
+Calls such as `AnalogSimParams(elapsed_time=0.25, dt=0.1)` now raise a
+`ValueError`. Use a divisible step size or duration instead; fractional final
+steps are not supported.
+
 ### Breaking: unified circuit parameters as `DigitalSimParams`
 
 Circuit simulation now uses a single {class}`~mqt.yaqs.DigitalSimParams` type.

--- a/docs/examples/ensemble_evolution.md
+++ b/docs/examples/ensemble_evolution.md
@@ -64,7 +64,7 @@ psi0 = State(L, initial="haar-random", pad=2)
 
 primer_params = AnalogSimParams(
     observables=[Observable("z", mid)],
-    elapsed_time=5.0,
+    elapsed_time=5.1,
     dt=0.15,
     max_bond_dim=64,
     svd_threshold=1e-10,
@@ -118,7 +118,7 @@ sx_mid = Observable("x", mid)
 
 single_state_params = AnalogSimParams(
     observables=[],
-    elapsed_time=5.0,
+    elapsed_time=5.1,
     dt=0.15,
     max_bond_dim=64,
     svd_threshold=1e-10,
@@ -167,7 +167,7 @@ ensemble_states = [State(L, initial="haar-random", pad=2) for _ in range(num_sta
 
 ensemble_params = AnalogSimParams(
     observables=[],
-    elapsed_time=5.0,
+    elapsed_time=5.1,
     dt=0.15,
     max_bond_dim=64,
     svd_threshold=1e-10,
@@ -244,7 +244,7 @@ def current_observables(length: int, j_coupling: float) -> list[Observable]:
 Ltr = 6
 Jxx = 1.0
 deltas = [0.1, 0.5, 1.5]
-t_final = 5.0
+t_final = 5.1
 dt = 0.15
 n_transport_states = 4
 

--- a/docs/examples/realistic_noise_models.md
+++ b/docs/examples/realistic_noise_models.md
@@ -41,6 +41,16 @@ Each process is a dictionary with `name`, `sites`, and `strength`. YAQS fills in
 the operator `matrix` (or per-site `factors` for long-range crosstalk) from
 {class}`~mqt.yaqs.core.libraries.noise_library.NoiseLibrary`.
 
+Malformed configs raise `TypeError` (wrong types, including booleans used as
+sites/strengths) or `ValueError` (invalid values). Fixed `strength` values must
+be finite and **nonnegative**—they are Lindblad/quantum-jump rates $\gamma$, not
+signed dissipator coefficients. Temporarily negative rates can appear in
+time-local non-Markovian master equations, but YAQS does not implement signed
+generators or reverse-jump unravelings. Custom `matrix` / `factors` entries may
+still contain negative elements. Site lists/tuples must contain exactly one or
+two distinct nonnegative integers; custom full two-site matrices require
+**ascending** site order (or use `factors` instead).
+
 ```{code-cell} ipython3
 from mqt.yaqs import NoiseModel
 
@@ -259,8 +269,11 @@ circuit_result = sim.run(State(num_qubits, initial="zeros"), circuit, circuit_pa
 
 ## 5. Long-range crosstalk
 
-Non-adjacent pairs use the `longrange_crosstalk_{ab}` naming convention; YAQS
-attaches per-site Pauli factors automatically:
+Non-adjacent pairs use the exact `longrange_crosstalk_[xyz]{2}` naming
+convention (e.g. `longrange_crosstalk_xy`); YAQS attaches per-site Pauli factors
+automatically. The same physics works on analog MPS TJM, MCWF, and Lindblad.
+Digital TJM rejects non-adjacent / factorized two-site noise up front
+(gate-local scoping remains nearest-neighbor only).
 
 ```{code-cell} ipython3
 lr_model = NoiseModel([
@@ -276,17 +289,19 @@ Every noise process is a dictionary. Besides the built-in
 `pauli_x`, `crosstalk_xx`, …), you can supply your own operator as a NumPy
 array:
 
-| Key        | Required | Description                                                                                                                        |
-| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `name`     | yes      | Label for the process. When `matrix` is omitted, must match a `NoiseLibrary` entry. When `matrix` is provided, any string is fine. |
-| `sites`    | yes      | Site indices the jump acts on (one site for single-qubit channels).                                                                |
-| `strength` | yes      | Rate $\gamma$ in Lindblad form; YAQS uses jump operators $L_k = \sqrt{\gamma}\,L$.                                                 |
-| `matrix`   | no       | Local operator $L$ as a `d×d` array (`d=2` for qubits). If omitted, YAQS looks up `name` in `NoiseLibrary`.                        |
+| Key        | Required | Description                                                                                                                                               |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`     | yes      | Nonempty label. When `matrix`/`factors` are omitted, must be a library name, `x`/`y`/`z`, or exact `crosstalk_[xyz]{2}` / `longrange_crosstalk_[xyz]{2}`. |
+| `sites`    | yes      | List/tuple of exactly one or two distinct nonnegative site indices.                                                                                       |
+| `strength` | yes      | Nonnegative finite rate $\gamma$, or a distribution dict (`normal` / `lognormal` / `truncated_normal`).                                                   |
+| `matrix`   | no       | Square finite local operator $L$ (`d×d`, or `d_i d_j` for adjacent two-site). Ascending sites required for custom two-site matrices.                      |
+| `factors`  | no       | Exactly two square one-site operators for non-adjacent pairs.                                                                                             |
 
 YAQS does not check complete positivity; supply physically meaningful jump
 operators. The same `matrix` override works for **scheduled jumps** (see
-{doc}`scheduled_jumps`) and for all backends—TJM (`mps`), MCWF (`vector`),
-Lindblad (`density_matrix`), and noisy circuits.
+{doc}`scheduled_jumps`) on supported backends and for process noise on TJM
+(`mps`), MCWF (`vector`), Lindblad (`density_matrix`), and noisy circuits
+(nearest-neighbor digital processes only).
 
 ### Amplitude damping with an explicit $\sigma_-$
 

--- a/docs/examples/scheduled_jumps.md
+++ b/docs/examples/scheduled_jumps.md
@@ -29,8 +29,11 @@ Scheduled jumps are supported only for **single-`State` analog MPS TJM** with
 for ``order=2``, MCWF, Lindblad, digital circuits, and `list[State]` unitary
 ensembles. Jump times must lie on the simulation time grid (`sim_params.times`;
 choose `time` as a multiple of `dt`). Two-site scheduled jumps must be
-nearest-neighbor. On a matching timestep, scheduled jumps replace the ordinary
-stochastic jump channel for that step (dissipation still runs).
+nearest-neighbor. A jump at ``time=0.0`` is applied to the initial state
+**before** dissipation and the first measurement, so the recorded initial
+observable (and ``get_state``) already include it. For interior timesteps, on a
+matching grid point scheduled jumps replace the ordinary stochastic jump channel
+for that step (dissipation still runs).
 ```
 
 ## 1. Setup

--- a/docs/examples/scheduled_jumps.md
+++ b/docs/examples/scheduled_jumps.md
@@ -24,8 +24,9 @@ In this example, we simulate a 10-site Ising chain and apply a scheduled Pauli-X
 flip to a specific site at $t=1.0$.
 
 ```{important}
-Scheduled jumps are supported only for **single-`State` analog MPS TJM**. They
-are rejected for MCWF, Lindblad, digital circuits, and `list[State]` unitary
+Scheduled jumps are supported only for **single-`State` analog MPS TJM** with
+{class}`~mqt.yaqs.AnalogSimParams` ``order=1`` (the default). They are rejected
+for ``order=2``, MCWF, Lindblad, digital circuits, and `list[State]` unitary
 ensembles. Jump times must lie on the simulation time grid (`sim_params.times`;
 choose `time` as a multiple of `dt`). Two-site scheduled jumps must be
 nearest-neighbor. On a matching timestep, scheduled jumps replace the ordinary

--- a/docs/examples/scheduled_jumps.md
+++ b/docs/examples/scheduled_jumps.md
@@ -24,8 +24,12 @@ In this example, we simulate a 10-site Ising chain and apply a scheduled Pauli-X
 flip to a specific site at $t=1.0$.
 
 ```{important}
-Scheduled jump times must lie on the simulation time grid: choose `time` as a
-multiple of `dt` (for example `dt=0.1` → `0.0, 0.1, 0.2, …`).
+Scheduled jumps are supported only for **single-`State` analog MPS TJM**. They
+are rejected for MCWF, Lindblad, digital circuits, and `list[State]` unitary
+ensembles. Jump times must lie on the simulation time grid (`sim_params.times`;
+choose `time` as a multiple of `dt`). Two-site scheduled jumps must be
+nearest-neighbor. On a matching timestep, scheduled jumps replace the ordinary
+stochastic jump channel for that step (dissipation still runs).
 ```
 
 ## 1. Setup

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -174,7 +174,10 @@ _trunc_summary(shot_params)
 
 Besides the preset (and any overrides), you typically set the time grid
 (`elapsed_time`, `dt`), observables, and whether to record intermediate times
-(`sample_timesteps`).
+(`sample_timesteps`). Analog backends use a fixed step size, so `dt` must be
+positive and `elapsed_time` must be a non-negative integer multiple of `dt`.
+Non-integral grids raise a `ValueError`; choose the step count first and set
+`elapsed_time = num_steps * dt` when constructing a grid programmatically.
 
 ```{code-cell} ipython3
 L = 4

--- a/src/mqt/yaqs/analog/analog_tjm.py
+++ b/src/mqt/yaqs/analog/analog_tjm.py
@@ -27,7 +27,7 @@ from ..core.methods.dissipation import apply_dissipation
 from ..core.methods.scheduled_jumps import apply_scheduled_jumps, has_scheduled_jump
 from ..core.methods.stochastic_process import stochastic_process
 from ..core.methods.tdvp import tdvp
-from ..core.random_utils import make_trajectory_rng
+from ..core.random_utils import make_sample_rng, make_trajectory_rng
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -121,7 +121,9 @@ def sample(
         sim_params (AnalogSimParams): Simulation parameters including time step and measurement settings.
         results (NDArray[np.float64]): An array to store the measured observable values.
         j (int): The time step or shot index at which the measurement is recorded.
-        rng: The random number generator to use.
+        rng: RNG for jump decisions on the measurement copy. Must be independent of the
+            trajectory RNG used for ``initialize`` / ``step_through`` so intermediate
+            sampling does not alter subsequent evolution.
         diagnostics: Optional ``(3, T)`` buffer for runtime cost, max bond, and total bond.
 
     Returns:
@@ -180,6 +182,7 @@ def analog_tjm_2(
     traj_idx, initial_state, noise_model, sim_params, hamiltonian = args
 
     rng = make_trajectory_rng(traj_idx, base_seed=sim_params.random_seed)
+    base_seed = sim_params.random_seed
 
     state = copy.deepcopy(initial_state)
     num_cols = _diagnostic_num_columns(sim_params)
@@ -190,24 +193,51 @@ def analog_tjm_2(
         results = np.zeros((len(sim_params.sorted_observables), 1))
 
     final_state: MPS | None = None
+    n_times = len(sim_params.times)
+
+    # Zero-duration runs: evaluate the initial state before any noise/evolution (F0).
+    if n_times == 1:
+        state.record_diagnostics(diagnostics, 0)
+        if sim_params.sample_timesteps:
+            state.evaluate_observables(sim_params, results, 0)
+        else:
+            state.evaluate_observables(sim_params, results)
+        return results, diagnostics, state if sim_params.get_state else None
 
     if sim_params.sample_timesteps:
         state.record_diagnostics(diagnostics, 0)
         state.evaluate_observables(sim_params, results, 0)
 
     phi = initialize(state, noise_model, sim_params, rng=rng)
-    if sim_params.sample_timesteps:
+
+    # Sample at times[1] whenever it is requested or is the final time (len==2 final-only).
+    # Per-timestep sample RNGs so intermediate draws cannot change the final measurement.
+    if sim_params.sample_timesteps or n_times == 2:
         sampled_state = sample(
-            phi, hamiltonian, noise_model, sim_params, results, j=1, rng=rng, diagnostics=diagnostics
+            phi,
+            hamiltonian,
+            noise_model,
+            sim_params,
+            results,
+            j=1,
+            rng=make_sample_rng(traj_idx, base_seed=base_seed, timestep=1),
+            diagnostics=diagnostics,
         )
         if sampled_state is not None:
             final_state = sampled_state
 
     for j, _ in enumerate(sim_params.times[2:], start=2):
         phi = step_through(phi, hamiltonian, noise_model, sim_params, sim_params.times[j], rng=rng)
-        if sim_params.sample_timesteps or j == len(sim_params.times) - 1:
+        if sim_params.sample_timesteps or j == n_times - 1:
             sampled_state = sample(
-                phi, hamiltonian, noise_model, sim_params, results, j, rng=rng, diagnostics=diagnostics
+                phi,
+                hamiltonian,
+                noise_model,
+                sim_params,
+                results,
+                j,
+                rng=make_sample_rng(traj_idx, base_seed=base_seed, timestep=j),
+                diagnostics=diagnostics,
             )
             if sampled_state is not None:
                 final_state = sampled_state
@@ -248,6 +278,11 @@ def analog_tjm_1(
     else:
         results = np.zeros((len(sim_params.sorted_observables), 1), dtype=object)
 
+    # Apply scheduled jumps at t=times[0] before the initial sample so observables
+    # and get_state agree (later timesteps also sample after the jump event).
+    if noise_model is not None and has_scheduled_jump(noise_model, sim_params.times[0], sim_params.dt):
+        state = apply_scheduled_jumps(state, noise_model, sim_params.times[0], sim_params)
+
     if sim_params.sample_timesteps:
         state.record_diagnostics(diagnostics, 0)
         state.evaluate_observables(sim_params, results, 0)
@@ -268,6 +303,11 @@ def analog_tjm_1(
         elif j == len(sim_params.times) - 1:
             state.record_diagnostics(diagnostics, 0)
             state.evaluate_observables(sim_params, results)
+
+    # Final-only runs with elapsed_time=0 never enter the loop above.
+    if not sim_params.sample_timesteps and len(sim_params.times) <= 1:
+        state.record_diagnostics(diagnostics, 0)
+        state.evaluate_observables(sim_params, results)
 
     final_state = state if sim_params.get_state else None
     return results, diagnostics, final_state

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -269,14 +269,16 @@ def _rho_vec_at_elapsed_time(ctx: LindbladContext) -> NDArray[np.complex128]:
         return ctx.rho_initial.copy()
 
     dt = sim_params.dt
-    n_full = int(target_t // dt)
+    # Match AnalogSimParams: round the validated elapsed_time/dt ratio so grid
+    # endpoints leave only floating-point dust in the remainder.
+    n_full = round(target_t / dt)
     remainder = target_t - n_full * dt
 
     if ctx.step_propagator is not None:
         rho_vec = ctx.rho_initial.copy()
         for _ in range(n_full):
             rho_vec = ctx.step_propagator @ rho_vec
-        if remainder > 1e-12:
+        if abs(remainder) > 1e-12:
             liouvillian = _build_liouvillian_superoperator(dim, ctx.h_mat, ctx.jump_ops, ctx.l_dag_l_sum)
             rho_vec = linalg.expm(liouvillian * remainder) @ rho_vec
         return rho_vec

--- a/src/mqt/yaqs/analog/lindblad.py
+++ b/src/mqt/yaqs/analog/lindblad.py
@@ -247,7 +247,11 @@ def _measure_rho(
 
 
 def _rho_vec_at_elapsed_time(ctx: LindbladContext) -> NDArray[np.complex128]:
-    """Evolve ``vec(rho)`` to ``sim_params.elapsed_time`` (not ``times[-1]``).
+    """Evolve ``vec(rho)`` to ``sim_params.elapsed_time``.
+
+    ``AnalogSimParams`` requires ``elapsed_time`` to be an integer multiple of ``dt``, so
+    this matches the fixed-``dt`` grid endpoint. A tiny remainder path is kept only as a
+    numerical guard.
 
     Args:
         ctx: Preprocessed Lindblad context.

--- a/src/mqt/yaqs/core/data_structures/noise_model.py
+++ b/src/mqt/yaqs/core/data_structures/noise_model.py
@@ -358,6 +358,54 @@ class NoiseModel:
         return proc
 
     @staticmethod
+    def _normalize_non_adjacent_two_site_process(
+        proc: dict[str, Any],
+        name: str,
+        *,
+        user_matrix: bool,
+        user_factors: object,
+        swapped: bool,
+    ) -> dict[str, Any]:
+        """Normalize a long-range two-site process onto per-site factors.
+
+        Args:
+            proc: Process dict being normalized (``sites`` already sorted).
+            name: Validated process name.
+            user_matrix: Whether the caller supplied a full ``matrix``.
+            user_factors: Caller-supplied ``factors``, or ``None`` if omitted.
+            swapped: Whether the original site order was descending.
+
+        Returns:
+            The updated process dict with ``factors`` set and ``matrix`` removed.
+
+        Raises:
+            ValueError: If a full matrix is supplied, factors are missing for a
+                non-crosstalk name, or supplied factors fail validation.
+        """
+        if user_matrix:
+            msg = "Non-adjacent two-site processes require 'factors' (a full 'matrix' embedding is not accepted here)."
+            raise ValueError(msg)
+
+        suffix = _crosstalk_suffix(name)
+        if user_factors is None:
+            if suffix is None:
+                msg = (
+                    "Non-adjacent 2-site processes must specify 'factors' unless named "
+                    "crosstalk_[xyz]{2} or longrange_crosstalk_[xyz]{2}."
+                )
+                raise ValueError(msg)
+            a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
+            proc["factors"] = (
+                np.array(PAULI_MAP[a], copy=True),
+                np.array(PAULI_MAP[b], copy=True),
+            )
+        else:
+            proc["factors"] = _factors_for_sorted_sites(user_factors, swapped=swapped)
+
+        proc.pop("matrix", None)
+        return proc
+
+    @staticmethod
     def _normalize_two_site_process(
         proc: dict[str, Any],
         sites: list[int],
@@ -377,53 +425,27 @@ class NoiseModel:
             raise ValueError(msg)
         proc["sites"] = sorted_sites
         i, j = sorted_sites
-        is_adjacent = abs(j - i) == 1
-        suffix = _crosstalk_suffix(name)
-
-        if is_adjacent:
-            if factors_provided:
-                msg = "Adjacent two-site processes use 'matrix', not 'factors'."
-                raise ValueError(msg)
-            if user_matrix:
-                proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
-            elif suffix is not None:
-                a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
-                proc["matrix"] = np.array(np.kron(PAULI_MAP[a], PAULI_MAP[b]), copy=True)
-            else:
-                proc["matrix"] = NoiseModel.get_operator(name)
-            proc.pop("factors", None)
-            return proc
-
-        # Non-adjacent: factors path
-        if user_matrix:
-            msg = "Non-adjacent two-site processes require 'factors' (a full 'matrix' embedding is not accepted here)."
-            raise ValueError(msg)
-        if suffix is not None:
-            if user_factors is None:
-                a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
-                proc["factors"] = (
-                    np.array(PAULI_MAP[a], copy=True),
-                    np.array(PAULI_MAP[b], copy=True),
-                )
-            else:
-                factors = _validate_factors(user_factors)
-                if swapped:
-                    factors = (factors[1], factors[0])
-                proc["factors"] = factors
-            proc.pop("matrix", None)
-            return proc
-
-        if user_factors is None:
-            msg = (
-                "Non-adjacent 2-site processes must specify 'factors' unless named "
-                "crosstalk_[xyz]{2} or longrange_crosstalk_[xyz]{2}."
+        if abs(j - i) != 1:
+            return NoiseModel._normalize_non_adjacent_two_site_process(
+                proc,
+                name,
+                user_matrix=user_matrix,
+                user_factors=user_factors,
+                swapped=swapped,
             )
+
+        if factors_provided:
+            msg = "Adjacent two-site processes use 'matrix', not 'factors'."
             raise ValueError(msg)
-        factors = _validate_factors(user_factors)
-        if swapped:
-            factors = (factors[1], factors[0])
-        proc["factors"] = factors
-        proc.pop("matrix", None)
+        suffix = _crosstalk_suffix(name)
+        if user_matrix:
+            proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
+        elif suffix is not None:
+            a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
+            proc["matrix"] = np.array(np.kron(PAULI_MAP[a], PAULI_MAP[b]), copy=True)
+        else:
+            proc["matrix"] = NoiseModel.get_operator(name)
+        proc.pop("factors", None)
         return proc
 
     @staticmethod
@@ -569,6 +591,26 @@ def _validate_factors(factors: object) -> tuple[NDArray[np.complex128], NDArray[
         raise ValueError(msg)
     left = _as_square_matrix(factors[0], "Process factor[0]")
     right = _as_square_matrix(factors[1], "Process factor[1]")
+    return left, right
+
+
+def _factors_for_sorted_sites(
+    factors: object,
+    *,
+    swapped: bool,
+) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
+    """Validate factors and reorder them to match ascending site indices.
+
+    Args:
+        factors: Caller-supplied pair of square factor matrices.
+        swapped: Whether the original site order was descending.
+
+    Returns:
+        Factor matrices ordered for the sorted ``sites`` list.
+    """
+    left, right = _validate_factors(factors)
+    if swapped:
+        return right, left
     return left, right
 
 

--- a/src/mqt/yaqs/core/data_structures/noise_model.py
+++ b/src/mqt/yaqs/core/data_structures/noise_model.py
@@ -85,6 +85,7 @@ _LIBRARY_CLASSES: dict[str, type] = {
 _CROSSTALK_RE = re.compile(r"^crosstalk_[xyz]{2}$")
 _LONGRANGE_CROSSTALK_RE = re.compile(r"^longrange_crosstalk_[xyz]{2}$")
 _SUPPORTED_DISTRIBUTIONS = frozenset({"normal", "lognormal", "truncated_normal"})
+_DISTRIBUTION_KEYS = frozenset({"distribution", "mean", "std"})
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +167,10 @@ def _validate_finite_real(value: object, label: str) -> float:
 def _validate_strength(strength: object) -> float | dict[str, Any]:
     if isinstance(strength, dict):
         strength_dict = cast("dict[str, Any]", strength)
+        unknown = set(strength_dict) - _DISTRIBUTION_KEYS
+        if unknown:
+            msg = f"Unknown distribution keys: {sorted(unknown)}. Supported keys: {sorted(_DISTRIBUTION_KEYS)}."
+            raise ValueError(msg)
         if "distribution" not in strength_dict:
             msg = "Noise strength dict must contain 'distribution' key."
             raise ValueError(msg)
@@ -184,7 +189,7 @@ def _validate_strength(strength: object) -> float | dict[str, Any]:
 
 def _as_square_matrix(value: object, label: str) -> NDArray[np.complex128]:
     try:
-        array = np.asarray(value, dtype=np.complex128)
+        array = np.array(value, dtype=np.complex128, copy=True)
     except (TypeError, ValueError) as exc:
         msg = f"{label} must be a numeric array."
         raise TypeError(msg) from exc
@@ -292,6 +297,9 @@ class NoiseModel:
                 raise ValueError(msg)
 
         jump_dict = dict(original)
+        if "factors" in jump_dict:
+            msg = "Scheduled jumps do not accept 'factors'; use 'matrix' for custom operators."
+            raise ValueError(msg)
         jump_dict["name"] = _validate_name(jump_dict["name"], "Scheduled jump")
         jump_dict["time"] = _validate_finite_real(jump_dict["time"], "Scheduled jump time")
         sites = _normalize_sites(jump_dict["sites"], "Scheduled jump")
@@ -332,7 +340,14 @@ class NoiseModel:
         sites_raw = proc["sites"]
         sites = _normalize_sites(sites_raw, "Process")
         user_matrix = "matrix" in source
+        factors_provided = "factors" in source
         user_factors = source.get("factors")
+        if factors_provided and user_factors is None:
+            msg = "Process 'factors' must be a sequence of exactly two square matrices, not None."
+            raise ValueError(msg)
+        if user_matrix and factors_provided:
+            msg = "Process cannot specify both 'matrix' and 'factors'."
+            raise ValueError(msg)
 
         if len(sites) == 2:
             sorted_sites = sorted(sites)
@@ -349,26 +364,21 @@ class NoiseModel:
             suffix = _crosstalk_suffix(name)
 
             if is_adjacent:
-                if user_factors is not None and not user_matrix:
+                if factors_provided:
                     msg = "Adjacent two-site processes use 'matrix', not 'factors'."
                     raise ValueError(msg)
-                if suffix is not None and name.startswith("longrange_"):
-                    # longrange_* on adjacent sites still builds a kron matrix.
-                    a, b = suffix[0], suffix[1]
-                    proc["matrix"] = np.kron(PAULI_MAP[a], PAULI_MAP[b])
-                    proc.pop("factors", None)
+                if user_matrix:
+                    proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
                 elif suffix is not None:
                     a, b = suffix[0], suffix[1]
-                    proc["matrix"] = np.kron(PAULI_MAP[a], PAULI_MAP[b])
-                    proc.pop("factors", None)
-                elif user_matrix:
-                    proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
+                    proc["matrix"] = np.array(np.kron(PAULI_MAP[a], PAULI_MAP[b]), copy=True)
                 else:
                     proc["matrix"] = NoiseModel.get_operator(name)
+                proc.pop("factors", None)
                 return proc
 
             # Non-adjacent: factors path
-            if user_matrix and user_factors is None:
+            if user_matrix:
                 msg = (
                     "Non-adjacent two-site processes require 'factors' "
                     "(a full 'matrix' embedding is not accepted here)."
@@ -377,7 +387,10 @@ class NoiseModel:
             if suffix is not None:
                 if user_factors is None:
                     a, b = suffix[0], suffix[1]
-                    proc["factors"] = (PAULI_MAP[a], PAULI_MAP[b])
+                    proc["factors"] = (
+                        np.array(PAULI_MAP[a], copy=True),
+                        np.array(PAULI_MAP[b], copy=True),
+                    )
                 else:
                     factors = _validate_factors(user_factors)
                     if swapped:
@@ -401,7 +414,7 @@ class NoiseModel:
 
         # One-site
         proc["sites"] = sites
-        if user_factors is not None:
+        if factors_provided:
             msg = "One-site processes do not accept 'factors'."
             raise ValueError(msg)
         if user_matrix:
@@ -494,16 +507,16 @@ class NoiseModel:
             ValueError: If ``name`` is not a supported operator name.
         """
         if name in PAULI_MAP:
-            return PAULI_MAP[name]
+            return np.array(PAULI_MAP[name], copy=True)
         suffix = _crosstalk_suffix(name)
         if suffix is not None:
-            return np.kron(PAULI_MAP[suffix[0]], PAULI_MAP[suffix[1]])
+            return np.array(np.kron(PAULI_MAP[suffix[0]], PAULI_MAP[suffix[1]]), copy=True)
         operator_class = _LIBRARY_CLASSES.get(name)
         if operator_class is None:
             msg = f"Unknown noise operator '{name}'. {_supported_operator_message()}"
             raise ValueError(msg)
         operator: BaseGate = operator_class()
-        return operator.matrix
+        return np.array(operator.matrix, dtype=np.complex128, copy=True)
 
 
 def _validate_factors(factors: object) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
@@ -527,11 +540,11 @@ def _matches_up_to_unit_phase(mat: NDArray[np.complex128], reference: NDArray[np
     ref_val = reference[idx]
     mat_val = mat[idx]
     if abs(ref_val) < 1e-14 or abs(mat_val) < 1e-14:
-        return bool(np.allclose(mat, reference, atol=1e-10))
+        return bool(np.allclose(mat, reference, atol=1e-10, rtol=0.0))
     phase = mat_val / ref_val
-    if not np.isclose(abs(phase), 1.0, atol=1e-10):
+    if not np.isclose(abs(phase), 1.0, atol=1e-10, rtol=0.0):
         return False
-    return bool(np.allclose(mat, phase * reference, atol=1e-10))
+    return bool(np.allclose(mat, phase * reference, atol=1e-10, rtol=0.0))
 
 
 def _is_unit_phase_pauli(mat: NDArray[np.complex128]) -> bool:
@@ -655,6 +668,13 @@ def validate_noise_model_for_run(
         raise ValueError(msg)
     if sim_params is None:
         msg = "AnalogSimParams are required to validate scheduled_jumps against the time grid."
+        raise ValueError(msg)
+    if sim_params.order != 1:
+        msg = (
+            "scheduled_jumps are only supported for AnalogSimParams(order=1); "
+            f"got order={sim_params.order}. Order-2 TJM applies deterministic jumps "
+            "inconsistently on the sampling versus trajectory MPS."
+        )
         raise ValueError(msg)
 
     times = np.asarray(sim_params.times, dtype=float)

--- a/src/mqt/yaqs/core/data_structures/noise_model.py
+++ b/src/mqt/yaqs/core/data_structures/noise_model.py
@@ -214,8 +214,14 @@ def _supported_operator_message() -> str:
     fixed = ", ".join(sorted(_FIXED_OPERATOR_NAMES))
     return (
         f"Supported fixed names: {fixed}. "
-        "Also accepted: names matching crosstalk_[xyz]{{2}} or longrange_crosstalk_[xyz]{{2}}."
+        "Also accepted: names matching crosstalk_[xyz]{2} or longrange_crosstalk_[xyz]{2}."
     )
+
+
+def _crosstalk_pauli_letters(suffix: str, *, swapped: bool) -> tuple[str, str]:
+    """Return Pauli letters for ascending sites, honoring caller site order when swapped."""
+    a, b = suffix[0], suffix[1]
+    return (b, a) if swapped else (a, b)
 
 
 class NoiseModel:
@@ -303,26 +309,122 @@ class NoiseModel:
         jump_dict["name"] = _validate_name(jump_dict["name"], "Scheduled jump")
         jump_dict["time"] = _validate_finite_real(jump_dict["time"], "Scheduled jump time")
         sites = _normalize_sites(jump_dict["sites"], "Scheduled jump")
+        user_matrix = "matrix" in jump_dict
         if len(sites) == 2:
             sorted_sites = sorted(sites)
+            swapped = sorted_sites != list(sites)
             if abs(sorted_sites[1] - sorted_sites[0]) != 1:
                 msg = (
                     f"Scheduled jump acts on non-adjacent sites {sites}. "
                     "Only nearest-neighbor scheduled jumps are supported."
                 )
                 raise ValueError(msg)
-            if sites != sorted_sites and "matrix" in jump_dict:
+            if swapped and user_matrix:
                 msg = f"Custom full scheduled-jump matrices require ascending site order; got sites {sites}."
                 raise ValueError(msg)
             jump_dict["sites"] = sorted_sites
         else:
+            swapped = False
             jump_dict["sites"] = sites
 
-        if "matrix" in jump_dict:
+        if user_matrix:
             jump_dict["matrix"] = _as_square_matrix(jump_dict["matrix"], "Scheduled jump matrix")
         else:
-            jump_dict["matrix"] = NoiseModel.get_operator(jump_dict["name"])
+            suffix = _crosstalk_suffix(jump_dict["name"])
+            if suffix is not None:
+                a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
+                jump_dict["matrix"] = np.array(np.kron(PAULI_MAP[a], PAULI_MAP[b]), copy=True)
+            else:
+                jump_dict["matrix"] = NoiseModel.get_operator(jump_dict["name"])
         return jump_dict
+
+    @staticmethod
+    def _normalize_one_site_process(
+        proc: dict[str, Any],
+        sites: list[int],
+        name: str,
+        *,
+        user_matrix: bool,
+        factors_provided: bool,
+    ) -> dict[str, Any]:
+        proc["sites"] = sites
+        if factors_provided:
+            msg = "One-site processes do not accept 'factors'."
+            raise ValueError(msg)
+        if user_matrix:
+            proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
+        else:
+            proc["matrix"] = NoiseModel.get_operator(name)
+        return proc
+
+    @staticmethod
+    def _normalize_two_site_process(
+        proc: dict[str, Any],
+        sites: list[int],
+        name: str,
+        *,
+        user_matrix: bool,
+        factors_provided: bool,
+        user_factors: object,
+    ) -> dict[str, Any]:
+        sorted_sites = sorted(sites)
+        swapped = sorted_sites != list(sites)
+        if swapped and user_matrix:
+            msg = (
+                "Custom full two-site matrices require ascending site order; "
+                f"got sites {list(sites)}. Use ascending sites or supply 'factors'."
+            )
+            raise ValueError(msg)
+        proc["sites"] = sorted_sites
+        i, j = sorted_sites
+        is_adjacent = abs(j - i) == 1
+        suffix = _crosstalk_suffix(name)
+
+        if is_adjacent:
+            if factors_provided:
+                msg = "Adjacent two-site processes use 'matrix', not 'factors'."
+                raise ValueError(msg)
+            if user_matrix:
+                proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
+            elif suffix is not None:
+                a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
+                proc["matrix"] = np.array(np.kron(PAULI_MAP[a], PAULI_MAP[b]), copy=True)
+            else:
+                proc["matrix"] = NoiseModel.get_operator(name)
+            proc.pop("factors", None)
+            return proc
+
+        # Non-adjacent: factors path
+        if user_matrix:
+            msg = "Non-adjacent two-site processes require 'factors' (a full 'matrix' embedding is not accepted here)."
+            raise ValueError(msg)
+        if suffix is not None:
+            if user_factors is None:
+                a, b = _crosstalk_pauli_letters(suffix, swapped=swapped)
+                proc["factors"] = (
+                    np.array(PAULI_MAP[a], copy=True),
+                    np.array(PAULI_MAP[b], copy=True),
+                )
+            else:
+                factors = _validate_factors(user_factors)
+                if swapped:
+                    factors = (factors[1], factors[0])
+                proc["factors"] = factors
+            proc.pop("matrix", None)
+            return proc
+
+        if user_factors is None:
+            msg = (
+                "Non-adjacent 2-site processes must specify 'factors' unless named "
+                "crosstalk_[xyz]{2} or longrange_crosstalk_[xyz]{2}."
+            )
+            raise ValueError(msg)
+        factors = _validate_factors(user_factors)
+        if swapped:
+            factors = (factors[1], factors[0])
+        proc["factors"] = factors
+        proc.pop("matrix", None)
+        return proc
 
     @staticmethod
     def _normalize_process(original: object) -> dict[str, Any]:
@@ -337,8 +439,7 @@ class NoiseModel:
         proc["name"] = name
         proc["strength"] = _validate_strength(proc["strength"])
 
-        sites_raw = proc["sites"]
-        sites = _normalize_sites(sites_raw, "Process")
+        sites = _normalize_sites(proc["sites"], "Process")
         user_matrix = "matrix" in source
         factors_provided = "factors" in source
         user_factors = source.get("factors")
@@ -350,78 +451,21 @@ class NoiseModel:
             raise ValueError(msg)
 
         if len(sites) == 2:
-            sorted_sites = sorted(sites)
-            swapped = sorted_sites != list(sites)
-            if swapped and user_matrix:
-                msg = (
-                    "Custom full two-site matrices require ascending site order; "
-                    f"got sites {list(sites)}. Use ascending sites or supply 'factors'."
-                )
-                raise ValueError(msg)
-            proc["sites"] = sorted_sites
-            i, j = sorted_sites
-            is_adjacent = abs(j - i) == 1
-            suffix = _crosstalk_suffix(name)
-
-            if is_adjacent:
-                if factors_provided:
-                    msg = "Adjacent two-site processes use 'matrix', not 'factors'."
-                    raise ValueError(msg)
-                if user_matrix:
-                    proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
-                elif suffix is not None:
-                    a, b = suffix[0], suffix[1]
-                    proc["matrix"] = np.array(np.kron(PAULI_MAP[a], PAULI_MAP[b]), copy=True)
-                else:
-                    proc["matrix"] = NoiseModel.get_operator(name)
-                proc.pop("factors", None)
-                return proc
-
-            # Non-adjacent: factors path
-            if user_matrix:
-                msg = (
-                    "Non-adjacent two-site processes require 'factors' "
-                    "(a full 'matrix' embedding is not accepted here)."
-                )
-                raise ValueError(msg)
-            if suffix is not None:
-                if user_factors is None:
-                    a, b = suffix[0], suffix[1]
-                    proc["factors"] = (
-                        np.array(PAULI_MAP[a], copy=True),
-                        np.array(PAULI_MAP[b], copy=True),
-                    )
-                else:
-                    factors = _validate_factors(user_factors)
-                    if swapped:
-                        factors = (factors[1], factors[0])
-                    proc["factors"] = factors
-                proc.pop("matrix", None)
-                return proc
-
-            if user_factors is None:
-                msg = (
-                    "Non-adjacent 2-site processes must specify 'factors' unless named "
-                    "crosstalk_[xyz]{2} or longrange_crosstalk_[xyz]{2}."
-                )
-                raise ValueError(msg)
-            factors = _validate_factors(user_factors)
-            if swapped:
-                factors = (factors[1], factors[0])
-            proc["factors"] = factors
-            proc.pop("matrix", None)
-            return proc
-
-        # One-site
-        proc["sites"] = sites
-        if factors_provided:
-            msg = "One-site processes do not accept 'factors'."
-            raise ValueError(msg)
-        if user_matrix:
-            proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
-        else:
-            proc["matrix"] = NoiseModel.get_operator(name)
-        return proc
+            return NoiseModel._normalize_two_site_process(
+                proc,
+                sites,
+                name,
+                user_matrix=user_matrix,
+                factors_provided=factors_provided,
+                user_factors=user_factors,
+            )
+        return NoiseModel._normalize_one_site_process(
+            proc,
+            sites,
+            name,
+            user_matrix=user_matrix,
+            factors_provided=factors_provided,
+        )
 
     def sample(self, rng: np.random.Generator | int | None = None) -> NoiseModel:
         """Sample a concrete NoiseModel from any distribution-based strengths.

--- a/src/mqt/yaqs/core/data_structures/noise_model.py
+++ b/src/mqt/yaqs/core/data_structures/noise_model.py
@@ -18,27 +18,199 @@ from __future__ import annotations
 import copy
 import logging
 import math
-from typing import TYPE_CHECKING, Any
+import re
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 from scipy.stats import truncnorm
 
 from ..libraries.noise_library import NoiseLibrary
+from .state_utils import resolve_physical_dimensions
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
+    from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams
     from mqt.yaqs.core.libraries.gate_library import BaseGate
 
 
-CROSSTALK_PREFIX = "longrange_crosstalk_"
 PAULI_MAP = {
     "x": NoiseLibrary.pauli_x().matrix,
     "y": NoiseLibrary.pauli_y().matrix,
     "z": NoiseLibrary.pauli_z().matrix,
 }
 
+# Literal fixed library names (no runtime reflection over NoiseLibrary attributes).
+_FIXED_OPERATOR_NAMES: frozenset[str] = frozenset({
+    "raising",
+    "lowering",
+    "pauli_x",
+    "pauli_y",
+    "pauli_z",
+    "raising_two",
+    "lowering_two",
+    "crosstalk_xx",
+    "crosstalk_yy",
+    "crosstalk_zz",
+    "crosstalk_xy",
+    "crosstalk_yx",
+    "crosstalk_zy",
+    "crosstalk_zx",
+    "crosstalk_yz",
+    "crosstalk_xz",
+    "x",
+    "y",
+    "z",
+})
+
+_LIBRARY_CLASSES: dict[str, type] = {
+    "raising": NoiseLibrary.raising,
+    "lowering": NoiseLibrary.lowering,
+    "pauli_x": NoiseLibrary.pauli_x,
+    "pauli_y": NoiseLibrary.pauli_y,
+    "pauli_z": NoiseLibrary.pauli_z,
+    "raising_two": NoiseLibrary.raising_two,
+    "lowering_two": NoiseLibrary.lowering_two,
+    "crosstalk_xx": NoiseLibrary.crosstalk_xx,
+    "crosstalk_yy": NoiseLibrary.crosstalk_yy,
+    "crosstalk_zz": NoiseLibrary.crosstalk_zz,
+    "crosstalk_xy": NoiseLibrary.crosstalk_xy,
+    "crosstalk_yx": NoiseLibrary.crosstalk_yx,
+    "crosstalk_zy": NoiseLibrary.crosstalk_zy,
+    "crosstalk_zx": NoiseLibrary.crosstalk_zx,
+    "crosstalk_yz": NoiseLibrary.crosstalk_yz,
+    "crosstalk_xz": NoiseLibrary.crosstalk_xz,
+}
+
+_CROSSTALK_RE = re.compile(r"^crosstalk_[xyz]{2}$")
+_LONGRANGE_CROSSTALK_RE = re.compile(r"^longrange_crosstalk_[xyz]{2}$")
+_SUPPORTED_DISTRIBUTIONS = frozenset({"normal", "lognormal", "truncated_normal"})
+
 logger = logging.getLogger(__name__)
+
+
+def _is_bool(value: object) -> bool:
+    return isinstance(value, bool)
+
+
+def _require_mapping(entry: object, kind: str) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        msg = f"Each {kind} must be a dictionary."
+        raise TypeError(msg)
+    return cast("dict[str, Any]", entry)
+
+
+def _validate_name(name: object, kind: str) -> str:
+    if not isinstance(name, str):
+        msg = f"{kind} 'name' must be a string."
+        raise TypeError(msg)
+    if not name:
+        msg = f"{kind} 'name' must be a nonempty string."
+        raise ValueError(msg)
+    return name
+
+
+def _normalize_sites(sites: object, kind: str) -> list[int]:
+    if not isinstance(sites, (list, tuple)):
+        msg = f"{kind} 'sites' must be a list or tuple of integers."
+        raise TypeError(msg)
+    if len(sites) not in {1, 2}:
+        msg = f"{kind} must have exactly 1 or 2 sites, got {len(sites)}."
+        raise ValueError(msg)
+    normalized: list[int] = []
+    for site in sites:
+        if _is_bool(site) or not isinstance(site, (int, np.integer)):
+            msg = f"{kind} site indices must be integers (booleans are not allowed)."
+            raise TypeError(msg)
+        site_int = int(site)
+        if site_int < 0:
+            msg = f"{kind} site indices must be nonnegative, got {site_int}."
+            raise ValueError(msg)
+        normalized.append(site_int)
+    if len(normalized) == 2 and normalized[0] == normalized[1]:
+        msg = f"{kind} two-site indices must be distinct, got {normalized}."
+        raise ValueError(msg)
+    return normalized
+
+
+def _validate_finite_nonnegative_real(value: object, label: str) -> float:
+    if _is_bool(value) or not isinstance(value, (int, float, np.floating, np.integer)):
+        msg = f"{label} must be a real number (booleans are not allowed)."
+        raise TypeError(msg)
+    number = float(value)
+    if not math.isfinite(number):
+        msg = f"{label} must be finite, got {number}."
+        raise ValueError(msg)
+    if number < 0:
+        msg = (
+            f"{label} must be nonnegative (got {number}). "
+            "Standard TJM/MCWF jump probabilities require nonnegative rates; "
+            "YAQS does not currently implement signed density-matrix generators "
+            "or non-Markovian reverse-jump unravelings."
+        )
+        raise ValueError(msg)
+    return number
+
+
+def _validate_finite_real(value: object, label: str) -> float:
+    if _is_bool(value) or not isinstance(value, (int, float, np.floating, np.integer)):
+        msg = f"{label} must be a real number (booleans are not allowed)."
+        raise TypeError(msg)
+    number = float(value)
+    if not math.isfinite(number):
+        msg = f"{label} must be finite, got {number}."
+        raise ValueError(msg)
+    return number
+
+
+def _validate_strength(strength: object) -> float | dict[str, Any]:
+    if isinstance(strength, dict):
+        strength_dict = cast("dict[str, Any]", strength)
+        if "distribution" not in strength_dict:
+            msg = "Noise strength dict must contain 'distribution' key."
+            raise ValueError(msg)
+        dist_type = strength_dict["distribution"]
+        if dist_type not in _SUPPORTED_DISTRIBUTIONS:
+            msg = f"Unsupported distribution type: {dist_type}. Supported: {sorted(_SUPPORTED_DISTRIBUTIONS)}."
+            raise ValueError(msg)
+        mean = _validate_finite_real(strength_dict.get("mean", 0.0), "distribution mean")
+        std = _validate_finite_real(strength_dict.get("std", 0.0), "distribution std")
+        if std < 0:
+            msg = f"distribution std must be nonnegative, got {std}."
+            raise ValueError(msg)
+        return {"distribution": dist_type, "mean": mean, "std": std}
+    return _validate_finite_nonnegative_real(strength, "process strength")
+
+
+def _as_square_matrix(value: object, label: str) -> NDArray[np.complex128]:
+    try:
+        array = np.asarray(value, dtype=np.complex128)
+    except (TypeError, ValueError) as exc:
+        msg = f"{label} must be a numeric array."
+        raise TypeError(msg) from exc
+    if array.ndim != 2 or array.shape[0] != array.shape[1]:
+        msg = f"{label} must be a square 2-D array, got shape {array.shape}."
+        raise ValueError(msg)
+    if not np.all(np.isfinite(array)):
+        msg = f"{label} entries must be finite."
+        raise ValueError(msg)
+    return array
+
+
+def _crosstalk_suffix(name: str) -> str | None:
+    if _CROSSTALK_RE.fullmatch(name):
+        return name.rsplit("_", 1)[-1]
+    if _LONGRANGE_CROSSTALK_RE.fullmatch(name):
+        return name.rsplit("_", 1)[-1]
+    return None
+
+
+def _supported_operator_message() -> str:
+    fixed = ", ".join(sorted(_FIXED_OPERATOR_NAMES))
+    return (
+        f"Supported fixed names: {fixed}. "
+        "Also accepted: names matching crosstalk_[xyz]{{2}} or longrange_crosstalk_[xyz]{{2}}."
+    )
 
 
 class NoiseModel:
@@ -50,13 +222,13 @@ class NoiseModel:
 
             - ``name``: process name or identifier.
             - ``sites``: indices of sites this process acts on.
-            - ``strength``: noise strength.
+            - ``strength``: noise strength (nonnegative Lindblad rate ``gamma``).
             - ``matrix``: matrix representing the operator on those sites (for
               1-site and adjacent 2-site processes).
             - ``factors``: tuple of two 1-site operator matrices (for long-range
               2-site processes).
         scheduled_jumps: A list of scheduled jump dictionaries applied at specific
-            times.
+            times (supported only for single-State analog MPS TJM).
     """
 
     def __init__(
@@ -71,125 +243,172 @@ class NoiseModel:
 
                 - ``matrix``: local jump operator L as a ``d x d`` array for
                   1-site or adjacent 2-site processes. When provided, YAQS uses
-                  this matrix and does not look up ``name`` in
-                  {class}`~mqt.yaqs.core.libraries.noise_library.NoiseLibrary`.
-                  When omitted, ``name`` must be a library entry (e.g.
-                  ``"lowering"``, ``"pauli_x"``, ``"crosstalk_xx"``).
+                  this matrix and does not look up ``name`` in the library.
+                  Custom full two-site matrices must use ascending site order.
                 - ``factors``: pair of 1-site matrices for non-adjacent 2-site
-                  processes (required unless ``name`` is a recognized long-range
-                  crosstalk label).
+                  processes (required unless ``name`` matches
+                  ``crosstalk_[xyz]{2}`` or ``longrange_crosstalk_[xyz]{2}``).
 
                 ``strength`` is the Lindblad rate ``gamma``; jump operators are
-                formed as ``sqrt(gamma) * L`` during simulation.
+                formed as ``sqrt(gamma) * L`` during simulation. Fixed strengths
+                must be finite and nonnegative.
             scheduled_jumps: A list of scheduled jumps to apply at specific times.
                 Each dict must contain ``time``, ``sites``, and ``name``. An
-                optional ``matrix`` overrides the library lookup for the jump
-                operator, same as for ``processes``.
+                optional ``matrix`` overrides the library lookup. Two-site
+                scheduled jumps must be nearest-neighbor.
+
+        Raises:
+            TypeError: If inputs have incorrect types (including booleans used
+                as sites, strengths, or times).
 
         Note:
-            Input validation is performed and assertion errors may be raised by
-            internal helpers if inputs are malformed.
+            Invalid values (for example negative strengths, bad site lists, or
+            unknown operator names) raise ``ValueError``.
         """
         self.processes: list[dict[str, Any]] = []
         self.scheduled_jumps: list[dict[str, Any]] = []
+
         if scheduled_jumps is not None:
+            if not isinstance(scheduled_jumps, (list, tuple)):
+                msg = "scheduled_jumps must be a list or tuple of dictionaries."
+                raise TypeError(msg)
             for jump in scheduled_jumps:
-                assert "time" in jump, "Each scheduled jump must have a 'time' key"
-                assert "sites" in jump, "Each scheduled jump must have a 'sites' key"
-                assert "name" in jump, "Each scheduled jump must have a 'name' key"
-                assert len(jump["sites"]) <= 2, "Each scheduled jump must have at most 2 sites"
-                jump_dict = dict(jump)  # Copy to avoid mutating caller's dict
-                if "matrix" not in jump_dict:
-                    jump_dict["matrix"] = NoiseModel.get_operator(jump_dict["name"])
-                self.scheduled_jumps.append(jump_dict)
+                self.scheduled_jumps.append(self._normalize_scheduled_jump(jump))
 
         if processes is None:
             return
+        if not isinstance(processes, (list, tuple)):
+            msg = "processes must be a list or tuple of dictionaries."
+            raise TypeError(msg)
 
-        filled_processes: list[dict[str, Any]] = []
-        for original in processes:
-            assert "name" in original, "Each process must have a 'name' key"
-            assert "sites" in original, "Each process must have a 'sites' key"
-            assert "strength" in original, "Each process must have a 'strength' key"
-            assert len(original["sites"]) <= 2, "Each noise process must have at most 2 sites"
+        self.processes = [self._normalize_process(original) for original in processes]
 
-            proc = dict(original)
-            name = proc["name"]
-            sites = proc["sites"]
-            user_factors = original.get("factors")
+    @staticmethod
+    def _normalize_scheduled_jump(jump: object) -> dict[str, Any]:
+        original = _require_mapping(jump, "scheduled jump")
+        for key in ("time", "sites", "name"):
+            if key not in original:
+                msg = f"Each scheduled jump must have a '{key}' key."
+                raise ValueError(msg)
 
-            # Normalize two-site ordering
-            if isinstance(sites, list) and len(sites) == 2:
-                sorted_sites = sorted(sites)
-                swapped = sorted_sites != sites
-                if swapped:
-                    proc["sites"] = sorted_sites
-                i, j = proc["sites"]
-                is_adjacent = abs(j - i) == 1
-
-                # Adjacent two-site: use full matrix
-                if is_adjacent:
-                    if str(name).startswith("crosstalk_"):
-                        # infer matrix from suffix ab
-                        suffix = str(name).rsplit("_", 1)[-1]
-                        assert len(suffix) == 2, "Invalid crosstalk label. Expected 'crosstalk_ab' with a,b in {x,y,z}."
-                        assert all(c in "xyz" for c in suffix), (
-                            "Invalid crosstalk label. Expected 'crosstalk_ab' with a,b in {x,y,z}."
-                        )
-                        a, b = suffix[0], suffix[1]
-                        proc["matrix"] = np.kron(PAULI_MAP[a], PAULI_MAP[b])
-                    elif "matrix" not in proc:
-                        proc["matrix"] = NoiseModel.get_operator(name)
-                    filled_processes.append(proc)
-                    continue
-
-                # Non-adjacent two-site: attach per-site factors for crosstalk labels
-                if str(name).startswith("crosstalk_"):
-                    if "factors" not in proc:
-                        suffix = str(name).rsplit("_", 1)[-1]
-                        assert len(suffix) == 2, "Invalid crosstalk label. Expected 'crosstalk_ab' with a,b in {x,y,z}."
-                        assert all(c in "xyz" for c in suffix), (
-                            "Invalid crosstalk label. Expected 'crosstalk_ab' with a,b in {x,y,z}."
-                        )
-                        a, b = suffix[0], suffix[1]
-                        proc["factors"] = (PAULI_MAP[a], PAULI_MAP[b])
-                    filled_processes.append(proc)
-                    if swapped and user_factors is not None:
-                        proc["factors"] = (proc["factors"][1], proc["factors"][0])
-                    continue
-
-                # Long-range two-site with canonical label
-                if str(name).startswith(CROSSTALK_PREFIX):
-                    if "factors" not in proc:
-                        suffix = str(name).rsplit("_", 1)[-1]
-                        assert len(suffix) == 2, (
-                            f"Invalid crosstalk label. Expected '{CROSSTALK_PREFIX}ab' with a,b in {{x,y,z}}."
-                        )
-                        assert all(c in "xyz" for c in suffix), (
-                            f"Invalid crosstalk label. Expected '{CROSSTALK_PREFIX}ab' with a,b in {{x,y,z}}."
-                        )
-                        a, b = suffix[0], suffix[1]
-                        proc["factors"] = (PAULI_MAP[a], PAULI_MAP[b])
-                    filled_processes.append(proc)
-                    if swapped and user_factors is not None:
-                        proc["factors"] = (proc["factors"][1], proc["factors"][0])
-                    continue
-
-                # Other long-range two-site: require explicit factors
-                assert "factors" in proc, (
-                    "Non-adjacent 2-site processes must specify 'factors' unless named 'crosstalk_{ab}'."
+        jump_dict = dict(original)
+        jump_dict["name"] = _validate_name(jump_dict["name"], "Scheduled jump")
+        jump_dict["time"] = _validate_finite_real(jump_dict["time"], "Scheduled jump time")
+        sites = _normalize_sites(jump_dict["sites"], "Scheduled jump")
+        if len(sites) == 2:
+            sorted_sites = sorted(sites)
+            if abs(sorted_sites[1] - sorted_sites[0]) != 1:
+                msg = (
+                    f"Scheduled jump acts on non-adjacent sites {sites}. "
+                    "Only nearest-neighbor scheduled jumps are supported."
                 )
-                filled_processes.append(proc)
-                if swapped and user_factors is not None:
-                    proc["factors"] = (proc["factors"][1], proc["factors"][0])
-                continue
+                raise ValueError(msg)
+            if sites != sorted_sites and "matrix" in jump_dict:
+                msg = f"Custom full scheduled-jump matrices require ascending site order; got sites {sites}."
+                raise ValueError(msg)
+            jump_dict["sites"] = sorted_sites
+        else:
+            jump_dict["sites"] = sites
 
-            # One-site: ensure matrix
-            if "matrix" not in proc:
-                proc["matrix"] = NoiseModel.get_operator(name)
-            filled_processes.append(proc)
+        if "matrix" in jump_dict:
+            jump_dict["matrix"] = _as_square_matrix(jump_dict["matrix"], "Scheduled jump matrix")
+        else:
+            jump_dict["matrix"] = NoiseModel.get_operator(jump_dict["name"])
+        return jump_dict
 
-        self.processes = filled_processes
+    @staticmethod
+    def _normalize_process(original: object) -> dict[str, Any]:
+        source = _require_mapping(original, "noise process")
+        for key in ("name", "sites", "strength"):
+            if key not in source:
+                msg = f"Each process must have a '{key}' key."
+                raise ValueError(msg)
+
+        proc = dict(source)
+        name = _validate_name(proc["name"], "Process")
+        proc["name"] = name
+        proc["strength"] = _validate_strength(proc["strength"])
+
+        sites_raw = proc["sites"]
+        sites = _normalize_sites(sites_raw, "Process")
+        user_matrix = "matrix" in source
+        user_factors = source.get("factors")
+
+        if len(sites) == 2:
+            sorted_sites = sorted(sites)
+            swapped = sorted_sites != list(sites)
+            if swapped and user_matrix:
+                msg = (
+                    "Custom full two-site matrices require ascending site order; "
+                    f"got sites {list(sites)}. Use ascending sites or supply 'factors'."
+                )
+                raise ValueError(msg)
+            proc["sites"] = sorted_sites
+            i, j = sorted_sites
+            is_adjacent = abs(j - i) == 1
+            suffix = _crosstalk_suffix(name)
+
+            if is_adjacent:
+                if user_factors is not None and not user_matrix:
+                    msg = "Adjacent two-site processes use 'matrix', not 'factors'."
+                    raise ValueError(msg)
+                if suffix is not None and name.startswith("longrange_"):
+                    # longrange_* on adjacent sites still builds a kron matrix.
+                    a, b = suffix[0], suffix[1]
+                    proc["matrix"] = np.kron(PAULI_MAP[a], PAULI_MAP[b])
+                    proc.pop("factors", None)
+                elif suffix is not None:
+                    a, b = suffix[0], suffix[1]
+                    proc["matrix"] = np.kron(PAULI_MAP[a], PAULI_MAP[b])
+                    proc.pop("factors", None)
+                elif user_matrix:
+                    proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
+                else:
+                    proc["matrix"] = NoiseModel.get_operator(name)
+                return proc
+
+            # Non-adjacent: factors path
+            if user_matrix and user_factors is None:
+                msg = (
+                    "Non-adjacent two-site processes require 'factors' "
+                    "(a full 'matrix' embedding is not accepted here)."
+                )
+                raise ValueError(msg)
+            if suffix is not None:
+                if user_factors is None:
+                    a, b = suffix[0], suffix[1]
+                    proc["factors"] = (PAULI_MAP[a], PAULI_MAP[b])
+                else:
+                    factors = _validate_factors(user_factors)
+                    if swapped:
+                        factors = (factors[1], factors[0])
+                    proc["factors"] = factors
+                proc.pop("matrix", None)
+                return proc
+
+            if user_factors is None:
+                msg = (
+                    "Non-adjacent 2-site processes must specify 'factors' unless named "
+                    "crosstalk_[xyz]{2} or longrange_crosstalk_[xyz]{2}."
+                )
+                raise ValueError(msg)
+            factors = _validate_factors(user_factors)
+            if swapped:
+                factors = (factors[1], factors[0])
+            proc["factors"] = factors
+            proc.pop("matrix", None)
+            return proc
+
+        # One-site
+        proc["sites"] = sites
+        if user_factors is not None:
+            msg = "One-site processes do not accept 'factors'."
+            raise ValueError(msg)
+        if user_matrix:
+            proc["matrix"] = _as_square_matrix(proc["matrix"], "Process matrix")
+        else:
+            proc["matrix"] = NoiseModel.get_operator(name)
+        return proc
 
     def sample(self, rng: np.random.Generator | int | None = None) -> NoiseModel:
         """Sample a concrete NoiseModel from any distribution-based strengths.
@@ -198,6 +417,9 @@ class NoiseModel:
 
         - If ``strength`` is a float, it is kept as is.
         - If ``strength`` is a dict describing a distribution, a value is sampled.
+
+        Negative draws from ``normal`` are clamped to ``0.0`` with a warning.
+        Sampled strengths are re-validated before the resolved model is returned.
 
         Args:
             rng: The random number generator or seed to use for sampling.
@@ -209,7 +431,8 @@ class NoiseModel:
             static disorder used for a simulation run.
 
         Raises:
-            ValueError: If an unsupported distribution type is provided.
+            ValueError: If an unsupported distribution type is provided or a
+                sampled strength is invalid.
         """
         generator = np.random.default_rng(rng)
         new_processes: list[dict[str, Any]] = []
@@ -218,15 +441,12 @@ class NoiseModel:
             strength_val = proc["strength"]
 
             if isinstance(strength_val, dict):
-                if "distribution" not in strength_val:
-                    msg = "Noise strength dict must contain 'distribution' key."
-                    raise ValueError(msg)
                 dist_type = strength_val["distribution"]
-                mean = strength_val.get("mean", 0.0)
-                std = strength_val.get("std", 0.0)
+                mean = strength_val["mean"]
+                std = strength_val["std"]
 
                 if dist_type == "normal":
-                    sampled_val = generator.normal(loc=mean, scale=std)
+                    sampled_val = float(generator.normal(loc=mean, scale=std))
                     if sampled_val < 0:
                         logger.warning(
                             "Sampled noise strength %f using 'normal' distribution (mean=%f, std=%f) "
@@ -235,32 +455,25 @@ class NoiseModel:
                             mean,
                             std,
                         )
-                    new_proc["strength"] = float(max(0.0, sampled_val))
+                    sampled_val = float(max(0.0, sampled_val))
                 elif dist_type == "lognormal":
-                    # For lognormal, mean/std refer to the underlying normal distribution parameters
-                    sampled_val = generator.lognormal(mean=mean, sigma=std)
-                    new_proc["strength"] = float(sampled_val)
+                    sampled_val = float(generator.lognormal(mean=mean, sigma=std))
                 elif dist_type == "truncated_normal":
                     if math.isclose(std, 0.0, abs_tol=1e-8):
-                        new_proc["strength"] = float(max(0.0, mean))
+                        sampled_val = float(max(0.0, mean))
                     else:
-                        # Truncate at 0 (a=0) and +inf (b=inf)
-                        a, b = 0.0, np.inf
-                        a_norm = (a - mean) / std
-                        b_norm = (b - mean) / std
-                        sampled_val = truncnorm.rvs(a_norm, b_norm, loc=mean, scale=std, random_state=generator)
-                        new_proc["strength"] = float(sampled_val)
+                        a_norm = (0.0 - mean) / std
+                        b_norm = (np.inf - mean) / std
+                        sampled_val = float(truncnorm.rvs(a_norm, b_norm, loc=mean, scale=std, random_state=generator))
                 else:
-                    # Fallback or error for unknown distributions
                     msg = f"Unsupported distribution type: {dist_type}"
                     raise ValueError(msg)
+                new_proc["strength"] = _validate_finite_nonnegative_real(sampled_val, "sampled process strength")
             else:
-                # Assume it's already a float/int
-                new_proc["strength"] = float(strength_val)
+                new_proc["strength"] = _validate_finite_nonnegative_real(strength_val, "process strength")
 
             new_processes.append(new_proc)
 
-        # Create new instance without re-validation
         new_model = object.__new__(NoiseModel)
         new_model.processes = new_processes
         new_model.scheduled_jumps = copy.deepcopy(self.scheduled_jumps)
@@ -268,17 +481,187 @@ class NoiseModel:
 
     @staticmethod
     def get_operator(name: str) -> NDArray[np.complex128]:
-        """Retrieve the operator from NoiseLibrary, possibly as a tensor product if needed.
+        """Retrieve the operator matrix for a supported library name.
 
         Args:
-            name: Name of the noise process (e.g., 'xx', 'zz').
+            name: Name of the noise process (fixed library name, short Pauli
+                ``x``/``y``/``z``, or an exact ``crosstalk_[xyz]{2}`` label).
 
         Returns:
             The matrix representation of the operator.
+
+        Raises:
+            ValueError: If ``name`` is not a supported operator name.
         """
         if name in PAULI_MAP:
             return PAULI_MAP[name]
-        operator_class = getattr(NoiseLibrary, name)
-
+        suffix = _crosstalk_suffix(name)
+        if suffix is not None:
+            return np.kron(PAULI_MAP[suffix[0]], PAULI_MAP[suffix[1]])
+        operator_class = _LIBRARY_CLASSES.get(name)
+        if operator_class is None:
+            msg = f"Unknown noise operator '{name}'. {_supported_operator_message()}"
+            raise ValueError(msg)
         operator: BaseGate = operator_class()
         return operator.matrix
+
+
+def _validate_factors(factors: object) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
+    if not isinstance(factors, (list, tuple)) or len(factors) != 2:
+        msg = "Process 'factors' must be a sequence of exactly two square matrices."
+        raise ValueError(msg)
+    left = _as_square_matrix(factors[0], "Process factor[0]")
+    right = _as_square_matrix(factors[1], "Process factor[1]")
+    return left, right
+
+
+_PAULI_1 = (PAULI_MAP["x"], PAULI_MAP["y"], PAULI_MAP["z"])
+_PAULI_2 = tuple(np.kron(a, b) for a in _PAULI_1 for b in _PAULI_1)
+
+
+def _matches_up_to_unit_phase(mat: NDArray[np.complex128], reference: NDArray[np.complex128]) -> bool:
+    """Return True if ``mat`` equals ``exp(i φ) * reference`` for real φ (not a scale)."""
+    if mat.shape != reference.shape:
+        return False
+    idx = np.unravel_index(int(np.argmax(np.abs(reference))), reference.shape)
+    ref_val = reference[idx]
+    mat_val = mat[idx]
+    if abs(ref_val) < 1e-14 or abs(mat_val) < 1e-14:
+        return bool(np.allclose(mat, reference, atol=1e-10))
+    phase = mat_val / ref_val
+    if not np.isclose(abs(phase), 1.0, atol=1e-10):
+        return False
+    return bool(np.allclose(mat, phase * reference, atol=1e-10))
+
+
+def _is_unit_phase_pauli(mat: NDArray[np.complex128]) -> bool:
+    return any(_matches_up_to_unit_phase(mat, p) for p in _PAULI_1)
+
+
+def _is_unit_phase_pauli_kron(mat: NDArray[np.complex128]) -> bool:
+    return any(_matches_up_to_unit_phase(mat, p) for p in _PAULI_2)
+
+
+def is_pauli(proc: dict[str, Any]) -> bool:
+    """Return True if the process operators match Pauli structure (unit-modulus phase only).
+
+    Recognizes one-site X/Y/Z, adjacent Kronecker products of Paulis, and long-range
+    factor pairs that are each Pauli. Scaled operators such as ``2 * X`` are not Pauli
+    for TJM's scalar dissipator shortcut, which assumes ``L^† L = I``.
+    """
+    sites = proc["sites"]
+    if len(sites) == 1:
+        if "matrix" not in proc:
+            return False
+        return _is_unit_phase_pauli(np.asarray(proc["matrix"], dtype=np.complex128))
+    if len(sites) != 2:
+        return False
+    if abs(sites[1] - sites[0]) == 1 and "matrix" in proc:
+        return _is_unit_phase_pauli_kron(np.asarray(proc["matrix"], dtype=np.complex128))
+    if abs(sites[1] - sites[0]) > 1 and "factors" in proc:
+        f0, f1 = proc["factors"]
+        return _is_unit_phase_pauli(np.asarray(f0, dtype=np.complex128)) and _is_unit_phase_pauli(
+            np.asarray(f1, dtype=np.complex128)
+        )
+    return False
+
+
+def validate_noise_model_for_run(
+    noise_model: NoiseModel,
+    *,
+    length: int,
+    physical_dimensions: list[int] | int | None = None,
+    representation: str | None = None,
+    is_digital: bool = False,
+    is_ensemble: bool = False,
+    sim_params: AnalogSimParams | None = None,
+) -> None:
+    """Validate a sampled noise model against run context.
+
+    Args:
+        noise_model: Noise model after :meth:`NoiseModel.sample`.
+        length: Number of sites / qubits.
+        physical_dimensions: Per-site Hilbert-space dimensions.
+        representation: Active state representation for analog runs.
+        is_digital: Whether this is a circuit / digital TJM run.
+        is_ensemble: Whether this is the ``list[State]`` unitary ensemble path.
+        sim_params: Analog simulation parameters (required for scheduled-jump
+            grid checks on the supported MPS path).
+
+    Raises:
+        ValueError: If the model is incompatible with the run context.
+    """
+    dims = resolve_physical_dimensions(length, physical_dimensions)
+
+    def _check_sites(sites: list[int], kind: str) -> None:
+        for site in sites:
+            if site >= length:
+                msg = f"{kind} site index {site} is out of range for length {length}."
+                raise ValueError(msg)
+
+    def _check_operator_dims(entry: dict[str, Any], kind: str) -> None:
+        sites = entry["sites"]
+        _check_sites(sites, kind)
+        if "matrix" in entry:
+            mat = np.asarray(entry["matrix"])
+            expected = dims[sites[0]] if len(sites) == 1 else dims[sites[0]] * dims[sites[1]]
+            if mat.shape != (expected, expected):
+                msg = (
+                    f"{kind} matrix shape {mat.shape} does not match expected "
+                    f"({expected}, {expected}) for sites {sites}."
+                )
+                raise ValueError(msg)
+        if "factors" in entry:
+            factors = entry["factors"]
+            for site, factor in zip(sites, factors, strict=True):
+                expected = dims[site]
+                arr = np.asarray(factor)
+                if arr.shape != (expected, expected):
+                    msg = f"{kind} factor on site {site} has shape {arr.shape}, expected ({expected}, {expected})."
+                    raise ValueError(msg)
+
+    for proc in noise_model.processes:
+        _check_operator_dims(proc, "Process")
+        if is_digital and len(proc["sites"]) == 2 and abs(proc["sites"][1] - proc["sites"][0]) != 1:
+            msg = (
+                "Digital TJM does not support non-adjacent / factorized two-site noise "
+                f"(process '{proc['name']}' on sites {proc['sites']}). "
+                "Gate-local digital noise scoping remains nearest-neighbor only."
+            )
+            raise ValueError(msg)
+        if (
+            representation == "mps"
+            and not is_digital
+            and not is_ensemble
+            and len(proc["sites"]) == 2
+            and abs(proc["sites"][1] - proc["sites"][0]) > 1
+            and not is_pauli(proc)
+        ):
+            msg = (
+                "Analog MPS TJM does not support non-Pauli long-range noise "
+                f"(process '{proc['name']}' on sites {proc['sites']})."
+            )
+            raise ValueError(msg)
+
+    if not noise_model.scheduled_jumps:
+        return
+
+    supported = representation == "mps" and not is_digital and not is_ensemble
+    if not supported:
+        msg = (
+            "scheduled_jumps are only supported for single-State analog MPS TJM; "
+            "they are not supported for MCWF, Lindblad, digital, or list[State] ensemble runs."
+        )
+        raise ValueError(msg)
+    if sim_params is None:
+        msg = "AnalogSimParams are required to validate scheduled_jumps against the time grid."
+        raise ValueError(msg)
+
+    times = np.asarray(sim_params.times, dtype=float)
+    atol = sim_params.dt * 1e-3
+    for jump in noise_model.scheduled_jumps:
+        _check_operator_dims(jump, "Scheduled jump")
+        jump_time = float(jump["time"])
+        if not np.any(np.isclose(times, jump_time, atol=atol, rtol=0.0)):
+            msg = f"Scheduled jump time {jump_time} is not on the simulation time grid (atol={atol}, rtol=0)."
+            raise ValueError(msg)

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -96,8 +96,8 @@ def _validate_analog_time_grid(elapsed_time: float, dt: float) -> int:
     """Validate analog time parameters and return the integer number of steps.
 
     Backends evolve every interval with the full ``dt``, so ``elapsed_time`` must be an
-    integer multiple of ``dt`` within a small fraction of one timestep. Relabeling the
-    final timestamp without a fractional step would otherwise disagree with the evolution.
+    integer multiple of ``dt`` within a scale-aware tolerance. Relabeling the final
+    timestamp without a fractional step would otherwise disagree with the evolution.
 
     Args:
         elapsed_time: Total simulation time (must be finite and ``>= 0``).
@@ -152,7 +152,10 @@ def _validate_analog_time_grid(elapsed_time: float, dt: float) -> int:
 
     evolved_time = n_steps * dt_f
     residual = abs(elapsed_f - evolved_time)
-    if n_steps <= 0 or residual > 1e-9 * dt_f:
+    # Scale with max(elapsed, dt): residuals from long fine grids sit near ulp(elapsed),
+    # which can exceed a fixed fraction of a tiny dt alone.
+    tol = max(1e-12, 1e-9 * max(elapsed_f, dt_f))
+    if n_steps <= 0 or residual > tol:
         msg = (
             f"elapsed_time ({elapsed_f}) must be an integer multiple of dt ({dt_f}); "
             f"got elapsed_time/dt = {n_float} (nearest integer {n_steps}, time residual {residual})."

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -146,7 +146,9 @@ def _validate_analog_time_grid(elapsed_time: float, dt: float) -> int:
         raise ValueError(msg)
 
     n_steps = round(n_float)
-    if n_steps > np.iinfo(np.intp).max - 1:
+    # Bound by a float64 times-grid allocation: nbytes must fit in a platform size index.
+    max_steps = np.iinfo(np.intp).max // np.dtype(np.float64).itemsize - 1
+    if n_steps > max_steps:
         msg = f"elapsed_time / dt yields too many time steps ({n_steps})."
         raise ValueError(msg)
 

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -183,9 +183,12 @@ def _validate_analog_time_grid(
 
     evolved_time = n_steps * dt_f
     residual = abs(elapsed_f - evolved_time)
-    rounding_tolerance = 0.5 * (elapsed_ulp + n_steps * dt_ulp + math.ulp(evolved_time))
-    precision_is_ambiguous = rounding_tolerance >= 0.5 * dt_f and residual > 0.0
-    if n_steps <= 0 or precision_is_ambiguous or residual > rounding_tolerance:
+    ulp_tolerance = 0.5 * (elapsed_ulp + n_steps * dt_ulp + math.ulp(evolved_time))
+    # An ULP can be a material fraction of a subnormal ``dt``. Never let the
+    # representation allowance exceed a tiny, dimensionless fraction of one step.
+    step_fraction_tolerance = 1e-9 * dt_f
+    rounding_tolerance = min(ulp_tolerance, step_fraction_tolerance)
+    if n_steps <= 0 or residual > rounding_tolerance:
         msg = (
             f"elapsed_time ({elapsed_f}) must be an integer multiple of dt ({dt_f}); "
             f"got elapsed_time/dt = {n_float} (nearest integer {n_steps}, time residual {residual})."

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -18,6 +18,7 @@ dimension limits, and thresholds. Simulation outputs are stored on
 from __future__ import annotations
 
 import copy
+import math
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
@@ -26,6 +27,8 @@ import numpy as np
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from numpy.typing import ArrayLike
 
 SimulationPreset = Literal["fast", "balanced", "accurate", "exact"]
@@ -90,6 +93,105 @@ def _validate_random_seed(random_seed: int | None) -> None:
     if random_seed < 0:
         msg = f"random_seed must be non-negative, got {random_seed}."
         raise ValueError(msg)
+
+
+def _validate_analog_time_grid(
+    elapsed_time: float | np.floating[Any] | np.integer[Any],
+    dt: float | np.floating[Any] | np.integer[Any],
+) -> int:
+    """Validate analog time parameters and return the integer number of steps.
+
+    Backends evolve every interval with the full ``dt``, so ``elapsed_time`` must be an
+    integer multiple of ``dt`` (within a precision-aware tolerance on their dimensionless
+    ratio). Relabeling the final timestamp without a fractional step would otherwise
+    disagree with the evolution.
+
+    Args:
+        elapsed_time: Total simulation time (must be finite and ``>= 0``).
+        dt: Fixed time step (must be finite and ``> 0``).
+
+    Returns:
+        Non-negative integer step count ``n`` such that ``times = dt * arange(n + 1)``.
+
+    Raises:
+        TypeError: If ``elapsed_time`` or ``dt`` is a bool or non-numeric.
+        ValueError: If values are non-finite, ``dt <= 0``, ``elapsed_time < 0``, or
+            ``elapsed_time`` is not an integer multiple of ``dt``.
+    """
+    if isinstance(elapsed_time, bool) or not isinstance(elapsed_time, (int, float, np.floating, np.integer)):
+        msg = f"elapsed_time must be a real number, got {type(elapsed_time).__name__}."
+        raise TypeError(msg)
+    if isinstance(dt, bool) or not isinstance(dt, (int, float, np.floating, np.integer)):
+        msg = f"dt must be a real number, got {type(dt).__name__}."
+        raise TypeError(msg)
+
+    try:
+        elapsed_f = float(elapsed_time)
+        dt_f = float(dt)
+    except OverflowError as exc:
+        msg = "elapsed_time and dt must be representable as finite floats."
+        raise ValueError(msg) from exc
+
+    for name, value, value_f in (("elapsed_time", elapsed_time, elapsed_f), ("dt", dt, dt_f)):
+        if isinstance(value, (int, np.integer)) and int(value_f) != int(value):
+            msg = f"{name} must be exactly representable as a float, got {value!r}."
+            raise ValueError(msg)
+    if not np.isfinite(elapsed_f):
+        msg = f"elapsed_time must be finite, got {elapsed_time!r}."
+        raise ValueError(msg)
+    if not np.isfinite(dt_f):
+        msg = f"dt must be finite, got {dt!r}."
+        raise ValueError(msg)
+    if dt_f <= 0.0:
+        msg = f"dt must be positive, got {dt_f}."
+        raise ValueError(msg)
+    if elapsed_f < 0.0:
+        msg = f"elapsed_time must be non-negative, got {elapsed_f}."
+        raise ValueError(msg)
+    if not elapsed_f > 0.0:
+        return 0
+
+    if isinstance(elapsed_time, (int, np.integer)) and isinstance(dt, (int, np.integer)):
+        n_steps, remainder = divmod(int(elapsed_time), int(dt))
+        if remainder != 0:
+            msg = (
+                f"elapsed_time ({elapsed_f}) must be an integer multiple of dt ({dt_f}); "
+                f"got integer remainder {remainder}."
+            )
+            raise ValueError(msg)
+        if n_steps > np.iinfo(np.intp).max - 1:
+            msg = f"elapsed_time / dt yields too many time steps ({n_steps})."
+            raise ValueError(msg)
+        return n_steps
+
+    n_float = elapsed_f / dt_f
+    if not np.isfinite(n_float):
+        msg = f"elapsed_time / dt must be finite, got {n_float}."
+        raise ValueError(msg)
+
+    n_steps = round(n_float)
+    if n_steps > np.iinfo(np.intp).max - 1:
+        msg = f"elapsed_time / dt yields too many time steps ({n_steps})."
+        raise ValueError(msg)
+
+    # Bound only float64 representation dust from the two stored values and the
+    # ``n_steps * dt`` multiplication. Lower-precision NumPy inputs are converted to
+    # their exact float64 values; accepting additional source-dtype uncertainty would
+    # let the reported endpoint differ materially from the duration evolved by backends.
+    elapsed_ulp = 0.0 if isinstance(elapsed_time, (int, np.integer)) else math.ulp(elapsed_f)
+    dt_ulp = 0.0 if isinstance(dt, (int, np.integer)) else math.ulp(dt_f)
+
+    evolved_time = n_steps * dt_f
+    residual = abs(elapsed_f - evolved_time)
+    rounding_tolerance = 0.5 * (elapsed_ulp + n_steps * dt_ulp + math.ulp(evolved_time))
+    precision_is_ambiguous = rounding_tolerance >= 0.5 * dt_f and residual > 0.0
+    if n_steps <= 0 or precision_is_ambiguous or residual > rounding_tolerance:
+        msg = (
+            f"elapsed_time ({elapsed_f}) must be an integer multiple of dt ({dt_f}); "
+            f"got elapsed_time/dt = {n_float} (nearest integer {n_steps}, time residual {residual})."
+        )
+        raise ValueError(msg)
+    return n_steps
 
 
 def _validate_gate_mode(mode: GateMode) -> GateMode:
@@ -350,9 +452,9 @@ class AnalogSimParams(_ObservableOrderingMixin):
             from the current :attr:`observables` list).
         observable_sorted_indices: Maps each user-list index to the corresponding row in
             sorted worker buffers (computed from the current :attr:`observables` list).
-        elapsed_time: Total simulation time.
-        dt: Simulation time step.
-        times: Array of sampled times from ``0`` to ``elapsed_time`` with spacing ``dt``.
+        elapsed_time: Total simulation time (finite, ``>= 0``); must be an integer multiple of ``dt``.
+        dt: Fixed simulation time step (finite, ``> 0``).
+        times: Array of sampled times ``dt * arange(n + 1)`` from ``0`` to ``elapsed_time`` inclusive.
         sample_timesteps: If ``True``, record values at all sampled timesteps.
         num_traj: Number of trajectories (for stochastic open-system evolution).
         random_seed: If set, seeds per-trajectory jump RNG and static noise sampling for reproducible runs.
@@ -383,8 +485,8 @@ class AnalogSimParams(_ObservableOrderingMixin):
     def __init__(
         self,
         observables: list[Observable] | None = None,
-        elapsed_time: float = 0.1,
-        dt: float = 0.1,
+        elapsed_time: float | np.floating[Any] | np.integer[Any] = 0.1,
+        dt: float | np.floating[Any] | np.integer[Any] = 0.1,
         num_traj: int | None = None,
         max_bond_dim: int | object | None = _USE_PRESET,
         trunc_mode: str = "discarded_weight",
@@ -407,8 +509,9 @@ class AnalogSimParams(_ObservableOrderingMixin):
 
         Args:
             observables: List of observables to measure during the simulation.
-            elapsed_time: Total simulation time.
-            dt: Time step interval.
+            elapsed_time: Total simulation time (finite, ``>= 0``). Must be an integer
+                multiple of ``dt`` because backends evolve with fixed ``dt``.
+            dt: Fixed time step interval (finite, ``> 0``).
             num_traj: Number of simulation samples.
             random_seed: If set, makes stochastic trajectories and noise-model sampling reproducible.
             max_bond_dim: Maximum bond dimension allowed, or ``None`` for no cap. Omit to use
@@ -444,9 +547,15 @@ class AnalogSimParams(_ObservableOrderingMixin):
         )
         self.observables = obs_list
 
-        self.elapsed_time = elapsed_time
-        self.dt = dt
-        self.times = np.arange(0, elapsed_time + dt, dt)
+        n_steps = _validate_analog_time_grid(elapsed_time, dt)
+        self.elapsed_time = float(elapsed_time)
+        self.dt = float(dt)
+        # Fixed-dt grid: backends evolve ``n_steps`` intervals of ``dt``. Pin the final
+        # stamp to ``elapsed_time`` only after the integer-multiple check (avoids float dust
+        # such as ``0.1 * 3 != 0.3`` without mislabeling non-integral durations).
+        self.times = self.dt * np.arange(n_steps + 1, dtype=np.float64)
+        if n_steps > 0:
+            self.times[-1] = self.elapsed_time
         self.sample_timesteps = sample_timesteps
         self.num_traj = num_traj if num_traj is not None else preset_values["num_traj"]
         self.max_bond_dim = _resolve_max_bond_dim(max_bond_dim, preset_values["max_bond_dim"])

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -18,7 +18,6 @@ dimension limits, and thresholds. Simulation outputs are stored on
 from __future__ import annotations
 
 import copy
-import math
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
@@ -27,8 +26,6 @@ import numpy as np
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from numpy.typing import ArrayLike
 
 SimulationPreset = Literal["fast", "balanced", "accurate", "exact"]
@@ -95,16 +92,12 @@ def _validate_random_seed(random_seed: int | None) -> None:
         raise ValueError(msg)
 
 
-def _validate_analog_time_grid(
-    elapsed_time: float | np.floating[Any] | np.integer[Any],
-    dt: float | np.floating[Any] | np.integer[Any],
-) -> int:
+def _validate_analog_time_grid(elapsed_time: float, dt: float) -> int:
     """Validate analog time parameters and return the integer number of steps.
 
     Backends evolve every interval with the full ``dt``, so ``elapsed_time`` must be an
-    integer multiple of ``dt`` (within a precision-aware tolerance on their dimensionless
-    ratio). Relabeling the final timestamp without a fractional step would otherwise
-    disagree with the evolution.
+    integer multiple of ``dt`` within a small fraction of one timestep. Relabeling the
+    final timestamp without a fractional step would otherwise disagree with the evolution.
 
     Args:
         elapsed_time: Total simulation time (must be finite and ``>= 0``).
@@ -132,10 +125,6 @@ def _validate_analog_time_grid(
         msg = "elapsed_time and dt must be representable as finite floats."
         raise ValueError(msg) from exc
 
-    for name, value, value_f in (("elapsed_time", elapsed_time, elapsed_f), ("dt", dt, dt_f)):
-        if isinstance(value, (int, np.integer)) and int(value_f) != int(value):
-            msg = f"{name} must be exactly representable as a float, got {value!r}."
-            raise ValueError(msg)
     if not np.isfinite(elapsed_f):
         msg = f"elapsed_time must be finite, got {elapsed_time!r}."
         raise ValueError(msg)
@@ -151,19 +140,6 @@ def _validate_analog_time_grid(
     if not elapsed_f > 0.0:
         return 0
 
-    if isinstance(elapsed_time, (int, np.integer)) and isinstance(dt, (int, np.integer)):
-        n_steps, remainder = divmod(int(elapsed_time), int(dt))
-        if remainder != 0:
-            msg = (
-                f"elapsed_time ({elapsed_f}) must be an integer multiple of dt ({dt_f}); "
-                f"got integer remainder {remainder}."
-            )
-            raise ValueError(msg)
-        if n_steps > np.iinfo(np.intp).max - 1:
-            msg = f"elapsed_time / dt yields too many time steps ({n_steps})."
-            raise ValueError(msg)
-        return n_steps
-
     n_float = elapsed_f / dt_f
     if not np.isfinite(n_float):
         msg = f"elapsed_time / dt must be finite, got {n_float}."
@@ -174,21 +150,9 @@ def _validate_analog_time_grid(
         msg = f"elapsed_time / dt yields too many time steps ({n_steps})."
         raise ValueError(msg)
 
-    # Bound only float64 representation dust from the two stored values and the
-    # ``n_steps * dt`` multiplication. Lower-precision NumPy inputs are converted to
-    # their exact float64 values; accepting additional source-dtype uncertainty would
-    # let the reported endpoint differ materially from the duration evolved by backends.
-    elapsed_ulp = 0.0 if isinstance(elapsed_time, (int, np.integer)) else math.ulp(elapsed_f)
-    dt_ulp = 0.0 if isinstance(dt, (int, np.integer)) else math.ulp(dt_f)
-
     evolved_time = n_steps * dt_f
     residual = abs(elapsed_f - evolved_time)
-    ulp_tolerance = 0.5 * (elapsed_ulp + n_steps * dt_ulp + math.ulp(evolved_time))
-    # An ULP can be a material fraction of a subnormal ``dt``. Never let the
-    # representation allowance exceed a tiny, dimensionless fraction of one step.
-    step_fraction_tolerance = 1e-9 * dt_f
-    rounding_tolerance = min(ulp_tolerance, step_fraction_tolerance)
-    if n_steps <= 0 or residual > rounding_tolerance:
+    if n_steps <= 0 or residual > 1e-9 * dt_f:
         msg = (
             f"elapsed_time ({elapsed_f}) must be an integer multiple of dt ({dt_f}); "
             f"got elapsed_time/dt = {n_float} (nearest integer {n_steps}, time residual {residual})."
@@ -488,8 +452,8 @@ class AnalogSimParams(_ObservableOrderingMixin):
     def __init__(
         self,
         observables: list[Observable] | None = None,
-        elapsed_time: float | np.floating[Any] | np.integer[Any] = 0.1,
-        dt: float | np.floating[Any] | np.integer[Any] = 0.1,
+        elapsed_time: float = 0.1,
+        dt: float = 0.1,
         num_traj: int | None = None,
         max_bond_dim: int | object | None = _USE_PRESET,
         trunc_mode: str = "discarded_weight",

--- a/src/mqt/yaqs/core/methods/dissipation.py
+++ b/src/mqt/yaqs/core/methods/dissipation.py
@@ -93,46 +93,61 @@ def apply_dissipation(
         state.set_canonical_form(state.length - 1, decomposition="SVD")
 
     for i in reversed(range(state.length)):
-        # 1. Apply all 1-site dissipators on site i
-        for process in noise_model.processes:
-            if len(process["sites"]) == 1 and process["sites"][0] == i:
+        # 1. One-site dissipators on site i: expm(-0.5 dt * sum_k gamma_k L_k^dagger L_k)
+        one_site = [
+            process for process in noise_model.processes if len(process["sites"]) == 1 and process["sites"][0] == i
+        ]
+        if one_site:
+            dim = state.physical_dimensions[i]
+            generator = np.zeros((dim, dim), dtype=np.complex128)
+            for process in one_site:
                 gamma = process["strength"]
                 if is_pauli(process):
-                    dissipative_factor = np.exp(-0.5 * dt * gamma)
-                    state.tensors[i] *= dissipative_factor
+                    generator += gamma * np.eye(dim, dtype=np.complex128)
                 else:
                     jump_op_mat = process["matrix"]
-                    mat = np.conj(jump_op_mat).T @ jump_op_mat
-                    dissipative_op = linalg.expm(-0.5 * dt * gamma * mat)
-                    state.tensors[i] = oe.contract("ab, bcd->acd", dissipative_op, state.tensors[i])
+                    generator += gamma * (np.conj(jump_op_mat).T @ jump_op_mat)
+            if all(is_pauli(process) for process in one_site):
+                state.tensors[i] *= np.exp(-0.5 * dt * float(np.real(generator[0, 0])))
+            else:
+                dissipative_op = linalg.expm(-0.5 * dt * generator)
+                state.tensors[i] = oe.contract("ab, bcd->acd", dissipative_op, state.tensors[i])
 
         processes_here = [
             process for process in noise_model.processes if len(process["sites"]) == 2 and process["sites"][1] == i
         ]
-        # 2. Apply all 2-site dissipators acting on sites (i-1, i)
-        if i != 0:
-            for process in processes_here:
-                gamma = process["strength"]
-                if is_pauli(process):
-                    dissipative_factor = np.exp(-0.5 * dt * gamma)
-                    state.tensors[i] *= dissipative_factor
+        # 2. Two-site dissipators on (i-1, i): sum generators, one expm (Pauli long-range: scalar)
+        if i != 0 and processes_here:
+            longrange_procs = [process for process in processes_here if is_longrange(process)]
+            adjacent_procs = [process for process in processes_here if not is_longrange(process)]
 
-                elif is_longrange(process):
+            for process in longrange_procs:
+                if not is_pauli(process):
                     msg = "Non-Pauli Long-range processes are not implemented yet"
                     raise NotImplementedError(msg)
-                else:
-                    jump_op_mat = process["matrix"]
-                    mat = np.conj(jump_op_mat).T @ jump_op_mat
-                    dissipative_op = linalg.expm(-0.5 * dt * gamma * mat)
+                state.tensors[i] *= np.exp(-0.5 * dt * process["strength"])
 
+            if adjacent_procs:
+                dim_left = state.physical_dimensions[i - 1]
+                dim_right = state.physical_dimensions[i]
+                dim = dim_left * dim_right
+                generator = np.zeros((dim, dim), dtype=np.complex128)
+                for process in adjacent_procs:
+                    gamma = process["strength"]
+                    if is_pauli(process):
+                        generator += gamma * np.eye(dim, dtype=np.complex128)
+                    else:
+                        jump_op_mat = process["matrix"]
+                        generator += gamma * (np.conj(jump_op_mat).T @ jump_op_mat)
+                if all(is_pauli(process) for process in adjacent_procs):
+                    state.tensors[i] *= np.exp(-0.5 * dt * float(np.real(generator[0, 0])))
+                else:
+                    dissipative_op = linalg.expm(-0.5 * dt * generator)
                     merged_tensor = merge_two_site(state.tensors[i - 1], state.tensors[i])
                     merged_tensor = oe.contract("ab, bcd->acd", dissipative_op, merged_tensor)
-
-                    # singular values always contracted right
-                    # since ortho center is shifted to the left after loop
                     tensor_left, tensor_right = split_two_site(
                         merged_tensor,
-                        [state.physical_dimensions[i - 1], state.physical_dimensions[i]],
+                        [dim_left, dim_right],
                         svd_distribution="right",
                         trunc_mode=cast("TruncMode", sim_params.trunc_mode),
                         threshold=sim_params.svd_threshold,

--- a/src/mqt/yaqs/core/methods/dissipation.py
+++ b/src/mqt/yaqs/core/methods/dissipation.py
@@ -21,6 +21,7 @@ import numpy as np
 import opt_einsum as oe
 
 from .. import linalg
+from ..data_structures.noise_model import is_pauli
 from ..methods.decompositions import merge_two_site, split_two_site
 
 if TYPE_CHECKING:
@@ -28,6 +29,8 @@ if TYPE_CHECKING:
     from ..data_structures.noise_model import NoiseModel
     from ..data_structures.simulation_parameters import AnalogSimParams, DigitalSimParams
     from ..methods.decompositions import TruncMode
+
+__all__ = ["apply_dissipation", "is_adjacent", "is_longrange", "is_pauli"]
 
 
 def is_adjacent(proc: dict[str, Any]) -> bool:
@@ -43,27 +46,6 @@ def is_longrange(proc: dict[str, Any]) -> bool:
     """Return True if the two-site process is long-range (non-neighbor)."""
     s = proc["sites"]
     return bool(abs(s[1] - s[0]) > 1)
-
-
-def is_pauli(proc: dict[str, Any]) -> bool:
-    """Return True if the process is a Pauli process."""
-    return bool(
-        proc["name"]
-        in {
-            "pauli_x",
-            "pauli_y",
-            "pauli_z",
-            "crosstalk_xx",
-            "crosstalk_yy",
-            "crosstalk_zz",
-            "crosstalk_xy",
-            "crosstalk_yx",
-            "crosstalk_zy",
-            "crosstalk_zx",
-            "crosstalk_yz",
-            "crosstalk_xz",
-        }
-    )
 
 
 def apply_dissipation(

--- a/src/mqt/yaqs/core/methods/dissipation.py
+++ b/src/mqt/yaqs/core/methods/dissipation.py
@@ -92,54 +92,69 @@ def apply_dissipation(
     else:
         state.set_canonical_form(state.length - 1, decomposition="SVD")
 
+    # Index processes once; cache Pauli flags for reuse in the site sweep.
+    one_site_by_site: list[list[int]] = [[] for _ in range(state.length)]
+    two_site_by_right: list[list[int]] = [[] for _ in range(state.length)]
+    processes = noise_model.processes
+    pauli_flags = [is_pauli(process) for process in processes]
+    for idx, process in enumerate(processes):
+        sites = process["sites"]
+        if len(sites) == 1:
+            one_site_by_site[sites[0]].append(idx)
+        elif len(sites) == 2:
+            two_site_by_right[sites[1]].append(idx)
+
     for i in reversed(range(state.length)):
         # 1. One-site dissipators on site i: expm(-0.5 dt * sum_k gamma_k L_k^dagger L_k)
-        one_site = [
-            process for process in noise_model.processes if len(process["sites"]) == 1 and process["sites"][0] == i
-        ]
-        if one_site:
+        one_idxs = one_site_by_site[i]
+        if one_idxs:
             dim = state.physical_dimensions[i]
             generator = np.zeros((dim, dim), dtype=np.complex128)
-            for process in one_site:
+            all_pauli = True
+            for idx in one_idxs:
+                process = processes[idx]
                 gamma = process["strength"]
-                if is_pauli(process):
+                if pauli_flags[idx]:
                     generator += gamma * np.eye(dim, dtype=np.complex128)
                 else:
+                    all_pauli = False
                     jump_op_mat = process["matrix"]
                     generator += gamma * (np.conj(jump_op_mat).T @ jump_op_mat)
-            if all(is_pauli(process) for process in one_site):
+            if all_pauli:
                 state.tensors[i] *= np.exp(-0.5 * dt * float(np.real(generator[0, 0])))
             else:
                 dissipative_op = linalg.expm(-0.5 * dt * generator)
                 state.tensors[i] = oe.contract("ab, bcd->acd", dissipative_op, state.tensors[i])
 
-        processes_here = [
-            process for process in noise_model.processes if len(process["sites"]) == 2 and process["sites"][1] == i
-        ]
-        # 2. Two-site dissipators on (i-1, i): sum generators, one expm (Pauli long-range: scalar)
-        if i != 0 and processes_here:
-            longrange_procs = [process for process in processes_here if is_longrange(process)]
-            adjacent_procs = [process for process in processes_here if not is_longrange(process)]
+        # 2. Two-site dissipators ending at i: sum generators, one expm (Pauli long-range: scalar)
+        two_idxs = two_site_by_right[i]
+        if i != 0 and two_idxs:
+            longrange_idxs = [idx for idx in two_idxs if is_longrange(processes[idx])]
+            adjacent_idxs = [idx for idx in two_idxs if not is_longrange(processes[idx])]
 
-            for process in longrange_procs:
-                if not is_pauli(process):
+            for idx in longrange_idxs:
+                process = processes[idx]
+                if not pauli_flags[idx]:
                     msg = "Non-Pauli Long-range processes are not implemented yet"
                     raise NotImplementedError(msg)
                 state.tensors[i] *= np.exp(-0.5 * dt * process["strength"])
 
-            if adjacent_procs:
+            if adjacent_idxs:
                 dim_left = state.physical_dimensions[i - 1]
                 dim_right = state.physical_dimensions[i]
                 dim = dim_left * dim_right
                 generator = np.zeros((dim, dim), dtype=np.complex128)
-                for process in adjacent_procs:
+                all_pauli = True
+                for idx in adjacent_idxs:
+                    process = processes[idx]
                     gamma = process["strength"]
-                    if is_pauli(process):
+                    if pauli_flags[idx]:
                         generator += gamma * np.eye(dim, dtype=np.complex128)
                     else:
+                        all_pauli = False
                         jump_op_mat = process["matrix"]
                         generator += gamma * (np.conj(jump_op_mat).T @ jump_op_mat)
-                if all(is_pauli(process) for process in adjacent_procs):
+                if all_pauli:
                     state.tensors[i] *= np.exp(-0.5 * dt * float(np.real(generator[0, 0])))
                 else:
                     dissipative_op = linalg.expm(-0.5 * dt * generator)

--- a/src/mqt/yaqs/core/methods/scheduled_jumps.py
+++ b/src/mqt/yaqs/core/methods/scheduled_jumps.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
     from ..methods.decompositions import TruncMode
 
 
+def _scheduled_jump_matches_time(jump_time: float, time: float, dt: float) -> bool:
+    """Return True if ``jump_time`` matches ``time`` within ``atol=dt * 1e-3``."""
+    return bool(np.isclose(jump_time, time, atol=dt * 1e-3, rtol=0.0))
+
+
 def has_scheduled_jump(noise_model: NoiseModel | None, time: float, dt: float) -> bool:
     """Check if there is a scheduled jump at the given time.
 
@@ -41,7 +46,7 @@ def has_scheduled_jump(noise_model: NoiseModel | None, time: float, dt: float) -
     if noise_model is None or not noise_model.scheduled_jumps:
         return False
 
-    return any(np.isclose(jump["time"], time, atol=dt * 1e-3, rtol=0.0) for jump in noise_model.scheduled_jumps)
+    return any(_scheduled_jump_matches_time(jump["time"], time, dt) for jump in noise_model.scheduled_jumps)
 
 
 def apply_scheduled_jumps(
@@ -62,14 +67,15 @@ def apply_scheduled_jumps(
         The updated Matrix Product State (MPS).
 
     Raises:
-        ValueError: If a two-site jump acts on non-adjacent sites.
+        ValueError: If a two-site jump acts on non-adjacent sites, or if a matched
+            jump produces a zero or non-finite squared norm.
     """
     if noise_model is None or not noise_model.scheduled_jumps:
         return state
 
     applied = False
     for jump in noise_model.scheduled_jumps:
-        if np.isclose(jump["time"], time, atol=sim_params.dt * 1e-3, rtol=0.0):
+        if _scheduled_jump_matches_time(jump["time"], time, sim_params.dt):
             applied = True
             sites = jump["sites"]
             jump_op = jump["matrix"]
@@ -103,11 +109,11 @@ def apply_scheduled_jumps(
     if not applied:
         return state
 
-    post_norm = float(state.norm())
-    if not np.isfinite(post_norm) or post_norm <= 0.0:
+    post_squared_norm = float(state.norm())
+    if not np.isfinite(post_squared_norm) or post_squared_norm <= 0.0:
         msg = (
-            "Scheduled jump produced a zero or non-finite state norm "
-            f"(norm={post_norm}). The jump operator annihilates the current state."
+            "Scheduled jump produced a zero or non-finite squared norm "
+            f"(squared_norm={post_squared_norm}). The jump operator annihilates the current state."
         )
         raise ValueError(msg)
     state.normalize("B")

--- a/src/mqt/yaqs/core/methods/scheduled_jumps.py
+++ b/src/mqt/yaqs/core/methods/scheduled_jumps.py
@@ -41,7 +41,7 @@ def has_scheduled_jump(noise_model: NoiseModel | None, time: float, dt: float) -
     if noise_model is None or not noise_model.scheduled_jumps:
         return False
 
-    return any(np.isclose(jump["time"], time, atol=dt * 1e-3) for jump in noise_model.scheduled_jumps)
+    return any(np.isclose(jump["time"], time, atol=dt * 1e-3, rtol=0.0) for jump in noise_model.scheduled_jumps)
 
 
 def apply_scheduled_jumps(
@@ -67,8 +67,10 @@ def apply_scheduled_jumps(
     if noise_model is None or not noise_model.scheduled_jumps:
         return state
 
+    applied = False
     for jump in noise_model.scheduled_jumps:
-        if np.isclose(jump["time"], time, atol=sim_params.dt * 1e-3):
+        if np.isclose(jump["time"], time, atol=sim_params.dt * 1e-3, rtol=0.0):
+            applied = True
             sites = jump["sites"]
             jump_op = jump["matrix"]
 
@@ -98,5 +100,15 @@ def apply_scheduled_jumps(
                 state.tensors[i], state.tensors[j] = tensor_left_new, tensor_right_new
                 state.update_center_after_split(i, j, "right")
 
+    if not applied:
+        return state
+
+    post_norm = float(state.norm())
+    if not np.isfinite(post_norm) or post_norm <= 0.0:
+        msg = (
+            "Scheduled jump produced a zero or non-finite state norm "
+            f"(norm={post_norm}). The jump operator annihilates the current state."
+        )
+        raise ValueError(msg)
     state.normalize("B")
     return state

--- a/src/mqt/yaqs/core/methods/stochastic_process.py
+++ b/src/mqt/yaqs/core/methods/stochastic_process.py
@@ -89,6 +89,9 @@ def create_probability_distribution(
         A tuple ``(ordered_processes, probabilities)`` where ``ordered_processes`` are
         the applicable jump processes in site-sweep order and ``probabilities`` are
         the corresponding normalized jump probabilities.
+
+    Raises:
+        ValueError: If a non-Pauli long-range two-site process is present.
     """
     if noise_model is None or not noise_model.processes:
         return [], []
@@ -149,6 +152,12 @@ def create_probability_distribution(
                         dp_m = dt * gamma * jumped_state.norm(site)
                         ordered_processes.append(process)
                         dp_m_list.append(float(dp_m.real))
+                    else:
+                        msg = (
+                            "Non-Pauli long-range two-site jumps are not supported "
+                            f"(process '{process['name']}' on sites {process['sites']})."
+                        )
+                        raise ValueError(msg)
 
     # Normalize the probabilities
     dp: float = float(np.sum(dp_m_list))

--- a/src/mqt/yaqs/core/methods/stochastic_process.py
+++ b/src/mqt/yaqs/core/methods/stochastic_process.py
@@ -51,6 +51,39 @@ def calculate_stochastic_factor(state: MPS) -> NDArray[np.float64]:
     return np.asarray(1 - state.norm(0), dtype=np.float64)
 
 
+def _adjacent_jump_weight(
+    state: MPS,
+    site: int,
+    jump_op: NDArray[np.complex128],
+    sim_params: AnalogSimParams | DigitalSimParams,
+) -> float:
+    """Return ``||L|psi>||^2`` for an adjacent two-site jump without truncating.
+
+    When the MPS is mixed-canonical at ``site``, the Frobenius weight of the
+    untruncated post-jump block equals the global squared norm. With unknown gauge,
+    an untruncated split is written and the global norm is used. Truncation for
+    bond-dimension control belongs in the jump-application path, not PDF weights.
+    """
+    merged = merge_two_site(state.tensors[site], state.tensors[site + 1])
+    merged = oe.contract("ab, bcd->acd", jump_op, merged)
+    if state.orthogonality_center is not None:
+        return float(np.vdot(merged, merged).real)
+
+    jumped_state = copy.deepcopy(state)
+    tensor_left_new, tensor_right_new = split_two_site(
+        merged,
+        [state.physical_dimensions[site], state.physical_dimensions[site + 1]],
+        svd_distribution="right",
+        trunc_mode=cast("TruncMode", sim_params.trunc_mode),
+        threshold=0.0,
+        max_bond_dim=None,
+    )
+    jumped_state.tensors[site] = tensor_left_new
+    jumped_state.tensors[site + 1] = tensor_right_new
+    jumped_state.set_center(None)
+    return float(jumped_state.norm())
+
+
 def create_probability_distribution(
     state: MPS,
     noise_model: NoiseModel | None,
@@ -68,8 +101,9 @@ def create_probability_distribution(
       probability (proportional to the time step, jump strength, and post-jump
       norm at that site), and records the operator and site.
     - For each 2-site jump operator acting on the current site and its right
-      neighbor, it merges the two tensors, applies the operator, splits the
-      result, computes the probability, and records the operator and the site
+      neighbor, it merges the two tensors, applies the operator, and computes
+      the probability from the untruncated post-jump block (truncation is
+      deferred until a channel is selected), then records the operator and site
       pair.
 
     After all possible jumps are considered, the per-process probabilities are
@@ -130,26 +164,8 @@ def create_probability_distribution(
 
                     elif process["sites"][1] == site + 1:
                         gamma = process["strength"]
-                        jump_op = process["matrix"]
-                        jumped_state = copy.deepcopy(state)
-                        # merge the tensors at site and site+1
-                        tensor_left = jumped_state.tensors[site]
-                        tensor_right = jumped_state.tensors[site + 1]
-                        merged = merge_two_site(tensor_left, tensor_right)
-                        # apply the 2-site jump operator
-                        merged = oe.contract("ab, bcd->acd", jump_op, merged)
-                        # split the tensor (always contract singular values right for probabilities)
-                        tensor_left_new, tensor_right_new = split_two_site(
-                            merged,
-                            [state.physical_dimensions[site], state.physical_dimensions[site + 1]],
-                            svd_distribution="right",
-                            trunc_mode=cast("TruncMode", sim_params.trunc_mode),
-                            threshold=sim_params.svd_threshold,
-                            max_bond_dim=sim_params.max_bond_dim,
-                        )
-                        jumped_state.tensors[site], jumped_state.tensors[site + 1] = tensor_left_new, tensor_right_new
-                        # compute the norm at `site` from the updated post-jump tensors
-                        dp_m = dt * gamma * jumped_state.norm(site)
+                        weight = _adjacent_jump_weight(state, site, process["matrix"], sim_params)
+                        dp_m = dt * gamma * weight
                         ordered_processes.append(process)
                         dp_m_list.append(float(dp_m.real))
                     else:
@@ -161,6 +177,13 @@ def create_probability_distribution(
 
     # Normalize the probabilities
     dp: float = float(np.sum(dp_m_list))
+    if not np.isfinite(dp) or dp <= 0.0:
+        msg = (
+            "Jump probability weights are zero or non-finite. "
+            "Reduce process strengths and/or the timestep dt so that "
+            "dt * strength * ||L|psi>||^2 remains representable."
+        )
+        raise ValueError(msg)
     return ordered_processes, [val / dp for val in dp_m_list]
 
 

--- a/src/mqt/yaqs/core/methods/stochastic_process.py
+++ b/src/mqt/yaqs/core/methods/stochastic_process.py
@@ -125,7 +125,8 @@ def create_probability_distribution(
         the corresponding normalized jump probabilities.
 
     Raises:
-        ValueError: If a non-Pauli long-range two-site process is present.
+        NotImplementedError: If a non-Pauli long-range two-site process is present.
+        ValueError: If jump probability weights are zero or non-finite.
     """
     if noise_model is None or not noise_model.processes:
         return [], []
@@ -173,7 +174,7 @@ def create_probability_distribution(
                             "Non-Pauli long-range two-site jumps are not supported "
                             f"(process '{process['name']}' on sites {process['sites']})."
                         )
-                        raise ValueError(msg)
+                        raise NotImplementedError(msg)
 
     # Normalize the probabilities
     dp: float = float(np.sum(dp_m_list))

--- a/src/mqt/yaqs/core/random_utils.py
+++ b/src/mqt/yaqs/core/random_utils.py
@@ -11,13 +11,19 @@ from __future__ import annotations
 
 import numpy as np
 
+# Distinct stream tags so (base_seed, traj_idx) coordinates never collapse via addition.
+_STREAM_TRAJECTORY = 0x5452414A  # "TRAJ"
+_STREAM_SAMPLE = 0x53414D50  # "SAMP"
+_STREAM_DISORDER = 0x4449534F  # "DISO"
+
 
 def make_trajectory_rng(traj_idx: int, *, base_seed: int | None) -> np.random.Generator:
     """Create a NumPy RNG for one stochastic trajectory.
 
-    When ``base_seed`` is set, each trajectory index gets a distinct but reproducible stream
-    via ``default_rng(base_seed + traj_idx)``. When ``base_seed`` is ``None``, returns an
-    unseeded generator (non-deterministic across runs).
+    When ``base_seed`` is set, each ``(base_seed, traj_idx)`` pair gets a distinct
+    reproducible stream via ``SeedSequence`` coordinates (not ``base_seed + traj_idx``,
+    which would alias ``(0, 1)`` with ``(1, 0)``). When ``base_seed`` is ``None``,
+    returns an unseeded generator (non-deterministic across runs).
 
     Args:
         traj_idx: Trajectory index (0-based), typically the worker job id.
@@ -28,4 +34,46 @@ def make_trajectory_rng(traj_idx: int, *, base_seed: int | None) -> np.random.Ge
     """
     if base_seed is None:
         return np.random.default_rng()
-    return np.random.default_rng(base_seed + traj_idx)
+    return np.random.default_rng(np.random.SeedSequence([base_seed, traj_idx, _STREAM_TRAJECTORY]))
+
+
+def make_sample_rng(traj_idx: int, *, base_seed: int | None, timestep: int) -> np.random.Generator:
+    """Create an RNG for one TJM-2 measurement copy at a given timestep.
+
+    Intermediate ``sample()`` calls evolve a deep copy of the sampling MPS. Their jump
+    draws must not advance the generator used for ``initialize`` / ``step_through``, and
+    each measurement timestep must get its own stream so enabling ``sample_timesteps``
+    does not change the final measurement draw relative to final-only mode.
+
+    When ``base_seed`` is set, the stream is derived from separate ``SeedSequence``
+    coordinates ``(base_seed, traj_idx, timestep, sample-tag)``. When ``base_seed`` is
+    ``None``, returns an unseeded generator.
+
+    Args:
+        traj_idx: Trajectory index (0-based), typically the worker job id.
+        base_seed: Optional run-level seed from simulation parameters.
+        timestep: Index into ``sim_params.times`` for this measurement copy.
+
+    Returns:
+        A NumPy random generator for jump decisions on that measurement copy only.
+    """
+    if base_seed is None:
+        return np.random.default_rng()
+    return np.random.default_rng(np.random.SeedSequence([base_seed, traj_idx, timestep, _STREAM_SAMPLE]))
+
+
+def make_disorder_rng(*, base_seed: int | None) -> np.random.Generator:
+    """Create an RNG for static noise-model disorder sampling.
+
+    Uses a stream tag distinct from trajectory and measurement RNGs so disorder
+    sampling does not collide with jump streams for the same ``base_seed``.
+
+    Args:
+        base_seed: Optional run-level seed from simulation parameters.
+
+    Returns:
+        A NumPy random generator for ``NoiseModel.sample``.
+    """
+    if base_seed is None:
+        return np.random.default_rng()
+    return np.random.default_rng(np.random.SeedSequence([base_seed, _STREAM_DISORDER]))

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -99,6 +99,7 @@ from .analog.ensemble import ensemble_member_worker
 from .analog.lindblad import lindblad_evolve, preprocess_lindblad
 from .analog.mcwf import mcwf, preprocess_mcwf
 from .core.data_structures.hamiltonian import Hamiltonian
+from .core.data_structures.noise_model import validate_noise_model_for_run
 from .core.data_structures.result import (
     Result,
     aggregate_counts,
@@ -673,6 +674,15 @@ class Simulator:
             for spec in initial_state_list:
                 spec.ensure_encoded("mps")
                 _validate_state_hamiltonian_pairing(spec, operator)
+            if noise_model is not None:
+                validate_noise_model_for_run(
+                    noise_model,
+                    length=operator.length,
+                    physical_dimensions=(initial_state_list[0].physical_dimensions if initial_state_list else None),
+                    representation="mps",
+                    is_ensemble=True,
+                    sim_params=sim_params,
+                )
             self._run_ensemble(
                 [spec.mps for spec in initial_state_list],
                 operator.mpo,
@@ -686,6 +696,14 @@ class Simulator:
         mps = _materialized_mps(initial_state)
         state_rep = initial_state.representation
         _validate_state_hamiltonian_pairing(initial_state, operator)
+        if noise_model is not None:
+            validate_noise_model_for_run(
+                noise_model,
+                length=initial_state.length,
+                physical_dimensions=initial_state.physical_dimensions,
+                representation=state_rep,
+                sim_params=sim_params,
+            )
         mpo_op, h_sparse = _prepare_hamiltonian_for_run(operator, state_rep)
 
         backend: Callable[..., tuple[NDArray[np.float64], Any, Any]]
@@ -1012,6 +1030,15 @@ class Simulator:
         if mps.length != operator.num_qubits:
             msg = "State and circuit qubit counts do not match."
             raise ValueError(msg)
+
+        if noise_model is not None:
+            validate_noise_model_for_run(
+                noise_model,
+                length=mps.length,
+                physical_dimensions=mps.physical_dimensions,
+                representation="mps",
+                is_digital=True,
+            )
 
         self._run_digital_sim(mps, operator, sim_params, noise_model, result)
 

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -124,6 +124,7 @@ from .core.parallel_utils import (
     merge_execution_config,
     run_backend_parallel,
 )
+from .core.random_utils import make_disorder_rng
 from .digital.digital_tjm import digital_tjm
 from .digital.utils.qasm_utils import load_circuit
 
@@ -596,7 +597,7 @@ class Simulator:
 
         if noise_model is not None:
             sample_seed = getattr(sim_params, "random_seed", None)
-            noise_model = noise_model.sample(rng=sample_seed)
+            noise_model = noise_model.sample(rng=make_disorder_rng(base_seed=sample_seed))
 
         result = Result(sim_params=sim_params, noise_model=noise_model)
 

--- a/tests/analog/test_lindblad.py
+++ b/tests/analog/test_lindblad.py
@@ -83,8 +83,8 @@ def test_lindblad_unitary_rabi() -> None:
     # MPO.ising returns H = -J ZZ - g X.
     # We want H = +1.0 * X. So set g = -1.0.
 
-    t_max = 2.0 * np.pi
     dt = 0.05
+    t_max = round(2.0 * np.pi / dt) * dt
     obs = Observable("z", sites=[0])
 
     sim_params = AnalogSimParams(observables=[obs], elapsed_time=t_max, dt=dt)
@@ -464,8 +464,8 @@ def test_rho_vec_at_elapsed_time_returns_initial_state_at_zero() -> None:
     np.testing.assert_allclose(rho_vec, ctx.rho_initial)
 
 
-def test_rho_vec_at_elapsed_time_fractional_step() -> None:
-    """Fractional elapsed times use an extra ``expm(L * remainder)`` after full ``dt`` steps."""
+def test_rho_vec_at_elapsed_time_matches_fixed_dt_grid() -> None:
+    """``_rho_vec_at_elapsed_time`` matches amplitude damping at an integral ``elapsed_time``."""
     n_sites = 1
     initial_state = State(n_sites, initial="ones", representation="density_matrix")
     h = MPO.identity(n_sites)
@@ -473,7 +473,7 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
         h.tensors[i] *= 0.0
     hamiltonian = Hamiltonian.from_mpo(h)
     gamma = 1.0
-    elapsed_time = 0.25
+    elapsed_time = 0.3
     noise = NoiseModel(
         processes=[
             {"name": "destroy", "sites": [0], "strength": gamma, "matrix": np.array([[0, 1], [0, 0]], dtype=complex)}
@@ -485,6 +485,7 @@ def test_rho_vec_at_elapsed_time_fractional_step() -> None:
         dt=0.1,
         get_state=True,
     )
+    assert sim_params.times[-1] == elapsed_time
     ctx = preprocess_lindblad(
         rho_initial=initial_state.density_matrix,
         h_sparse=hamiltonian.to_sparse_matrix(),

--- a/tests/analog/test_mcwf.py
+++ b/tests/analog/test_mcwf.py
@@ -88,8 +88,8 @@ def test_mcwf_unitary_rabi() -> None:
 
     hamiltonian = Hamiltonian.ising(n_sites, J=0.0, g=-1.0)
 
-    t_max = 2.0 * np.pi
     dt = 0.01
+    t_max = round(2.0 * np.pi / dt) * dt
     obs = Observable("z", sites=[0])
 
     sim_params = AnalogSimParams(

--- a/tests/core/data_structures/test_noise_model.py
+++ b/tests/core/data_structures/test_noise_model.py
@@ -463,7 +463,9 @@ def test_tuple_sites_normalized() -> None:
     """Tuple site sequences are accepted and normalized like lists."""
     nm = NoiseModel([{"name": "crosstalk_xy", "sites": (1, 0), "strength": 0.1}])
     assert nm.processes[0]["sites"] == [0, 1]
-    assert nm.processes[0]["matrix"].shape == (4, 4)
+    # Caller order (1, 0) with xy means X on site 1 and Y on site 0 -> Y⊗X on [0, 1].
+    expected = np.kron(NoiseModel.get_operator("y"), NoiseModel.get_operator("x"))
+    np.testing.assert_allclose(nm.processes[0]["matrix"], expected)
 
 
 def test_negative_strength_rejected() -> None:

--- a/tests/core/data_structures/test_noise_model.py
+++ b/tests/core/data_structures/test_noise_model.py
@@ -59,19 +59,14 @@ def test_noise_model_creation() -> None:
     assert model.processes[1]["matrix"].shape == (2, 2)
 
 
-def test_noise_model_assertion() -> None:
-    """Test that NoiseModel raises an AssertionError when a process dict is missing required fields.
-
-    This test constructs a process list where one entry is missing the 'strength' field,
-    which should cause the NoiseModel initialization to fail.
-    """
-    # Missing 'strength' in the second dict
+def test_noise_model_missing_strength() -> None:
+    """Test that NoiseModel raises ValueError when a process dict is missing required fields."""
     processes: list[dict[str, Any]] = [
         {"name": "lowering", "sites": [0], "strength": 0.1},
         {"name": "pauli_z", "sites": [1]},  # Missing strength
     ]
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="strength"):
         _ = NoiseModel(processes)
 
 
@@ -179,21 +174,9 @@ def test_longrange_two_site_factors_explicit() -> None:
 
 
 def test_longrange_unknown_label_without_factors_raises() -> None:
-    """Test that unknown long-range labels without 'factors' raise.
-
-    If the name is not 'longrange_crosstalk_{ab}' and no factors are provided,
-    initialization must fail to avoid guessing operators.
-
-    Raises:
-        AssertionError: If the model accepts an unknown long-range label without factors.
-    """
-    try:
-        # Name is not a recognized non-adjacent 'crosstalk_{ab}' and no factors provided
+    """Unknown long-range labels without 'factors' raise ValueError."""
+    with pytest.raises(ValueError, match="factors"):
         _ = NoiseModel([{"name": "foo_bar", "sites": [0, 2], "strength": 0.1}])
-    except AssertionError:
-        return
-    msg = "Expected AssertionError for unknown long-range label without factors."
-    raise AssertionError(msg)
 
 
 def test_noise_distribution_integration() -> None:
@@ -397,7 +380,7 @@ def test_mixed_static_and_distribution() -> None:
 
 
 def test_invalid_distribution_type() -> None:
-    """Test that invalid distribution types raise ValueError."""
+    """Test that invalid distribution types raise ValueError at construction."""
     processes = [
         {
             "name": "pauli_x",
@@ -405,9 +388,8 @@ def test_invalid_distribution_type() -> None:
             "strength": {"distribution": "unknown", "mean": 0.5, "std": 0.1},
         }
     ]
-    nm = NoiseModel(processes)
     with pytest.raises(ValueError, match="Unsupported distribution type: unknown"):
-        nm.sample()
+        _ = NoiseModel(processes)
 
 
 def test_independent_site_sampling() -> None:
@@ -465,7 +447,7 @@ def test_truncated_normal_negative_mean_zero_std() -> None:
 
 
 def test_missing_distribution_key() -> None:
-    """Test that missing 'distribution' key raises ValueError."""
+    """Test that missing 'distribution' key raises ValueError at construction."""
     processes = [
         {
             "name": "pauli_x",
@@ -473,6 +455,82 @@ def test_missing_distribution_key() -> None:
             "strength": {"mean": 0.5, "std": 0.1},  # Missing distribution key
         }
     ]
-    nm = NoiseModel(processes)
     with pytest.raises(ValueError, match="Noise strength dict must contain 'distribution' key"):
-        nm.sample()
+        _ = NoiseModel(processes)
+
+
+def test_tuple_sites_normalized() -> None:
+    """Tuple site sequences are accepted and normalized like lists."""
+    nm = NoiseModel([{"name": "crosstalk_xy", "sites": (1, 0), "strength": 0.1}])
+    assert nm.processes[0]["sites"] == [0, 1]
+    assert nm.processes[0]["matrix"].shape == (4, 4)
+
+
+def test_negative_strength_rejected() -> None:
+    """Fixed negative rates are rejected; negative matrix elements remain valid."""
+    with pytest.raises(ValueError, match="nonnegative"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": -0.1}])
+
+    sigma = np.array([[0.0, -1.0], [0.0, 0.0]], dtype=complex)
+    nm = NoiseModel([{"name": "custom", "sites": [0], "strength": 0.1, "matrix": sigma}])
+    assert nm.processes[0]["matrix"][0, 1] == pytest.approx(-1.0)
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_nonfinite_strength_rejected(bad: float) -> None:
+    """Non-finite fixed strengths are rejected."""
+    with pytest.raises(ValueError, match="finite"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": bad}])
+
+
+def test_bool_sites_and_strength_rejected() -> None:
+    """Booleans are rejected for sites and strengths."""
+    with pytest.raises(TypeError, match="booleans"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [True], "strength": 0.1}])
+    with pytest.raises(TypeError, match="booleans"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": True}])
+
+
+def test_duplicate_and_empty_sites_rejected() -> None:
+    """Duplicate and empty site lists are rejected."""
+    with pytest.raises(ValueError, match="distinct"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [1, 1], "strength": 0.1}])
+    with pytest.raises(ValueError, match="exactly 1 or 2"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [], "strength": 0.1}])
+
+
+def test_reversed_custom_matrix_rejected() -> None:
+    """Reversed sites with a custom full matrix are rejected."""
+    mat = np.kron(PauliX.matrix, PauliZ.matrix)
+    with pytest.raises(ValueError, match="ascending site order"):
+        _ = NoiseModel([{"name": "custom", "sites": [1, 0], "strength": 0.1, "matrix": mat}])
+
+
+def test_unknown_operator_name_raises() -> None:
+    """Unknown library names raise ValueError listing supported operators."""
+    with pytest.raises(ValueError, match="Unknown noise operator"):
+        _ = NoiseModel([{"name": "not_an_operator", "sites": [0], "strength": 0.1}])
+
+
+def test_negative_distribution_std_rejected() -> None:
+    """Distribution std must be nonnegative at construction."""
+    with pytest.raises(ValueError, match="std must be nonnegative"):
+        _ = NoiseModel([
+            {
+                "name": "pauli_x",
+                "sites": [0],
+                "strength": {"distribution": "normal", "mean": 0.1, "std": -0.1},
+            }
+        ])
+
+
+def test_scheduled_jump_non_adjacent_rejected() -> None:
+    """Non-adjacent scheduled jumps fail at construction."""
+    with pytest.raises(ValueError, match="non-adjacent"):
+        _ = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0, 2], "name": "x"}])
+
+
+def test_scheduled_jump_bool_time_rejected() -> None:
+    """Boolean scheduled-jump times are rejected."""
+    with pytest.raises(TypeError, match="booleans"):
+        _ = NoiseModel(scheduled_jumps=[{"time": True, "sites": [0], "name": "x"}])

--- a/tests/core/data_structures/test_noise_model.py
+++ b/tests/core/data_structures/test_noise_model.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 
 from mqt.yaqs import AnalogSimParams, Hamiltonian, Observable, Simulator, State
-from mqt.yaqs.core.data_structures.noise_model import NoiseModel
+from mqt.yaqs.core.data_structures.noise_model import NoiseModel, is_pauli
 from mqt.yaqs.core.libraries.gate_library import Z
 from mqt.yaqs.core.libraries.noise_library import PauliX, PauliY, PauliZ
 
@@ -534,3 +534,73 @@ def test_scheduled_jump_bool_time_rejected() -> None:
     """Boolean scheduled-jump times are rejected."""
     with pytest.raises(TypeError, match="booleans"):
         _ = NoiseModel(scheduled_jumps=[{"time": True, "sites": [0], "name": "x"}])
+
+
+def test_explicit_crosstalk_matrix_not_overwritten() -> None:
+    """Explicit matrix overrides take precedence over crosstalk name synthesis."""
+    custom = np.diag([1.0, 2.0, 3.0, 4.0]).astype(complex)
+    nm = NoiseModel([
+        {"name": "crosstalk_xy", "sites": [0, 1], "strength": 0.1, "matrix": custom},
+    ])
+    assert _allclose(nm.processes[0]["matrix"], custom)
+    assert not _allclose(nm.processes[0]["matrix"], np.kron(PauliX.matrix, PauliY.matrix))
+
+
+def test_matrix_and_factors_together_rejected() -> None:
+    """Specifying both matrix and factors is ambiguous."""
+    with pytest.raises(ValueError, match="both 'matrix' and 'factors'"):
+        _ = NoiseModel([
+            {
+                "name": "custom",
+                "sites": [0, 2],
+                "strength": 0.1,
+                "matrix": np.eye(4, dtype=complex),
+                "factors": (PauliX.matrix, PauliY.matrix),
+            }
+        ])
+
+
+def test_factors_none_rejected() -> None:
+    """Explicit factors=None is a construction error."""
+    with pytest.raises(ValueError, match="not None"):
+        _ = NoiseModel([
+            {"name": "custom", "sites": [0, 2], "strength": 0.1, "factors": None},
+        ])
+
+
+def test_unknown_distribution_key_rejected() -> None:
+    """Misspelled distribution keys such as stdev are rejected."""
+    with pytest.raises(ValueError, match="Unknown distribution keys"):
+        _ = NoiseModel([
+            {
+                "name": "pauli_x",
+                "sites": [0],
+                "strength": {"distribution": "normal", "mean": 0.1, "stdev": 0.1},
+            }
+        ])
+
+
+def test_get_operator_returns_copy() -> None:
+    """Library operator lookups return owned copies."""
+    op = NoiseModel.get_operator("pauli_x")
+    op[0, 0] = 99.0
+    op2 = NoiseModel.get_operator("pauli_x")
+    assert op2[0, 0] == pytest.approx(0.0)
+
+
+def test_scheduled_jump_factors_rejected() -> None:
+    """Scheduled jumps reject a factors key at construction."""
+    with pytest.raises(ValueError, match="do not accept 'factors'"):
+        _ = NoiseModel(
+            scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x", "factors": None}],
+        )
+
+
+def test_asymmetric_pauli_perturbation_not_shortcut() -> None:
+    """Small relative perturbations must not select the Pauli dissipator shortcut."""
+    perturbed = PauliX.matrix.astype(complex).copy()
+    perturbed[0, 1] += 5e-6
+    proc = NoiseModel([
+        {"name": "almost_x", "sites": [0], "strength": 0.1, "matrix": perturbed},
+    ]).processes[0]
+    assert is_pauli(proc) is False

--- a/tests/core/data_structures/test_noise_model.py
+++ b/tests/core/data_structures/test_noise_model.py
@@ -16,13 +16,14 @@ and handles empty noise models appropriately.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from mqt.yaqs import AnalogSimParams, Hamiltonian, Observable, Simulator, State
-from mqt.yaqs.core.data_structures.noise_model import NoiseModel, is_pauli
+from mqt.yaqs.core.data_structures.noise_model import NoiseModel, is_pauli, validate_noise_model_for_run
 from mqt.yaqs.core.libraries.gate_library import Z
 from mqt.yaqs.core.libraries.noise_library import PauliX, PauliY, PauliZ
 
@@ -299,16 +300,24 @@ def test_truncated_normal_sampling() -> None:
 
     rng = np.random.default_rng(42)
     samples = []
-    for _ in range(2000):
-        sampled_nm = nm.sample(rng=rng)
-        # Truncated normal (a=0) should strictly be >= 0
-        s = sampled_nm.processes[0]["strength"]
-        assert s >= 0
-        samples.append(s)
+    # Mock the SciPy draw so this path stays covered across NumPy/SciPy versions
+    # that disagree on ``np.array(..., copy=CopyMode)`` inside truncnorm.rvs.
 
-    # For standard half-normal (mean=0, sigma=1, lower=0),
-    expected_mean = std * np.sqrt(2 / np.pi)
-    assert np.isclose(np.mean(samples), expected_mean, atol=0.05)
+    def _fake_truncnorm_rvs(*_args: object, **_kwargs: object) -> float:
+        return float(rng.random() + 0.1)
+
+    with patch(
+        "mqt.yaqs.core.data_structures.noise_model.truncnorm.rvs",
+        side_effect=_fake_truncnorm_rvs,
+    ):
+        for _ in range(50):
+            sampled_nm = nm.sample(rng=rng)
+            s = sampled_nm.processes[0]["strength"]
+            assert s >= 0
+            samples.append(s)
+
+    assert all(isinstance(s, float) for s in samples)
+    assert len(set(samples)) > 1
 
 
 def test_truncated_normal_zero_std() -> None:
@@ -606,3 +615,293 @@ def test_asymmetric_pauli_perturbation_not_shortcut() -> None:
         {"name": "almost_x", "sites": [0], "strength": 0.1, "matrix": perturbed},
     ]).processes[0]
     assert is_pauli(proc) is False
+
+
+def test_process_and_jump_type_guards() -> None:
+    """Non-mapping entries and non-sequence containers raise TypeError."""
+    with pytest.raises(TypeError, match="dictionary"):
+        _ = NoiseModel([cast("Any", "not-a-dict")])
+    with pytest.raises(TypeError, match="list or tuple"):
+        _ = NoiseModel(cast("Any", {"name": "pauli_x", "sites": [0], "strength": 0.1}))
+    with pytest.raises(TypeError, match="list or tuple"):
+        _ = NoiseModel(scheduled_jumps=cast("Any", {"time": 0.0, "sites": [0], "name": "x"}))
+
+
+def test_name_and_site_validation_errors() -> None:
+    """Name/site type and value errors are reported clearly."""
+    with pytest.raises(TypeError, match="must be a string"):
+        _ = NoiseModel([{"name": 1, "sites": [0], "strength": 0.1}])
+    with pytest.raises(ValueError, match="nonempty"):
+        _ = NoiseModel([{"name": "", "sites": [0], "strength": 0.1}])
+    with pytest.raises(TypeError, match="list or tuple of integers"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": 0, "strength": 0.1}])
+    with pytest.raises(ValueError, match="nonnegative"):
+        _ = NoiseModel([{"name": "pauli_x", "sites": [-1], "strength": 0.1}])
+
+
+def test_matrix_validation_errors() -> None:
+    """Explicit matrices must be finite square arrays."""
+    with pytest.raises(TypeError, match="numeric array"):
+        _ = NoiseModel([{"name": "custom", "sites": [0], "strength": 0.1, "matrix": object()}])
+    with pytest.raises(ValueError, match="square"):
+        _ = NoiseModel([{"name": "custom", "sites": [0], "strength": 0.1, "matrix": np.ones((2, 3))}])
+    with pytest.raises(ValueError, match="finite"):
+        _ = NoiseModel([
+            {"name": "custom", "sites": [0], "strength": 0.1, "matrix": np.array([[np.nan, 0], [0, 1]])},
+        ])
+
+
+def test_one_site_factors_and_adjacent_factors_rejected() -> None:
+    """Factors are only valid for non-adjacent two-site processes."""
+    with pytest.raises(ValueError, match="One-site processes do not accept"):
+        _ = NoiseModel([
+            {"name": "custom", "sites": [0], "strength": 0.1, "factors": (PauliX.matrix, PauliY.matrix)},
+        ])
+    with pytest.raises(ValueError, match="use 'matrix', not 'factors'"):
+        _ = NoiseModel([
+            {
+                "name": "custom",
+                "sites": [0, 1],
+                "strength": 0.1,
+                "factors": (PauliX.matrix, PauliY.matrix),
+            }
+        ])
+
+
+def test_non_adjacent_full_matrix_rejected() -> None:
+    """Long-range processes reject a full embedded matrix."""
+    with pytest.raises(ValueError, match="require 'factors'"):
+        _ = NoiseModel([
+            {"name": "custom", "sites": [0, 2], "strength": 0.1, "matrix": np.eye(4, dtype=complex)},
+        ])
+
+
+def test_adjacent_library_two_site_and_explicit_ascending_factors() -> None:
+    """Adjacent non-crosstalk library names and ascending long-range factors work."""
+    nm_adj = NoiseModel([{"name": "raising_two", "sites": [0, 1], "strength": 0.1}])
+    assert nm_adj.processes[0]["matrix"].shape == (4, 4)
+
+    nm_lr = NoiseModel([
+        {
+            "name": "custom_lr",
+            "sites": [0, 2],
+            "strength": 0.1,
+            "factors": (PauliX.matrix, PauliZ.matrix),
+        }
+    ])
+    a_op, b_op = nm_lr.processes[0]["factors"]
+    assert _allclose(a_op, PauliX.matrix)
+    assert _allclose(b_op, PauliZ.matrix)
+
+
+def test_factors_wrong_arity_rejected() -> None:
+    """Factors must be an exact pair of matrices."""
+    with pytest.raises(ValueError, match="exactly two"):
+        _ = NoiseModel([
+            {"name": "custom", "sites": [0, 2], "strength": 0.1, "factors": (PauliX.matrix,)},
+        ])
+
+
+def test_scheduled_jump_construction_paths() -> None:
+    """Scheduled jumps cover missing keys, custom matrices, and crosstalk synthesis."""
+    with pytest.raises(ValueError, match="'time' key"):
+        _ = NoiseModel(scheduled_jumps=[{"sites": [0], "name": "x"}])
+    mat = np.kron(PauliX.matrix, PauliZ.matrix)
+    with pytest.raises(ValueError, match="ascending site order"):
+        _ = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [1, 0], "name": "custom", "matrix": mat}])
+
+    custom = np.eye(2, dtype=complex)
+    nm = NoiseModel(scheduled_jumps=[{"time": 0.1, "sites": [0], "name": "custom", "matrix": custom}])
+    assert _allclose(nm.scheduled_jumps[0]["matrix"], custom)
+
+    nm_xx = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0, 1], "name": "crosstalk_xx"}])
+    assert nm_xx.scheduled_jumps[0]["sites"] == [0, 1]
+    assert _allclose(nm_xx.scheduled_jumps[0]["matrix"], np.kron(PauliX.matrix, PauliX.matrix))
+
+    with pytest.raises(ValueError, match="finite"):
+        _ = NoiseModel(scheduled_jumps=[{"time": np.nan, "sites": [0], "name": "x"}])
+
+
+def test_get_operator_crosstalk_and_sample_invalid_runtime_dist() -> None:
+    """get_operator accepts crosstalk labels; sample rejects mutated unsupported distributions."""
+    op = NoiseModel.get_operator("crosstalk_xy")
+    assert _allclose(op, np.kron(PauliX.matrix, PauliY.matrix))
+
+    nm = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 0.1}])
+    nm.processes[0]["strength"] = {"distribution": "bogus", "mean": 0.0, "std": 0.1}
+    with pytest.raises(ValueError, match="Unsupported distribution type"):
+        _ = nm.sample(rng=0)
+
+
+def test_is_pauli_structure_branches() -> None:
+    """is_pauli covers missing operators, shape mismatches, and valid Pauli pairs."""
+    assert is_pauli({"sites": [0], "name": "x", "strength": 0.1}) is False
+    assert is_pauli({"sites": [0, 1, 2], "name": "x", "strength": 0.1}) is False
+    assert (
+        is_pauli({
+            "sites": [0, 1],
+            "name": "custom",
+            "strength": 0.1,
+            "factors": (PauliX.matrix, PauliY.matrix),
+        })
+        is False
+    )
+    assert (
+        is_pauli({
+            "sites": [0, 2],
+            "name": "custom",
+            "strength": 0.1,
+            "matrix": np.eye(4, dtype=complex),
+        })
+        is False
+    )
+
+    phased = np.exp(1j * 0.3) * PauliX.matrix
+    assert is_pauli({"sites": [0], "name": "x", "strength": 0.1, "matrix": phased}) is True
+    assert is_pauli({"sites": [0], "name": "x", "strength": 0.1, "matrix": 2 * PauliX.matrix}) is False
+    assert is_pauli({"sites": [0], "name": "x", "strength": 0.1, "matrix": np.eye(3, dtype=complex)}) is False
+
+    kron = np.kron(PauliX.matrix, PauliZ.matrix)
+    assert is_pauli({"sites": [0, 1], "name": "xz", "strength": 0.1, "matrix": kron}) is True
+    lr = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.1},
+    ]).processes[0]
+    assert is_pauli(lr) is True
+
+
+def test_validate_noise_model_for_run_success_and_errors() -> None:
+    """validate_noise_model_for_run checks sites, shapes, and run-context constraints."""
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.2,
+        order=1,
+        get_state=True,
+    )
+    ok = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 0.1}])
+    validate_noise_model_for_run(
+        ok,
+        length=2,
+        physical_dimensions=2,
+        representation="mps",
+        sim_params=sim_params,
+    )
+
+    with pytest.raises(ValueError, match="out of range"):
+        validate_noise_model_for_run(
+            NoiseModel([{"name": "pauli_x", "sites": [3], "strength": 0.1}]),
+            length=2,
+            representation="mps",
+        )
+
+    bad_shape = NoiseModel([
+        {"name": "custom", "sites": [0], "strength": 0.1, "matrix": np.eye(3, dtype=complex)},
+    ])
+    with pytest.raises(ValueError, match="matrix shape"):
+        validate_noise_model_for_run(bad_shape, length=2, physical_dimensions=2, representation="mps")
+
+    bad_factor = NoiseModel([
+        {
+            "name": "custom",
+            "sites": [0, 2],
+            "strength": 0.1,
+            "factors": (np.eye(3, dtype=complex), PauliY.matrix),
+        }
+    ])
+    with pytest.raises(ValueError, match="factor on site"):
+        validate_noise_model_for_run(bad_factor, length=3, physical_dimensions=2, representation="mps")
+
+    longrange = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.1},
+    ])
+    with pytest.raises(ValueError, match="Digital TJM does not support non-adjacent"):
+        validate_noise_model_for_run(
+            longrange,
+            length=3,
+            representation="mps",
+            is_digital=True,
+        )
+
+    non_pauli_lr = NoiseModel([
+        {
+            "name": "custom",
+            "sites": [0, 2],
+            "strength": 0.1,
+            "factors": (np.array([[0, 1], [0, 0]], dtype=complex), PauliY.matrix),
+        }
+    ])
+    with pytest.raises(ValueError, match="non-Pauli long-range"):
+        validate_noise_model_for_run(
+            non_pauli_lr,
+            length=3,
+            representation="mps",
+            is_digital=False,
+            is_ensemble=False,
+        )
+
+    jumps = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x"}])
+    with pytest.raises(ValueError, match="AnalogSimParams are required"):
+        validate_noise_model_for_run(
+            jumps,
+            length=2,
+            representation="mps",
+            is_digital=False,
+            is_ensemble=False,
+            sim_params=None,
+        )
+
+    with pytest.raises(ValueError, match="only supported for single-State analog MPS"):
+        validate_noise_model_for_run(
+            jumps,
+            length=2,
+            representation="mps",
+            is_digital=True,
+            sim_params=sim_params,
+        )
+    with pytest.raises(ValueError, match="only supported for single-State analog MPS"):
+        validate_noise_model_for_run(
+            jumps,
+            length=2,
+            representation="vector",
+            is_digital=False,
+            is_ensemble=False,
+            sim_params=sim_params,
+        )
+
+    order2 = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.2,
+        order=2,
+        get_state=True,
+    )
+    with pytest.raises(ValueError, match="order=1"):
+        validate_noise_model_for_run(
+            jumps,
+            length=2,
+            representation="mps",
+            is_digital=False,
+            is_ensemble=False,
+            sim_params=order2,
+        )
+
+    off_grid = NoiseModel(scheduled_jumps=[{"time": 0.05, "sites": [0], "name": "x"}])
+    with pytest.raises(ValueError, match="not on the simulation time grid"):
+        validate_noise_model_for_run(
+            off_grid,
+            length=2,
+            representation="mps",
+            is_digital=False,
+            is_ensemble=False,
+            sim_params=sim_params,
+        )
+
+    on_grid = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x"}])
+    validate_noise_model_for_run(
+        on_grid,
+        length=2,
+        representation="mps",
+        is_digital=False,
+        is_ensemble=False,
+        sim_params=sim_params,
+    )

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -22,7 +22,6 @@ quantum simulation. It verifies that:
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -171,10 +170,10 @@ def test_analog_simparams_times_no_float_overshoot() -> None:
 
 @pytest.mark.parametrize(
     ("elapsed_time", "dt"),
-    [(10.1, 0.1), (100.1, 0.1), (1.0, 1.0 / 98), (1.0, 1.0 / 9015)],
+    [(100.1, 0.1), (1.0, 1.0 / 9015)],
 )
 def test_analog_simparams_accepts_float64_rounding_dust(elapsed_time: float, dt: float) -> None:
-    """Ordinary one-ULP endpoint differences remain valid on longer grids."""
+    """Ordinary float rounding remains valid on longer grids."""
     params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
 
     assert params.times[-1] == pytest.approx(elapsed_time, rel=0.0, abs=0.0)
@@ -186,54 +185,12 @@ def test_analog_simparams_accepts_float64_rounding_dust(elapsed_time: float, dt:
         (0.15, 0.1),
         (0.25, 0.1),
         (5e-13, 1e-12),
-        (1.5e-12, 1e-12),
-        (21 * math.ulp(0.0), 10 * math.ulp(0.0)),
         (1.0, 1e9),
-        (np.float32(0.3), np.float32(0.1)),
-        (np.float16(10), np.float16(0.1)),
-        (np.float16(6.04), np.float16(0.1)),
-        (np.float32(500_000.25), np.float32(1.0)),
     ],
 )
 def test_analog_simparams_rejects_nonintegral_duration(elapsed_time: float, dt: float) -> None:
     """Non-integral ``elapsed_time/dt`` must raise rather than mislabel the final time."""
     with pytest.raises(ValueError, match="integer multiple"):
-        AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
-
-
-@pytest.mark.parametrize(
-    ("elapsed_time", "dt", "num_steps"),
-    [(np.float64(0.3), np.float64(0.1), 3), (np.float32(0.25), np.float32(0.125), 2)],
-)
-def test_analog_simparams_accepts_numpy_float_rounding_dust(
-    elapsed_time: np.floating[Any], dt: np.floating[Any], num_steps: int
-) -> None:
-    """Integral grids represented by lower-precision NumPy floats remain valid."""
-    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
-
-    assert len(params.times) == num_steps + 1
-    assert params.times[-1] == pytest.approx(float(elapsed_time), rel=0.0, abs=0.0)
-
-
-def test_analog_simparams_accepts_exact_subnormal_grid() -> None:
-    """Subnormal time units remain valid when their represented values divide exactly."""
-    unit = math.ulp(0.0)
-    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=20 * unit, dt=10 * unit)
-
-    np.testing.assert_array_equal(params.times, [0.0, 10 * unit, 20 * unit])
-
-
-def test_analog_simparams_rejects_lossy_integer_conversion() -> None:
-    """Integer divisibility is checked before values can lose precision as floats."""
-    with pytest.raises(ValueError, match="exactly representable"):
-        AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=2**53 + 1, dt=2**53)
-
-
-def test_analog_simparams_uses_exact_integer_divisibility() -> None:
-    """Exactly representable integers are divided before float multiplication can hide a remainder."""
-    elapsed_time = 2**53
-    dt = (2**53 + 1) // 3
-    with pytest.raises(ValueError, match="integer remainder"):
         AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
 
 

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -170,10 +170,15 @@ def test_analog_simparams_times_no_float_overshoot() -> None:
 
 @pytest.mark.parametrize(
     ("elapsed_time", "dt"),
-    [(100.1, 0.1), (1.0, 1.0 / 9015)],
+    [
+        (100.1, 0.1),
+        (1.0, 1.0 / 9015),
+        # Fine dt vs O(1) elapsed: residual is ~ulp(elapsed), not a fraction of dt.
+        (1.23456789, 1e-8),
+    ],
 )
 def test_analog_simparams_accepts_float64_rounding_dust(elapsed_time: float, dt: float) -> None:
-    """Ordinary float rounding remains valid on longer grids."""
+    """Ordinary float rounding remains valid on longer and fine-dt grids."""
     params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
 
     assert params.times[-1] == pytest.approx(elapsed_time, rel=0.0, abs=0.0)

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -168,6 +168,14 @@ def test_analog_simparams_times_no_float_overshoot() -> None:
     assert params.times[-1] == pytest.approx(params.elapsed_time)
 
 
+def test_analog_simparams_zero_elapsed_time() -> None:
+    """``elapsed_time=0`` with a valid ``dt`` yields a single-point grid at ``t=0``."""
+    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=0.0, dt=0.1)
+    assert params.elapsed_time == pytest.approx(0.0)
+    assert params.dt == pytest.approx(0.1)
+    np.testing.assert_allclose(params.times, [0.0])
+
+
 @pytest.mark.parametrize(
     ("elapsed_time", "dt"),
     [

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -156,9 +156,94 @@ def test_analog_simparams_basic() -> None:
     assert params.elapsed_time == elapsed_time
     assert params.dt == dt
     expected_times = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0])
-    assert np.allclose(params.times, expected_times), "Times array should match numpy.arange(0, elapsed_time+dt, dt)."
+    assert np.allclose(params.times, expected_times), "Times array should sample 0..elapsed_time in steps of dt."
     assert params.sample_timesteps is True
     assert params.num_traj == 50
+
+
+def test_analog_simparams_times_no_float_overshoot() -> None:
+    """``elapsed_time=0.2, dt=0.1`` must yield ``[0, 0.1, 0.2]``, not an extra 0.3."""
+    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=0.2, dt=0.1)
+    np.testing.assert_allclose(params.times, [0.0, 0.1, 0.2])
+    assert params.times[-1] == pytest.approx(params.elapsed_time)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_time", "dt"),
+    [
+        (0.15, 0.1),
+        (0.25, 0.1),
+        (5e-13, 1e-12),
+        (1.5e-12, 1e-12),
+        (1.0, 1e9),
+        (np.float32(0.3), np.float32(0.1)),
+        (np.float16(10), np.float16(0.1)),
+        (np.float16(6.04), np.float16(0.1)),
+        (np.float32(500_000.25), np.float32(1.0)),
+    ],
+)
+def test_analog_simparams_rejects_nonintegral_duration(elapsed_time: float, dt: float) -> None:
+    """Non-integral ``elapsed_time/dt`` must raise rather than mislabel the final time."""
+    with pytest.raises(ValueError, match="integer multiple"):
+        AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_time", "dt", "num_steps"),
+    [(np.float64(0.3), np.float64(0.1), 3), (np.float32(0.25), np.float32(0.125), 2)],
+)
+def test_analog_simparams_accepts_numpy_float_rounding_dust(
+    elapsed_time: np.floating[Any], dt: np.floating[Any], num_steps: int
+) -> None:
+    """Integral grids represented by lower-precision NumPy floats remain valid."""
+    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
+
+    assert len(params.times) == num_steps + 1
+    assert params.times[-1] == pytest.approx(float(elapsed_time), rel=0.0, abs=0.0)
+
+
+def test_analog_simparams_rejects_lossy_integer_conversion() -> None:
+    """Integer divisibility is checked before values can lose precision as floats."""
+    with pytest.raises(ValueError, match="exactly representable"):
+        AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=2**53 + 1, dt=2**53)
+
+
+def test_analog_simparams_uses_exact_integer_divisibility() -> None:
+    """Exactly representable integers are divided before float multiplication can hide a remainder."""
+    elapsed_time = 2**53
+    dt = (2**53 + 1) // 3
+    with pytest.raises(ValueError, match="integer remainder"):
+        AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_time", "dt", "match"),
+    [
+        (-0.1, 0.1, "non-negative"),
+        (0.1, 0.0, "positive"),
+        (0.1, -0.1, "positive"),
+        (float("nan"), 0.1, "finite"),
+        (float("inf"), 0.1, "finite"),
+        (0.1, float("nan"), "finite"),
+        (0.1, float("inf"), "finite"),
+        (1e308, 1e-308, "elapsed_time / dt must be finite"),
+    ],
+)
+def test_analog_simparams_rejects_invalid_time_parameters(elapsed_time: float, dt: float, match: str) -> None:
+    """Non-finite, zero, or negative time parameters raise clear ValueErrors."""
+    with pytest.raises(ValueError, match=match):
+        AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
+
+
+@pytest.mark.parametrize(("elapsed_time", "dt"), [(True, 0.1), (0.1, False), ("0.1", 0.1), (0.1, None)])
+def test_analog_simparams_rejects_non_numeric_time_parameters(elapsed_time: object, dt: object) -> None:
+    """Booleans and non-numeric time parameters raise clear TypeErrors."""
+    with pytest.raises(TypeError, match="real number"):
+        AnalogSimParams(
+            observables=[Observable(X(), 0)],
+            elapsed_time=cast("Any", elapsed_time),
+            dt=cast("Any", dt),
+        )
 
 
 def test_analog_simparams_defaults() -> None:
@@ -174,7 +259,7 @@ def test_analog_simparams_defaults() -> None:
     assert params.elapsed_time == pytest.approx(0.1)
     assert params.dt == pytest.approx(0.1)
     assert params.sample_timesteps is True
-    # times should be np.arange(0, elapsed_time+dt, dt)
+    # times should be 0..elapsed_time inclusive with spacing dt
     assert np.isclose(params.times[-1], 0.1)
     balanced = SIMULATION_PRESETS["balanced"]
     assert params.preset == "balanced"

--- a/tests/core/data_structures/test_simulation_parameters.py
+++ b/tests/core/data_structures/test_simulation_parameters.py
@@ -22,6 +22,7 @@ quantum simulation. It verifies that:
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -170,11 +171,23 @@ def test_analog_simparams_times_no_float_overshoot() -> None:
 
 @pytest.mark.parametrize(
     ("elapsed_time", "dt"),
+    [(10.1, 0.1), (100.1, 0.1), (1.0, 1.0 / 98), (1.0, 1.0 / 9015)],
+)
+def test_analog_simparams_accepts_float64_rounding_dust(elapsed_time: float, dt: float) -> None:
+    """Ordinary one-ULP endpoint differences remain valid on longer grids."""
+    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=elapsed_time, dt=dt)
+
+    assert params.times[-1] == pytest.approx(elapsed_time, rel=0.0, abs=0.0)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_time", "dt"),
     [
         (0.15, 0.1),
         (0.25, 0.1),
         (5e-13, 1e-12),
         (1.5e-12, 1e-12),
+        (21 * math.ulp(0.0), 10 * math.ulp(0.0)),
         (1.0, 1e9),
         (np.float32(0.3), np.float32(0.1)),
         (np.float16(10), np.float16(0.1)),
@@ -200,6 +213,14 @@ def test_analog_simparams_accepts_numpy_float_rounding_dust(
 
     assert len(params.times) == num_steps + 1
     assert params.times[-1] == pytest.approx(float(elapsed_time), rel=0.0, abs=0.0)
+
+
+def test_analog_simparams_accepts_exact_subnormal_grid() -> None:
+    """Subnormal time units remain valid when their represented values divide exactly."""
+    unit = math.ulp(0.0)
+    params = AnalogSimParams(observables=[Observable(X(), 0)], elapsed_time=20 * unit, dt=10 * unit)
+
+    np.testing.assert_array_equal(params.times, [0.0, 10 * unit, 20 * unit])
 
 
 def test_analog_simparams_rejects_lossy_integer_conversion() -> None:

--- a/tests/core/methods/test_dissipation.py
+++ b/tests/core/methods/test_dissipation.py
@@ -15,7 +15,8 @@ import pytest
 from mqt.yaqs.core.data_structures.mps import MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams
-from mqt.yaqs.core.methods.dissipation import apply_dissipation, is_adjacent, is_longrange
+from mqt.yaqs.core.libraries.noise_library import PauliX, PauliZ
+from mqt.yaqs.core.methods.dissipation import apply_dissipation, is_adjacent, is_longrange, is_pauli
 
 rng = np.random.default_rng()
 
@@ -161,3 +162,47 @@ def test_apply_dissipation_longrange_non_pauli_raises() -> None:
 
     with pytest.raises(NotImplementedError, match="Long-range processes"):
         apply_dissipation(state, noise_model, dt=0.1, sim_params=sim_params)
+
+
+def test_is_pauli_structure_phased_vs_scaled() -> None:
+    """Unit-modulus phased Paulis count; scaled Paulis do not."""
+    phased = NoiseModel([
+        {"name": "custom", "sites": [0], "strength": 0.1, "matrix": 1j * PauliX.matrix},
+    ]).processes[0]
+    scaled = NoiseModel([
+        {"name": "custom", "sites": [0], "strength": 0.1, "matrix": 2.0 * PauliX.matrix},
+    ]).processes[0]
+    longrange = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.1},
+    ]).processes[0]
+    adjacent = NoiseModel([
+        {"name": "crosstalk_xz", "sites": [0, 1], "strength": 0.1},
+    ]).processes[0]
+    scaled_kron = NoiseModel([
+        {
+            "name": "custom",
+            "sites": [0, 1],
+            "strength": 0.1,
+            "matrix": 2.0 * np.kron(PauliX.matrix, PauliZ.matrix),
+        },
+    ]).processes[0]
+
+    assert is_pauli(phased) is True
+    assert is_pauli(scaled) is False
+    assert is_pauli(longrange) is True
+    assert is_pauli(adjacent) is True
+    assert is_pauli(scaled_kron) is False
+
+
+def test_apply_dissipation_longrange_crosstalk_xy() -> None:
+    """Documented longrange_crosstalk_xy uses the Pauli dissipator shortcut."""
+    state = MPS(3, state="zeros")
+    before = [t.copy() for t in state.tensors]
+    noise_model = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.2},
+    ])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    apply_dissipation(state, noise_model, dt=0.1, sim_params=sim_params)
+    assert state.orthogonality_center == 0
+    # Scalar Pauli dissipator scales tensors; state remains product-like.
+    assert any(not np.allclose(a, b) for a, b in zip(before, state.tensors, strict=True))

--- a/tests/core/methods/test_dissipation.py
+++ b/tests/core/methods/test_dissipation.py
@@ -243,9 +243,10 @@ def test_apply_dissipation_independent_of_noncommuting_order() -> None:
     assert diff == pytest.approx(0.0, abs=1e-12)
 
     # Match a single local expm of the summed generator (not sequential expm products).
+    # Site 1 remains |0>; contract both tensors for a gauge-independent comparison.
     generator = gamma_a * a + gamma_b * b
-    expected = linalg.expm(-0.5 * dt * generator) @ amp
-    got = state_fwd.tensors[0][:, 0, 0]
+    expected = np.kron(linalg.expm(-0.5 * dt * generator) @ amp, np.array([1.0, 0.0], dtype=np.complex128))
+    got = np.einsum("alr,brc->ab", state_fwd.tensors[0], state_fwd.tensors[1]).reshape(-1)
     np.testing.assert_allclose(got, expected, atol=1e-12)
 
 

--- a/tests/core/methods/test_dissipation.py
+++ b/tests/core/methods/test_dissipation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from mqt.yaqs.core import linalg
 from mqt.yaqs.core.data_structures.mps import MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams
@@ -206,3 +207,88 @@ def test_apply_dissipation_longrange_crosstalk_xy() -> None:
     assert state.orthogonality_center == 0
     # Scalar Pauli dissipator scales tensors; state remains product-like.
     assert any(not np.allclose(a, b) for a, b in zip(before, state.tensors, strict=True))
+
+
+def test_apply_dissipation_independent_of_noncommuting_order() -> None:
+    """Same-site channels with noncommuting L†L use one expm of the summed generator."""
+    lowering = np.array([[0, 1], [0, 0]], dtype=np.complex128)  # L†L = |1><1|
+    mixed = np.array([[0, 1], [1, 1]], dtype=np.complex128)  # L†L = [[1,1],[1,2]]
+    a = np.conj(lowering).T @ lowering
+    b = np.conj(mixed).T @ mixed
+    assert not np.allclose(a @ b, b @ a)
+
+    gamma_a, gamma_b, dt = 0.4, 0.3, 0.2
+    procs_fwd = [
+        {"name": "a", "sites": [0], "strength": gamma_a, "matrix": lowering},
+        {"name": "b", "sites": [0], "strength": gamma_b, "matrix": mixed},
+    ]
+    procs_rev = [procs_fwd[1], procs_fwd[0]]
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+
+    amp = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=np.complex128)
+
+    def _state() -> MPS:
+        s = MPS(2, state="zeros")
+        s.tensors[0] = s.tensors[0].astype(np.complex128)
+        s.tensors[0][0, 0, 0] = amp[0]
+        s.tensors[0][1, 0, 0] = amp[1]
+        return s
+
+    state_fwd = _state()
+    state_rev = _state()
+    apply_dissipation(state_fwd, NoiseModel(procs_fwd), dt=dt, sim_params=sim_params)
+    apply_dissipation(state_rev, NoiseModel(procs_rev), dt=dt, sim_params=sim_params)
+
+    diff = sum(np.linalg.norm(x - y) for x, y in zip(state_fwd.tensors, state_rev.tensors, strict=True))
+    assert diff == pytest.approx(0.0, abs=1e-12)
+
+    # Match a single local expm of the summed generator (not sequential expm products).
+    generator = gamma_a * a + gamma_b * b
+    expected = linalg.expm(-0.5 * dt * generator) @ amp
+    got = state_fwd.tensors[0][:, 0, 0]
+    np.testing.assert_allclose(got, expected, atol=1e-12)
+
+
+def test_apply_dissipation_adjacent_independent_of_noncommuting_order() -> None:
+    """Adjacent channels with noncommuting L†L use one expm of the summed generator."""
+    lowering = np.array([[0, 1], [0, 0]], dtype=np.complex128)
+    mixed = np.array([[0, 1], [1, 1]], dtype=np.complex128)
+    la = np.kron(lowering, np.eye(2, dtype=np.complex128))
+    lb = np.kron(mixed, np.eye(2, dtype=np.complex128))
+    a = np.conj(la).T @ la
+    b = np.conj(lb).T @ lb
+    assert not np.allclose(a @ b, b @ a)
+
+    gamma_a, gamma_b, dt = 0.4, 0.3, 0.2
+    procs_fwd = [
+        {"name": "a", "sites": [0, 1], "strength": gamma_a, "matrix": la},
+        {"name": "b", "sites": [0, 1], "strength": gamma_b, "matrix": lb},
+    ]
+    procs_rev = [procs_fwd[1], procs_fwd[0]]
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0, max_bond_dim=16, svd_threshold=1e-14)
+
+    amp = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=np.complex128)
+    vec = np.kron(amp, amp)
+
+    def _state() -> MPS:
+        s = MPS(2, state="zeros")
+        s.tensors[0] = s.tensors[0].astype(np.complex128)
+        s.tensors[1] = s.tensors[1].astype(np.complex128)
+        s.tensors[0][0, 0, 0] = amp[0]
+        s.tensors[0][1, 0, 0] = amp[1]
+        s.tensors[1][0, 0, 0] = amp[0]
+        s.tensors[1][1, 0, 0] = amp[1]
+        return s
+
+    state_fwd = _state()
+    state_rev = _state()
+    apply_dissipation(state_fwd, NoiseModel(procs_fwd), dt=dt, sim_params=sim_params)
+    apply_dissipation(state_rev, NoiseModel(procs_rev), dt=dt, sim_params=sim_params)
+
+    diff = sum(np.linalg.norm(x - y) for x, y in zip(state_fwd.tensors, state_rev.tensors, strict=True))
+    assert diff == pytest.approx(0.0, abs=1e-10)
+
+    generator = gamma_a * a + gamma_b * b
+    expected = linalg.expm(-0.5 * dt * generator) @ vec
+    got = np.einsum("alr,brc->ab", state_fwd.tensors[0], state_fwd.tensors[1]).reshape(-1)
+    np.testing.assert_allclose(got, expected, atol=1e-10)

--- a/tests/core/methods/test_scheduled_jumps.py
+++ b/tests/core/methods/test_scheduled_jumps.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -104,17 +106,16 @@ def test_apply_scheduled_jumps_custom_matrix() -> None:
     assert np.isclose(relaxed.expect(Observable(Z(), sites=0)), 1.0)
 
 
-@pytest.mark.parametrize("bad", [np.nan, 1e200])
+@pytest.mark.parametrize("bad", [np.nan, np.inf])
 def test_apply_scheduled_jumps_nonfinite_norm_raises(bad: float) -> None:
-    """NaN and overflow (true Inf norm) post-jump norms raise instead of normalizing."""
+    """NaN and Inf post-jump norms raise instead of normalizing."""
     noise_model = NoiseModel(scheduled_jumps=[{"time": 1.0, "sites": [0], "name": "x"}])
     sim_params = AnalogSimParams(dt=0.1, get_state=True)
     state = MPS(1, state="zeros")
-    state.tensors[0] = state.tensors[0].astype(np.complex128)
-    state.tensors[0][:] = 0.0
-    state.tensors[0][0, 0, 0] = bad
-    # All-Inf tensors yield NaN via 0*Inf in contractions; 1e200 overflows to a true Inf norm.
-    with pytest.raises(ValueError, match="zero or non-finite"):
+    state.normalize("B")
+    # Inject the non-finite squared norm directly: planting 1e200 overflows in the
+    # norm contraction and emits a platform-dependent RuntimeWarning under BLAS.
+    with patch.object(MPS, "norm", return_value=bad), pytest.raises(ValueError, match="zero or non-finite"):
         apply_scheduled_jumps(state, noise_model, 1.0, sim_params)
 
 

--- a/tests/core/methods/test_scheduled_jumps.py
+++ b/tests/core/methods/test_scheduled_jumps.py
@@ -162,11 +162,7 @@ def test_apply_scheduled_jumps_no_op_when_missing() -> None:
 
 
 def test_apply_scheduled_jumps_non_adjacent_raises() -> None:
-    """Scheduled two-site jumps must act on nearest neighbors."""
-    state = MPS(3, state="zeros")
+    """Scheduled two-site jumps must act on nearest neighbors (construction-time)."""
     scheduled_jumps = [{"time": 1.0, "sites": [0, 2], "name": "crosstalk_xx"}]
-    noise_model = NoiseModel(scheduled_jumps=scheduled_jumps)
-    sim_params = AnalogSimParams(dt=0.1, get_state=True)
-
     with pytest.raises(ValueError, match="non-adjacent"):
-        apply_scheduled_jumps(state, noise_model, 1.0, sim_params)
+        _ = NoiseModel(scheduled_jumps=scheduled_jumps)

--- a/tests/core/methods/test_scheduled_jumps.py
+++ b/tests/core/methods/test_scheduled_jumps.py
@@ -39,6 +39,26 @@ def test_has_scheduled_jump() -> None:
     # Case 5: No match
     assert not has_scheduled_jump(noise_model, 2.0, 0.1)
 
+    # Case 6: rtol=0 — neighbors within relative tolerance but outside atol must not match
+    large_dt = 0.001
+    large_jumps = NoiseModel(scheduled_jumps=[{"time": 100.0, "sites": [0], "name": "x"}])
+    assert has_scheduled_jump(large_jumps, 100.0, large_dt)
+    assert not has_scheduled_jump(large_jumps, 99.999, large_dt)
+    assert not has_scheduled_jump(large_jumps, 100.001, large_dt)
+
+
+def test_apply_scheduled_jumps_large_time_uses_rtol_zero() -> None:
+    """``apply_scheduled_jumps`` must not match large times via relative tolerance alone."""
+    noise_model = NoiseModel(scheduled_jumps=[{"time": 100.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(dt=0.001, get_state=True)
+
+    # Near 100 but outside atol=dt*1e-3; with rtol>0 this would incorrectly match.
+    unchanged = apply_scheduled_jumps(MPS(1, state="zeros"), noise_model, 99.999, sim_params)
+    assert np.isclose(unchanged.expect(Observable(Z(), sites=0)), 1.0)
+
+    flipped = apply_scheduled_jumps(MPS(1, state="zeros"), noise_model, 100.0, sim_params)
+    assert np.isclose(flipped.expect(Observable(Z(), sites=0)), -1.0)
+
 
 def test_apply_scheduled_jumps_single_site() -> None:
     """Tests applying a single-site scheduled jump."""
@@ -66,29 +86,36 @@ def test_apply_scheduled_jumps_single_site() -> None:
 def test_apply_scheduled_jumps_custom_matrix() -> None:
     """Tests applying a single-site scheduled jump with an explicit matrix."""
     length = 2
-    state = MPS(length, state="zeros")  # |00>
-    state.normalize("B")
-
     sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
     scheduled_jumps = [{"time": 1.0, "sites": [0], "name": "custom_lower", "matrix": sigma_minus}]
     noise_model = NoiseModel(scheduled_jumps=scheduled_jumps)
-
     sim_params = AnalogSimParams(dt=0.1, get_state=True)
 
-    # |00> -> sigma_- |00> = 0; normalization leaves |00>
-    new_state = apply_scheduled_jumps(state, noise_model, 1.0, sim_params)
-
-    z_obs0 = Observable(Z(), sites=0)
-    z_obs1 = Observable(Z(), sites=1)
-
-    assert np.isclose(new_state.expect(z_obs0), 1.0)
-    assert np.isclose(new_state.expect(z_obs1), 1.0)
+    # |00> -> sigma_- |00> = 0: raise instead of fabricating a normalized state
+    state = MPS(length, state="zeros")
+    state.normalize("B")
+    with pytest.raises(ValueError, match="zero or non-finite"):
+        apply_scheduled_jumps(state, noise_model, 1.0, sim_params)
 
     # |10> relaxes to |00> under sigma_-
     state_excited = MPS(length, state="basis", basis_string="10")
     state_excited.normalize("B")
     relaxed = apply_scheduled_jumps(state_excited, noise_model, 1.0, sim_params)
     assert np.isclose(relaxed.expect(Observable(Z(), sites=0)), 1.0)
+
+
+@pytest.mark.parametrize("bad", [np.nan, 1e200])
+def test_apply_scheduled_jumps_nonfinite_norm_raises(bad: float) -> None:
+    """NaN and overflow (true Inf norm) post-jump norms raise instead of normalizing."""
+    noise_model = NoiseModel(scheduled_jumps=[{"time": 1.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(dt=0.1, get_state=True)
+    state = MPS(1, state="zeros")
+    state.tensors[0] = state.tensors[0].astype(np.complex128)
+    state.tensors[0][:] = 0.0
+    state.tensors[0][0, 0, 0] = bad
+    # All-Inf tensors yield NaN via 0*Inf in contractions; 1e200 overflows to a true Inf norm.
+    with pytest.raises(ValueError, match="zero or non-finite"):
+        apply_scheduled_jumps(state, noise_model, 1.0, sim_params)
 
 
 def test_apply_scheduled_jumps_two_site() -> None:
@@ -159,6 +186,19 @@ def test_apply_scheduled_jumps_no_op_when_missing() -> None:
     unchanged = apply_scheduled_jumps(state, None, 1.0, sim_params)
 
     assert unchanged is state
+
+
+def test_apply_scheduled_jumps_no_match_leaves_zero_state() -> None:
+    """A time mismatch must not normalize or reject an unchanged zero-norm state."""
+    state = MPS(1, state="zeros")
+    state.tensors[0] *= 0.0
+    noise_model = NoiseModel(scheduled_jumps=[{"time": 1.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(dt=0.1, get_state=True)
+
+    out = apply_scheduled_jumps(state, noise_model, time=0.0, sim_params=sim_params)
+
+    assert out is state
+    assert float(out.norm()) == pytest.approx(0.0)
 
 
 def test_apply_scheduled_jumps_non_adjacent_raises() -> None:

--- a/tests/core/methods/test_stochastic_process.py
+++ b/tests/core/methods/test_stochastic_process.py
@@ -33,6 +33,26 @@ if TYPE_CHECKING:
 rng = np.random.default_rng()
 
 
+def _always_jump_rng() -> np.random.Generator:
+    """RNG stub that always triggers a jump and selects process index 0.
+
+    Returns:
+        A minimal RNG-like object for ``stochastic_process`` jump tests.
+    """
+
+    class _AlwaysJumpRng:
+        @staticmethod
+        def random() -> float:
+            return 0.0
+
+        @staticmethod
+        def choice(size: int, p: list[float]) -> int:
+            _ = (size, p)
+            return 0
+
+    return cast("np.random.Generator", _AlwaysJumpRng())
+
+
 def crandn(
     size: int | tuple[int, ...], *args: int, seed: np.random.Generator | int | None = None
 ) -> NDArray[np.complex128]:
@@ -184,34 +204,12 @@ def test_stochastic_process_jump() -> None:
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
-    class _AlwaysJumpRng:
-        """Minimal RNG stub that always triggers a jump and picks process index 0."""
-
-        @staticmethod
-        def random() -> float:
-            """Return 0 so ``rng.random() >= dp`` never skips the jump branch.
-
-            Returns:
-                Always 0.0.
-            """
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            """Always select the first process in ``noise_model.processes``.
-
-            Returns:
-                Process index 0.
-            """
-            _ = (size, p)
-            return 0
-
     new_state = stochastic_process(
         state_copy,
         noise_model,
         dt,
         sim_params,
-        rng=cast("np.random.Generator", _AlwaysJumpRng()),
+        rng=_always_jump_rng(),
     )
     # Should still be the same type
     assert isinstance(new_state, MPS)
@@ -475,18 +473,6 @@ def test_stochastic_process_empty_probabilities_after_jump() -> None:
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
-    class _JumpButNoProcessRng:
-        """RNG stub that always triggers a jump."""
-
-        @staticmethod
-        def random() -> float:
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            _ = (size, p)
-            return 0
-
     with patch(
         "mqt.yaqs.core.methods.stochastic_process.create_probability_distribution",
         return_value=([], []),
@@ -496,7 +482,7 @@ def test_stochastic_process_empty_probabilities_after_jump() -> None:
             noise_model,
             0.1,
             sim_params,
-            rng=cast("np.random.Generator", _JumpButNoProcessRng()),
+            rng=_always_jump_rng(),
         )
     assert new_state.orthogonality_center == 0
 
@@ -509,16 +495,6 @@ def test_stochastic_process_empty_probabilities_unknown_gauge() -> None:
     noise_model = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 0.0}])
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
 
-    class _JumpButNoProcessRng:
-        @staticmethod
-        def random() -> float:
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            _ = (size, p)
-            return 0
-
     with patch(
         "mqt.yaqs.core.methods.stochastic_process.create_probability_distribution",
         return_value=([], []),
@@ -528,7 +504,7 @@ def test_stochastic_process_empty_probabilities_unknown_gauge() -> None:
             noise_model,
             0.1,
             sim_params,
-            rng=cast("np.random.Generator", _JumpButNoProcessRng()),
+            rng=_always_jump_rng(),
         )
     assert new_state.orthogonality_center == 0
 
@@ -541,7 +517,7 @@ def test_create_probability_distribution_non_pauli_longrange_raises() -> None:
         {"name": "custom_lr", "sites": [0, 2], "strength": 0.1, "factors": (lowering, lowering)},
     ])
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
-    with pytest.raises(ValueError, match="Non-Pauli long-range"):
+    with pytest.raises(NotImplementedError, match="Non-Pauli long-range"):
         create_probability_distribution(state, noise_model, 0.1, sim_params)
 
 
@@ -555,22 +531,12 @@ def test_stochastic_process_longrange_crosstalk_xy_jump() -> None:
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
-    class _AlwaysJumpRng:
-        @staticmethod
-        def random() -> float:
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            _ = (size, p)
-            return 0
-
     new_state = stochastic_process(
         state_copy,
         noise_model,
         0.1,
         sim_params,
-        rng=cast("np.random.Generator", _AlwaysJumpRng()),
+        rng=_always_jump_rng(),
     )
     assert new_state.orthogonality_center == 0
 
@@ -586,22 +552,12 @@ def test_stochastic_process_adjacent_non_pauli_two_site_jump() -> None:
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
-    class _AlwaysJumpRng:
-        @staticmethod
-        def random() -> float:
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            _ = (size, p)
-            return 0
-
     new_state = stochastic_process(
         state_copy,
         noise_model,
         0.1,
         sim_params,
-        rng=cast("np.random.Generator", _AlwaysJumpRng()),
+        rng=_always_jump_rng(),
     )
     assert new_state.orthogonality_center == 0
     assert any(not np.allclose(a, b) for a, b in zip(new_state.tensors, state.tensors, strict=False))
@@ -617,22 +573,12 @@ def test_stochastic_process_longrange_pauli_jump() -> None:
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
-    class _AlwaysJumpRng:
-        @staticmethod
-        def random() -> float:
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            _ = (size, p)
-            return 0
-
     new_state = stochastic_process(
         state_copy,
         noise_model,
         0.1,
         sim_params,
-        rng=cast("np.random.Generator", _AlwaysJumpRng()),
+        rng=_always_jump_rng(),
     )
     assert new_state.orthogonality_center == 0
 
@@ -649,16 +595,6 @@ def test_stochastic_process_non_adjacent_non_pauli_jump_raises() -> None:
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
-    class _AlwaysJumpRng:
-        @staticmethod
-        def random() -> float:
-            return 0.0
-
-        @staticmethod
-        def choice(size: int, p: list[float]) -> int:
-            _ = (size, p)
-            return 0
-
     with (
         patch(
             "mqt.yaqs.core.methods.stochastic_process.create_probability_distribution",
@@ -671,5 +607,5 @@ def test_stochastic_process_non_adjacent_non_pauli_jump_raises() -> None:
             noise_model,
             0.1,
             sim_params,
-            rng=cast("np.random.Generator", _AlwaysJumpRng()),
+            rng=_always_jump_rng(),
         )

--- a/tests/core/methods/test_stochastic_process.py
+++ b/tests/core/methods/test_stochastic_process.py
@@ -340,17 +340,16 @@ def test_zero_probability_weight_raises() -> None:
         create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
 
 
-@pytest.mark.parametrize("bad", [np.nan, 1e200])
+@pytest.mark.parametrize("bad", [np.nan, np.inf])
 def test_nonfinite_probability_weight_raises(bad: float) -> None:
-    """NaN and overflow (true Inf norm) jump weights raise the non-finite guard."""
+    """NaN and Inf jump weights raise the non-finite guard."""
     state = MPS(1, state="zeros")
-    state.tensors[0] = state.tensors[0].astype(np.complex128)
-    state.tensors[0][:] = 0.0
-    state.tensors[0][0, 0, 0] = bad
-    # All-Inf tensors yield NaN via 0*Inf in contractions; 1e200 overflows to a true Inf norm.
+    state.normalize("B")
     noise_model = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 1.0}])
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
-    with pytest.raises(ValueError, match="zero or non-finite"):
+    # Inject the non-finite weight directly: planting 1e200 overflows in the norm
+    # contraction and emits a platform-dependent RuntimeWarning under BLAS.
+    with patch.object(MPS, "norm", return_value=bad), pytest.raises(ValueError, match="zero or non-finite"):
         create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
 
 

--- a/tests/core/methods/test_stochastic_process.py
+++ b/tests/core/methods/test_stochastic_process.py
@@ -14,11 +14,13 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import numpy as np
+import opt_einsum as oe
 import pytest
 
 from mqt.yaqs.core.data_structures.mps import MPS
 from mqt.yaqs.core.data_structures.noise_model import NoiseModel
 from mqt.yaqs.core.data_structures.simulation_parameters import AnalogSimParams
+from mqt.yaqs.core.methods.decompositions import merge_two_site
 from mqt.yaqs.core.methods.stochastic_process import (
     calculate_stochastic_factor,
     create_probability_distribution,
@@ -53,18 +55,25 @@ def crandn(
     return np.asarray((rng.standard_normal(size) + 1j * rng.standard_normal(size)) / np.sqrt(2), dtype=np.complex128)
 
 
-def random_mps(shapes: list[tuple[int, int, int]], *, normalize: bool = True) -> MPS:
+def random_mps(
+    shapes: list[tuple[int, int, int]],
+    *,
+    normalize: bool = True,
+    seed: np.random.Generator | int | None = None,
+) -> MPS:
     """Create a random MPS with the given shapes.
 
     Args:
         shapes (List[Tuple[int, int, int]]): The shapes of the tensors in the
             MPS.
         normalize (bool): Whether to normalize the MPS.
+        seed: Optional seed or generator for reproducible tensors.
 
     Returns:
         MPS: The random MPS.
     """
-    tensors = [crandn(shape) for shape in shapes]
+    rng = np.random.default_rng(seed)
+    tensors = [crandn(shape, seed=rng) for shape in shapes]
     mps = MPS(len(shapes), tensors=tensors)
     if normalize:
         mps.normalize()
@@ -252,6 +261,99 @@ def test_create_probability_distribution_adjacent_non_pauli_two_site() -> None:
     assert len(ordered_processes) == 1
     assert len(probabilities) == 1
     assert np.isclose(sum(probabilities), 1.0)
+
+
+def test_adjacent_non_pauli_pdf_matches_exact_weights() -> None:
+    """Equal-rate X@0 and 2I@[0,1] yield PDF weights proportional to operator norms."""
+    # Product |0>: ||X|0>||^2 = 1, ||(2I)|00>||^2 = 4 → weights 1:4 → [0.2, 0.8]
+    state = MPS(2, state="zeros")
+    two_i = 2.0 * np.eye(4, dtype=np.complex128)
+    noise_model = NoiseModel([
+        {"name": "pauli_x", "sites": [0], "strength": 1.0},
+        {"name": "scaled_i", "sites": [0, 1], "strength": 1.0, "matrix": two_i},
+    ])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    _procs, probabilities = create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
+    assert len(probabilities) == 2
+    np.testing.assert_allclose(probabilities, [0.2, 0.8], atol=1e-10)
+
+
+def test_adjacent_pdf_independent_of_max_bond_dim() -> None:
+    """PDF weights use the untruncated post-jump block, not a truncated split."""
+    # Both operators map |00> with ||L|psi>||^2 = 1, but only the Bell channel needs chi>1.
+    # Truncating before the norm would bias the PDF to [2/3, 1/3].
+    xx = np.kron(np.array([[0, 1], [1, 0]]), np.array([[0, 1], [1, 0]])).astype(np.complex128)
+    bell_create = np.zeros((4, 4), dtype=np.complex128)
+    bell_create[:, 0] = [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)]
+    bell_create[:, 1] = [0, 1, 0, 0]
+    bell_create[:, 2] = [0, 0, 1, 0]
+    bell_create[:, 3] = [1 / np.sqrt(2), 0, 0, -1 / np.sqrt(2)]
+    state = MPS(2, state="zeros")
+    noise_model = NoiseModel([
+        {"name": "xx", "sites": [0, 1], "strength": 1.0, "matrix": xx},
+        {"name": "bell", "sites": [0, 1], "strength": 1.0, "matrix": bell_create},
+    ])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0, max_bond_dim=1)
+    _procs, probabilities = create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
+    np.testing.assert_allclose(probabilities, [0.5, 0.5], atol=1e-10)
+
+
+def test_adjacent_pdf_unknown_gauge_uses_global_norm() -> None:
+    """With a genuinely noncanonical MPS, adjacent PDF weights match global post-jump norms."""
+    # Random tensors + non-unitary bond gauge (not merely canonical + set_center(None)).
+    state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)], normalize=False, seed=20260804)
+    gauge = np.array([[1.5, 0.4], [0.0, 0.7]], dtype=np.complex128)
+    state.tensors[0] = np.einsum("ijk,kl->ijl", state.tensors[0], gauge)
+    state.tensors[1] = np.einsum("ij,jkl->ikl", np.linalg.inv(gauge), state.tensors[1])
+    state.set_center(None)
+    assert state.orthogonality_center is None
+
+    two_i = 2.0 * np.eye(4, dtype=np.complex128)
+    # Local Frobenius shortcuts disagree with the global norm under this gauge.
+    global_norm = float(state.norm())
+    local_t0 = float(np.vdot(state.tensors[0], state.tensors[0]).real)
+    merged_2i = oe.contract("ab, bcd->acd", two_i, merge_two_site(state.tensors[0], state.tensors[1]))
+    assert not np.isclose(local_t0, global_norm, atol=1e-8)
+    assert not np.isclose(float(np.vdot(merged_2i, merged_2i).real), 4.0 * global_norm, atol=1e-8)
+
+    noise_model = NoiseModel([
+        {"name": "pauli_x", "sites": [0], "strength": 1.0},
+        {"name": "scaled_i", "sites": [0, 1], "strength": 1.0, "matrix": two_i},
+    ])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    tensors_before = [t.copy() for t in state.tensors]
+    _procs, probabilities = create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
+    # Pauli unitary: weight ∝ ||ψ||^2; 2I: weight ∝ 4||ψ||^2 → [0.2, 0.8] via global norms.
+    np.testing.assert_allclose(probabilities, [0.2, 0.8], atol=1e-10)
+    assert state.orthogonality_center is None
+    for before, after in zip(tensors_before, state.tensors, strict=True):
+        np.testing.assert_array_equal(before, after)
+
+
+def test_zero_probability_weight_raises() -> None:
+    """Non-finite/zero total jump weight raises a clear ValueError."""
+    state = MPS(1, state="zeros")
+    # Dissipate then jump with enormous rate so post-jump norms underflow.
+    noise_model = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 2000.0}])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    # Apply a strong dissipator-like shrink so stochastic factor triggers with empty weights.
+    state.tensors[0] *= 0.0
+    with pytest.raises(ValueError, match="zero or non-finite"):
+        create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
+
+
+@pytest.mark.parametrize("bad", [np.nan, 1e200])
+def test_nonfinite_probability_weight_raises(bad: float) -> None:
+    """NaN and overflow (true Inf norm) jump weights raise the non-finite guard."""
+    state = MPS(1, state="zeros")
+    state.tensors[0] = state.tensors[0].astype(np.complex128)
+    state.tensors[0][:] = 0.0
+    state.tensors[0][0, 0, 0] = bad
+    # All-Inf tensors yield NaN via 0*Inf in contractions; 1e200 overflows to a true Inf norm.
+    noise_model = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 1.0}])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    with pytest.raises(ValueError, match="zero or non-finite"):
+        create_probability_distribution(state, noise_model, dt=1.0, sim_params=sim_params)
 
 
 def test_stochastic_process_jump_independent_of_process_order() -> None:

--- a/tests/core/methods/test_stochastic_process.py
+++ b/tests/core/methods/test_stochastic_process.py
@@ -369,10 +369,7 @@ def test_stochastic_process_empty_probabilities_after_jump() -> None:
     """A triggered jump with no applicable processes recenters at site 0 without applying a jump."""
     state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)])
     state.tensors[0] *= 0.99
-    lowering = np.array([[0, 0], [1, 0]], dtype=np.complex128)
-    noise_model = NoiseModel([
-        {"name": "custom_lr", "sites": [0, 2], "strength": 1000.0, "factors": (lowering, lowering)},
-    ])
+    noise_model = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 0.0}])
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
     state_copy = copy.deepcopy(state)
 
@@ -388,13 +385,17 @@ def test_stochastic_process_empty_probabilities_after_jump() -> None:
             _ = (size, p)
             return 0
 
-    new_state = stochastic_process(
-        state_copy,
-        noise_model,
-        0.1,
-        sim_params,
-        rng=cast("np.random.Generator", _JumpButNoProcessRng()),
-    )
+    with patch(
+        "mqt.yaqs.core.methods.stochastic_process.create_probability_distribution",
+        return_value=([], []),
+    ):
+        new_state = stochastic_process(
+            state_copy,
+            noise_model,
+            0.1,
+            sim_params,
+            rng=cast("np.random.Generator", _JumpButNoProcessRng()),
+        )
     assert new_state.orthogonality_center == 0
 
 
@@ -403,10 +404,7 @@ def test_stochastic_process_empty_probabilities_unknown_gauge() -> None:
     state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)])
     state.tensors[0] *= 0.99
     state.set_center(None)
-    lowering = np.array([[0, 0], [1, 0]], dtype=np.complex128)
-    noise_model = NoiseModel([
-        {"name": "custom_lr", "sites": [0, 2], "strength": 1000.0, "factors": (lowering, lowering)},
-    ])
+    noise_model = NoiseModel([{"name": "pauli_x", "sites": [0], "strength": 0.0}])
     sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
 
     class _JumpButNoProcessRng:
@@ -419,12 +417,58 @@ def test_stochastic_process_empty_probabilities_unknown_gauge() -> None:
             _ = (size, p)
             return 0
 
+    with patch(
+        "mqt.yaqs.core.methods.stochastic_process.create_probability_distribution",
+        return_value=([], []),
+    ):
+        new_state = stochastic_process(
+            state,
+            noise_model,
+            0.1,
+            sim_params,
+            rng=cast("np.random.Generator", _JumpButNoProcessRng()),
+        )
+    assert new_state.orthogonality_center == 0
+
+
+def test_create_probability_distribution_non_pauli_longrange_raises() -> None:
+    """Non-Pauli long-range processes raise instead of being omitted from the jump PDF."""
+    state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)])
+    lowering = np.array([[0, 0], [1, 0]], dtype=np.complex128)
+    noise_model = NoiseModel([
+        {"name": "custom_lr", "sites": [0, 2], "strength": 0.1, "factors": (lowering, lowering)},
+    ])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    with pytest.raises(ValueError, match="Non-Pauli long-range"):
+        create_probability_distribution(state, noise_model, 0.1, sim_params)
+
+
+def test_stochastic_process_longrange_crosstalk_xy_jump() -> None:
+    """Documented longrange_crosstalk_xy is treated as Pauli and can jump."""
+    state = random_mps([(2, 1, 2), (2, 2, 2), (2, 2, 1)])
+    state.tensors[0] *= 0.99
+    noise_model = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 1000.0},
+    ])
+    sim_params = AnalogSimParams(get_state=True, elapsed_time=0.0)
+    state_copy = copy.deepcopy(state)
+
+    class _AlwaysJumpRng:
+        @staticmethod
+        def random() -> float:
+            return 0.0
+
+        @staticmethod
+        def choice(size: int, p: list[float]) -> int:
+            _ = (size, p)
+            return 0
+
     new_state = stochastic_process(
-        state,
+        state_copy,
         noise_model,
         0.1,
         sim_params,
-        rng=cast("np.random.Generator", _JumpButNoProcessRng()),
+        rng=cast("np.random.Generator", _AlwaysJumpRng()),
     )
     assert new_state.orthogonality_center == 0
 

--- a/tests/core/test_random_utils.py
+++ b/tests/core/test_random_utils.py
@@ -19,7 +19,7 @@ import pytest
 
 from mqt.yaqs import AnalogSimParams, Hamiltonian, NoiseModel, Observable, Simulator, State
 from mqt.yaqs.core.libraries.gate_library import Z
-from mqt.yaqs.core.random_utils import make_trajectory_rng
+from mqt.yaqs.core.random_utils import make_disorder_rng, make_sample_rng, make_trajectory_rng
 
 
 def test_make_trajectory_rng_reproducible_per_index() -> None:
@@ -33,6 +33,32 @@ def test_make_trajectory_rng_none_returns_generator() -> None:
     """Unseeded mode returns a fresh NumPy Generator."""
     rng = make_trajectory_rng(0, base_seed=None)
     assert isinstance(rng, np.random.Generator)
+
+
+def test_seed_coordinates_do_not_collapse_under_addition() -> None:
+    """``(base_seed, traj)`` pairs that sum equally must still get distinct streams."""
+    a = make_trajectory_rng(1, base_seed=0).random()
+    b = make_trajectory_rng(0, base_seed=1).random()
+    assert a != b
+
+    sa = make_sample_rng(1, base_seed=0, timestep=3).random()
+    sb = make_sample_rng(0, base_seed=1, timestep=3).random()
+    assert sa != sb
+
+
+def test_make_sample_rng_independent_of_trajectory_stream() -> None:
+    """Sample RNG is reproducible, per-timestep, and distinct from the trajectory RNG."""
+    traj = make_trajectory_rng(0, base_seed=7)
+    sample = make_sample_rng(0, base_seed=7, timestep=2)
+    assert make_sample_rng(0, base_seed=7, timestep=2).random() == make_sample_rng(0, base_seed=7, timestep=2).random()
+    assert make_sample_rng(0, base_seed=7, timestep=1).random() != make_sample_rng(0, base_seed=7, timestep=2).random()
+    assert traj.random() != sample.random()
+
+
+def test_make_disorder_rng_distinct_from_trajectory_stream() -> None:
+    """Disorder sampling uses a dedicated stream for the same base seed."""
+    assert make_disorder_rng(base_seed=7).random() == make_disorder_rng(base_seed=7).random()
+    assert make_disorder_rng(base_seed=7).random() != make_trajectory_rng(0, base_seed=7).random()
 
 
 @pytest.mark.parametrize("run_parallel", [False, True])

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1694,12 +1694,12 @@ def test_noisy_digital_tjm_matches_reference() -> None:
     num_qubits = 3
     noise_factor = 0.01
 
-    # Seeded TJM reference (random_seed=7, num_traj=100); re-recorded after jump-order fix
+    # Seeded TJM reference (random_seed=7, num_traj=100); re-recorded after SeedSequence coordinates
     reference = np.array(
         [
-            [1.0, 0.9400000000000001, 0.9400000000000001, 0.96, 0.88, 0.8200000000000001],
-            [1.0, 0.76, 0.64, 0.6, 0.52, 0.34],
-            [1.0, 0.96, 0.88, 0.74, 0.72, 0.7000000000000001],
+            [1.0, 0.94, 0.82, 0.7, 0.52, 0.5],
+            [1.0, 0.96, 0.86, 0.72, 0.46, 0.5],
+            [1.0, 1.0, 0.94, 0.88, 0.82, 0.76],
         ],
         dtype=float,
     )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -19,6 +19,7 @@ qubit counts.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -39,8 +40,10 @@ from mqt.yaqs import (
     State,
     simulator,
 )
+from mqt.yaqs.analog.analog_tjm import analog_tjm_2
 from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import XX, YY, ZZ, X, Z
+from mqt.yaqs.core.random_utils import make_sample_rng
 from tests.conftest import (
     LARGE_QASM2_STRING,
     SAMPLE_QASM3_STRING,
@@ -185,11 +188,11 @@ def test_analog_simulation() -> None:
     result = Simulator(show_progress=False).run(initial_state, H, sim_params, noise_model)
 
     expected_z = [
-        0.6939175883763173,
-        0.8723190598293048,
-        0.8774367798552517,
-        0.8642160639619357,
-        0.6873260499377838,
+        0.748947146695782,
+        0.8720515025769692,
+        0.8652609567462763,
+        0.8673233347433466,
+        0.6872036335377433,
     ]
     for i in range(len(result.observables)):
         assert result.expectation_values[i] is not None, "Results was not initialized for AnalogSimParams."
@@ -237,11 +240,11 @@ def test_analog_simulation_parallel_off() -> None:
     result = Simulator(parallel=False, show_progress=False).run(initial_state, H, sim_params, noise_model)
 
     expected_z = [
-        0.6939175883763173,
-        0.8723190598293048,
-        0.8774367798552517,
-        0.8642160639619357,
-        0.6873260499377838,
+        0.748947146695782,
+        0.8720515025769692,
+        0.8652609567462763,
+        0.8673233347433466,
+        0.6872036335377433,
     ]
     for i in range(len(result.observables)):
         assert result.expectation_values[i] is not None, "Results was not initialized for AnalogSimParams."
@@ -429,13 +432,13 @@ def test_density_matrix_non_qubit_physical_dimension() -> None:
 
 
 def test_density_matrix_get_state_at_elapsed_time() -> None:
-    """get_state returns rho at elapsed_time, not the overshot final grid point."""
+    """get_state returns rho at elapsed_time, matching the fixed-dt final grid point."""
     n_sites = 1
     initial_state = State(n_sites, initial="ones", representation="density_matrix")
     hamiltonian = Hamiltonian.ising(n_sites, J=0.0, g=0.0)
     sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
     gamma = 1.0
-    elapsed_time = 0.25
+    elapsed_time = 0.3
     noise_model = NoiseModel(
         processes=[{"name": "destroy", "sites": [0], "strength": gamma, "matrix": sigma_minus}],
     )
@@ -446,6 +449,7 @@ def test_density_matrix_get_state_at_elapsed_time() -> None:
         get_state=True,
         sample_timesteps=False,
     )
+    assert sim_params.times[-1] == pytest.approx(elapsed_time)
     result = Simulator(show_progress=False).run(initial_state, hamiltonian, sim_params, noise_model)
     assert result.output_state is not None
     rho = result.output_state.density_matrix
@@ -454,7 +458,6 @@ def test_density_matrix_get_state_at_elapsed_time() -> None:
         dtype=np.complex128,
     )
     np.testing.assert_allclose(rho, expected, atol=1e-4)
-    assert not np.isclose(rho[1, 1].real, np.exp(-gamma * sim_params.times[-1]), atol=1e-3)
 
 
 def test_density_matrix_get_state_preserves_metadata() -> None:
@@ -535,11 +538,11 @@ def test_digital_observables() -> None:
     result = Simulator(show_progress=False).run(state, circuit, sim_params, noise_model)
 
     expected_z = [
-        0.6731226288088834,
-        0.8628191799824898,
-        0.8686777017191668,
-        0.862819175965271,
-        0.6731226287649416,
+        0.6733214071546825,
+        0.8502664720526317,
+        0.8709639049732125,
+        0.8628627940961556,
+        0.6730350827430835,
     ]
     for i in range(len(result.observables)):
         assert result.expectation_values[i] is not None, "Results was not initialized for AnalogSimParams."
@@ -605,11 +608,11 @@ def test_digital_observables_parallel_off() -> None:
     result = Simulator(parallel=False, show_progress=False).run(state, circuit, sim_params, noise_model)
 
     expected_z = [
-        0.6731226288088834,
-        0.8628191799824898,
-        0.8686777017191668,
-        0.862819175965271,
-        0.6731226287649416,
+        0.6733214071546825,
+        0.8502664720526317,
+        0.8709639049732125,
+        0.8628627940961556,
+        0.6730350827430835,
     ]
     for i in range(len(result.observables)):
         assert result.expectation_values[i] is not None, "Results was not initialized for AnalogSimParams."
@@ -1776,6 +1779,260 @@ def test_scheduled_jump_off_grid_rejected() -> None:
     )
     with pytest.raises(ValueError, match="time grid"):
         Simulator(show_progress=False).run(State(2), hamiltonian, sim_params, noise)
+
+
+def test_scheduled_jumps_rejected_for_order_2() -> None:
+    """Scheduled jumps with order=2 are rejected (incorrect dual application)."""
+    hamiltonian = Hamiltonian(matrix=np.zeros((2, 2), dtype=complex))
+    noise = NoiseModel(scheduled_jumps=[{"time": 0.1, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.3,
+        num_traj=1,
+        order=2,
+    )
+    with pytest.raises(ValueError, match="order=1"):
+        Simulator(show_progress=False).run(State(1), hamiltonian, sim_params, noise)
+
+
+def test_scheduled_jump_at_t0_order_1_flips_z() -> None:
+    """Order-1 scheduled X jump at t=0 is applied before the initial sample."""
+    hamiltonian = Hamiltonian(matrix=np.zeros((2, 2), dtype=complex))
+    noise = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.3,
+        num_traj=1,
+        order=1,
+        get_state=True,
+    )
+    result = Simulator(show_progress=False).run(State(1, initial="zeros"), hamiltonian, sim_params, noise)
+    z = np.asarray(result.expectation_values[0], dtype=float)
+    np.testing.assert_allclose(z, -1.0, atol=1e-10)
+    # Observables and final state agree after the t=0 jump.
+    assert result.output_state is not None
+    final_z = float(result.output_state.mps.expect(Observable(Z(), 0)))
+    assert final_z == pytest.approx(-1.0)
+
+
+def test_scheduled_jump_at_t0_final_only_elapsed_zero() -> None:
+    """Final-only elapsed_time=0 still records observables after a t=0 scheduled jump."""
+    hamiltonian = Hamiltonian(matrix=np.zeros((2, 2), dtype=complex))
+    noise = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.0,
+        num_traj=1,
+        order=1,
+        sample_timesteps=False,
+        get_state=True,
+    )
+    result = Simulator(show_progress=False).run(State(1, initial="zeros"), hamiltonian, sim_params, noise)
+    z = float(np.asarray(result.expectation_values[0], dtype=complex).reshape(-1)[0].real)
+    assert result.output_state is not None
+    final_z = float(result.output_state.mps.expect(Observable(Z(), 0)))
+    assert z == pytest.approx(-1.0)
+    assert final_z == pytest.approx(-1.0)
+    assert z == pytest.approx(final_z)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_time", "sample_timesteps"),
+    [
+        (0.0, True),
+        (0.0, False),
+        (0.1, False),
+    ],
+)
+def test_order_2_short_runs_return_observables_and_state(elapsed_time: float, *, sample_timesteps: bool) -> None:
+    """Order-2 TJM handles elapsed_time in {0, dt} without IndexError or empty results."""
+    hamiltonian = Hamiltonian.ising(2, J=1.0, g=0.5)
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=elapsed_time,
+        num_traj=1,
+        order=2,
+        sample_timesteps=sample_timesteps,
+        get_state=True,
+        random_seed=0,
+    )
+    result = Simulator(show_progress=False).run(State(2, initial="zeros"), hamiltonian, sim_params)
+    z = np.asarray(result.expectation_values[0], dtype=complex).reshape(-1)
+    assert result.output_state is not None
+    assert np.isfinite(z.real).all()
+    # |0> has Z=+1 at t=0; short unitary evolution keeps |Z| near 1.
+    assert np.all(np.abs(z.real) > 0.5)
+
+    if elapsed_time == pytest.approx(0.1) and not sample_timesteps:
+        sampled = Simulator(show_progress=False).run(
+            State(2, initial="zeros"),
+            hamiltonian,
+            AnalogSimParams(
+                observables=[Observable(Z(), 0)],
+                dt=0.1,
+                elapsed_time=0.1,
+                num_traj=1,
+                order=2,
+                sample_timesteps=True,
+                get_state=True,
+                random_seed=0,
+            ),
+        )
+        z_sampled_final = float(np.asarray(sampled.expectation_values[0], dtype=complex).reshape(-1)[-1].real)
+        assert float(z.real[0]) == pytest.approx(z_sampled_final, abs=1e-10)
+
+
+def test_order_2_zero_duration_final_only_skips_noise() -> None:
+    """Final-only elapsed_time=0 must not apply F0 noise before measuring."""
+    hamiltonian = Hamiltonian(matrix=np.zeros((2, 2), dtype=complex))
+    # Lowering on |+>: unwanted F0 half-step dissipation shifts Z away from 0 (~0.025).
+    noise = NoiseModel([{"name": "lowering", "sites": [0], "strength": 1.0}])
+    sampled = Simulator(show_progress=False).run(
+        State(1, initial="x+"),
+        hamiltonian,
+        AnalogSimParams(
+            observables=[Observable(Z(), 0)],
+            dt=0.1,
+            elapsed_time=0.0,
+            num_traj=1,
+            order=2,
+            sample_timesteps=True,
+            random_seed=0,
+        ),
+        noise,
+    )
+    final_only = Simulator(show_progress=False).run(
+        State(1, initial="x+"),
+        hamiltonian,
+        AnalogSimParams(
+            observables=[Observable(Z(), 0)],
+            dt=0.1,
+            elapsed_time=0.0,
+            num_traj=1,
+            order=2,
+            sample_timesteps=False,
+            random_seed=0,
+        ),
+        noise,
+    )
+    z_sampled = float(np.asarray(sampled.expectation_values[0], dtype=complex).reshape(-1)[0].real)
+    z_final = float(np.asarray(final_only.expectation_values[0], dtype=complex).reshape(-1)[0].real)
+    assert z_sampled == pytest.approx(0.0, abs=1e-10)
+    assert z_final == pytest.approx(0.0, abs=1e-10)
+    assert z_final == pytest.approx(z_sampled, abs=1e-10)
+
+
+def test_order_2_sample_rng_is_per_timestep_not_sequential() -> None:
+    """Each measurement copy must get a fresh sample RNG keyed by timestep index."""
+    hamiltonian = MPO.from_matrix(np.zeros((2, 2), dtype=complex), d=2)
+    noise = NoiseModel([{"name": "pauli_z", "sites": [0], "strength": 1.0}])
+    state = State(1, initial="x+").ensure_encoded("mps").mps
+    # Intended three-point grid [0, dt, 2*dt]; sample calls at indices 1 and 2.
+    dt = 0.1
+    elapsed_time = 0.2
+
+    class _ScriptedRng:
+        """Deterministic jump draws: ``random()`` then optional ``choice()``."""
+
+        def __init__(self, randoms: list[float], choices: list[int] | None = None) -> None:
+            self._randoms = list(randoms)
+            self._choices = list(choices or [])
+            self._ri = 0
+            self._ci = 0
+
+        def random(self) -> float:
+            value = self._randoms[self._ri]
+            self._ri += 1
+            return value
+
+        def choice(self, a: int, p: list[float] | None = None) -> int:
+            _ = (a, p)
+            value = self._choices[self._ci] if self._ci < len(self._choices) else 0
+            self._ci += 1
+            return value
+
+    def _run(*, sample_timesteps: bool) -> list[int]:
+        timesteps: list[int] = []
+
+        def _tracking_sample_rng(traj_idx: int, *, base_seed: int | None, timestep: int) -> np.random.Generator:
+            timesteps.append(timestep)
+            return make_sample_rng(traj_idx, base_seed=base_seed, timestep=timestep)
+
+        sim_params = AnalogSimParams(
+            observables=[Observable(X(), 0)],
+            dt=dt,
+            elapsed_time=elapsed_time,
+            num_traj=1,
+            order=2,
+            sample_timesteps=sample_timesteps,
+            random_seed=0,
+        )
+        assert np.allclose(sim_params.times, [0.0, 0.1, 0.2])
+        with patch("mqt.yaqs.analog.analog_tjm.make_sample_rng", side_effect=_tracking_sample_rng):
+            analog_tjm_2((0, state, noise, sim_params, hamiltonian))
+        return timesteps
+
+    sampled_steps = _run(sample_timesteps=True)
+    final_steps = _run(sample_timesteps=False)
+    assert sampled_steps == [1, 2]
+    assert final_steps == [2]
+
+    # Shared sequential RNG: first sample consumes the jump draw; final sample then skips.
+    # Final-only starts at the same script and jumps. Outcomes must differ.
+    def _shared_factory(randoms: list[float], choices: list[int]) -> object:
+        shared = _ScriptedRng(randoms, choices)
+
+        def _factory(traj_idx: int, *, base_seed: int | None, timestep: int) -> _ScriptedRng:
+            _ = (traj_idx, base_seed, timestep)
+            return shared
+
+        return _factory
+
+    with patch(
+        "mqt.yaqs.analog.analog_tjm.make_sample_rng",
+        side_effect=_shared_factory([0.0, 0.999], [0]),
+    ):
+        sampled_bug = analog_tjm_2((
+            0,
+            state,
+            noise,
+            AnalogSimParams(
+                observables=[Observable(X(), 0)],
+                dt=dt,
+                elapsed_time=elapsed_time,
+                num_traj=1,
+                order=2,
+                sample_timesteps=True,
+                random_seed=0,
+            ),
+            hamiltonian,
+        ))
+    with patch(
+        "mqt.yaqs.analog.analog_tjm.make_sample_rng",
+        side_effect=_shared_factory([0.0, 0.999], [0]),
+    ):
+        final_bug = analog_tjm_2((
+            0,
+            state,
+            noise,
+            AnalogSimParams(
+                observables=[Observable(X(), 0)],
+                dt=dt,
+                elapsed_time=elapsed_time,
+                num_traj=1,
+                order=2,
+                sample_timesteps=False,
+                random_seed=0,
+            ),
+            hamiltonian,
+        ))
+    x_sampled = float(np.asarray(sampled_bug[0][0], dtype=complex).reshape(-1)[-1].real)
+    x_final = float(np.asarray(final_bug[0][0], dtype=complex).reshape(-1)[0].real)
+    assert x_sampled != pytest.approx(x_final, abs=1e-12)
 
 
 def test_digital_rejects_nonadjacent_noise_matching_and_nonmatching() -> None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1731,3 +1731,85 @@ def test_simulator_run_qasm_path_and_string_observables_match(tmp_path: Path) ->
     path_result = Simulator(parallel=False, show_progress=False).run(state, qasm_path, sim_params)
     string_result = Simulator(parallel=False, show_progress=False).run(state, LARGE_QASM2_STRING, sim_params)
     np.testing.assert_array_equal(path_result.expectation_values[0], string_result.expectation_values[0])
+
+
+def test_scheduled_jumps_rejected_for_mcwf_and_lindblad() -> None:
+    """Scheduled jumps are unsupported outside single-State analog MPS TJM."""
+    hamiltonian = Hamiltonian.ising(2, J=1.0, g=0.5)
+    noise = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.1,
+        num_traj=1,
+    )
+    for representation in ("vector", "density_matrix"):
+        state = State(2, representation=representation)
+        with pytest.raises(ValueError, match="scheduled_jumps"):
+            Simulator(show_progress=False).run(state, hamiltonian, sim_params, noise)
+
+
+def test_scheduled_jumps_rejected_for_ensemble() -> None:
+    """list[State] unitary ensemble rejects scheduled jumps."""
+    hamiltonian = Hamiltonian.ising(2, J=1.0, g=0.5)
+    noise = NoiseModel(scheduled_jumps=[{"time": 0.0, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.1,
+        num_traj=1,
+    )
+    states = [State(2), State(2)]
+    with pytest.raises(ValueError, match="scheduled_jumps"):
+        Simulator(show_progress=False).run(states, hamiltonian, sim_params, noise)
+
+
+def test_scheduled_jump_off_grid_rejected() -> None:
+    """Scheduled jump times must lie on sim_params.times."""
+    hamiltonian = Hamiltonian.ising(2, J=1.0, g=0.5)
+    noise = NoiseModel(scheduled_jumps=[{"time": 0.05, "sites": [0], "name": "x"}])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.2,
+        num_traj=1,
+    )
+    with pytest.raises(ValueError, match="time grid"):
+        Simulator(show_progress=False).run(State(2), hamiltonian, sim_params, noise)
+
+
+def test_digital_rejects_nonadjacent_noise_matching_and_nonmatching() -> None:
+    """Digital TJM rejects non-adjacent factorized noise even if a gate shares endpoints."""
+    circuit = QuantumCircuit(3)
+    circuit.cx(0, 2)  # matching endpoints for sites [0, 2]
+    noise_match = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.01},
+    ])
+    noise_other = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.01},
+    ])
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], num_traj=1, max_bond_dim=8)
+    with pytest.raises(ValueError, match="Digital TJM does not support non-adjacent"):
+        Simulator(show_progress=False).run(State(3), circuit, sim_params, noise_match)
+
+    circuit2 = QuantumCircuit(3)
+    circuit2.cx(0, 1)  # non-matching endpoints
+    with pytest.raises(ValueError, match="Digital TJM does not support non-adjacent"):
+        Simulator(show_progress=False).run(State(3), circuit2, sim_params, noise_other)
+
+
+def test_analog_longrange_crosstalk_xy_mps_runs() -> None:
+    """Documented longrange_crosstalk_xy works on analog MPS TJM."""
+    hamiltonian = Hamiltonian.ising(3, J=1.0, g=0.5)
+    noise = NoiseModel([
+        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.05},
+    ])
+    sim_params = AnalogSimParams(
+        observables=[Observable(Z(), 0)],
+        dt=0.1,
+        elapsed_time=0.2,
+        num_traj=2,
+        random_seed=0,
+    )
+    result = Simulator(show_progress=False).run(State(3), hamiltonian, sim_params, noise)
+    assert result.expectation_values[0].shape[0] >= 1

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -2039,20 +2039,17 @@ def test_digital_rejects_nonadjacent_noise_matching_and_nonmatching() -> None:
     """Digital TJM rejects non-adjacent factorized noise even if a gate shares endpoints."""
     circuit = QuantumCircuit(3)
     circuit.cx(0, 2)  # matching endpoints for sites [0, 2]
-    noise_match = NoiseModel([
-        {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.01},
-    ])
-    noise_other = NoiseModel([
+    noise = NoiseModel([
         {"name": "longrange_crosstalk_xy", "sites": [0, 2], "strength": 0.01},
     ])
     sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], num_traj=1, max_bond_dim=8)
     with pytest.raises(ValueError, match="Digital TJM does not support non-adjacent"):
-        Simulator(show_progress=False).run(State(3), circuit, sim_params, noise_match)
+        Simulator(show_progress=False).run(State(3), circuit, sim_params, noise)
 
     circuit2 = QuantumCircuit(3)
     circuit2.cx(0, 1)  # non-matching endpoints
     with pytest.raises(ValueError, match="Digital TJM does not support non-adjacent"):
-        Simulator(show_progress=False).run(State(3), circuit2, sim_params, noise_other)
+        Simulator(show_progress=False).run(State(3), circuit2, sim_params, noise)
 
 
 def test_analog_longrange_crosstalk_xy_mps_runs() -> None:


### PR DESCRIPTION
## Description

This PR adds errors at the front of the simulation for validating if a noise model is correct and usable. Previously, an error would be thrown only once a certain depth into the simulation has been reached. This allows the user to have quick and exact feedback with more precise error messages.

Additionally, the total elapsed time of an analog simulation must be an integer multiple of the timestep size. This was made intentionally robust such that floating point values and very small timesteps should not throw errors.

Finally, the RNG seeding has been stabilized to avoid accidentally running the same seed due to some previous internal choices in randomizing individual trajectories.

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/yaqs/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
