### PR TITLE
🐛 Fix non-canonical truncation in two-qubit TEBD gate application

### DIFF
--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -238,10 +238,10 @@ Digital circuit simulation on an MPS defaults to **`gate_mode="mpo"`** (generic
 MPO--MPS application): nearest-neighbor gates use the same local TEBD/SVD path
 as `swaps` (the orthogonality center is moved onto the gate pair first, so the
 truncated SVD discards the smallest Schmidt coefficients of the state), and
-long-range gates contract an extended gate MPO site-wise
-(library leg ordering, MPS virtual index before MPO virtual index) followed by
-compression with `svd_threshold` and `max_bond_dim`. Other modes differ only in
-how two-qubit gates are applied:
+long-range gates contract an extended gate MPO site-wise (library leg ordering,
+MPS virtual index before MPO virtual index) followed by compression with
+`svd_threshold` and `max_bond_dim`. Other modes differ only in how two-qubit
+gates are applied:
 
 - **`swaps`** — TEBD/SVD for every two-qubit gate; long-range gates are routed
   with adjacent SWAP insertion before and after the local update.

--- a/docs/examples/simulation_parameters.md
+++ b/docs/examples/simulation_parameters.md
@@ -236,7 +236,9 @@ sampling with `sample_layers=True` (see {doc}`circuit_observables`).
 
 Digital circuit simulation on an MPS defaults to **`gate_mode="mpo"`** (generic
 MPO--MPS application): nearest-neighbor gates use the same local TEBD/SVD path
-as `swaps`, and long-range gates contract an extended gate MPO site-wise
+as `swaps` (the orthogonality center is moved onto the gate pair first, so the
+truncated SVD discards the smallest Schmidt coefficients of the state), and
+long-range gates contract an extended gate MPO site-wise
 (library leg ordering, MPS virtual index before MPO virtual index) followed by
 compression with `svd_threshold` and `max_bond_dim`. Other modes differ only in
 how two-qubit gates are applied:

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -306,6 +306,11 @@ def apply_two_qubit_gate_tebd(
 ) -> tuple[int, int]:
     """Apply a two-qubit gate via TEBD/SVD, inserting adjacent SWAPs if needed.
 
+    The orthogonality center is moved onto the gate pair before the two-site split,
+    so the SVD truncation is performed in a canonical gauge. Truncating in any other
+    gauge is not equivalent to discarding the smallest Schmidt values of the state and
+    can leave errors far above the optimal truncation error at the same bond dimension.
+
     Args:
         state: MPS updated in place.
         gate: Internal gate object from the gate library.
@@ -343,6 +348,13 @@ def apply_two_qubit_gate_tebd(
     left_site = min(site0, site1)
     right_site = max(site0, site1)
     u_gate = resolve_lr_tensor(gate, left_site, right_site)
+
+    # The truncated split below is optimal only if the orthogonality center lies on
+    # the gate pair; establish that gauge first (cf. apply_window and MPS.compress).
+    if state.orthogonality_center is None:
+        state.set_canonical_form(left_site)
+    elif state.orthogonality_center not in {left_site, right_site}:
+        state.shift_center_to(left_site)
 
     left_tensor = state.tensors[left_site]
     right_tensor = state.tensors[right_site]

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -24,6 +24,7 @@ from qiskit.converters import circuit_to_dag
 from qiskit.quantum_info import Pauli, Statevector
 
 from mqt.yaqs import DigitalSimParams, NoiseModel, Observable, Simulator, State
+from mqt.yaqs.core.data_structures.mpo_utils import resolve_lr_tensor
 from mqt.yaqs.core.data_structures.mps import MPS
 from mqt.yaqs.core.libraries.circuit_library import create_ising_circuit
 from mqt.yaqs.core.libraries.gate_library import GateLibrary, X, Y, Z
@@ -2356,3 +2357,102 @@ def test_obs_order_aligned() -> None:
         expected = float(np.real(Statevector(vec).expectation_value(Pauli("".join(label)))))
         got = float(np.real(result.expectation_values[i][-1]))
         assert got == pytest.approx(expected, abs=1e-10)
+
+
+# ---- TEBD truncation gauge --------------------------------------------------------------
+
+GAUGE_LENGTH = 8
+GAUGE_CHI = 4
+GAUGE_SEED = 7
+GAUGE_OPT_RTOL = 0.05
+
+
+def _random_capped_mps(length: int, chi: int, seed: int) -> MPS:
+    """Random right-canonical MPS with every bond at its maximal value capped by ``chi``.
+
+    Args:
+        length: Number of sites.
+        chi: Bond-dimension cap.
+        seed: RNG seed.
+
+    Returns:
+        Right-canonical MPS with the orthogonality center at site 0.
+    """
+    rng = np.random.default_rng(seed)
+    bonds = [1] + [min(chi, 2**i, 2 ** (length - i)) for i in range(1, length)] + [1]
+    tensors = [
+        rng.standard_normal((2, bonds[i], bonds[i + 1])) + 1j * rng.standard_normal((2, bonds[i], bonds[i + 1]))
+        for i in range(length)
+    ]
+    state = MPS(length=length, tensors=tensors)
+    state.normalize(form="B", decomposition="QR")
+    return state
+
+
+def _dense_state(state: MPS) -> np.ndarray:
+    """Contract an MPS into a dense array in site order.
+
+    Args:
+        state: MPS to contract.
+
+    Returns:
+        Dense state of shape ``[2] * length`` with axes in site order.
+    """
+    acc = state.tensors[0].transpose(1, 0, 2)
+    for tensor in state.tensors[1:]:
+        acc = np.tensordot(acc, tensor.transpose(1, 0, 2), axes=([acc.ndim - 1], [0]))
+    return np.asarray(acc, dtype=np.complex128).reshape([2] * state.length)
+
+
+@pytest.mark.parametrize("gauge_known", [True, False])
+@pytest.mark.parametrize("left_site", [2, 3, 4])
+def test_tebd_truncation_schmidt_optimal(left_site: int, *, gauge_known: bool) -> None:
+    """Capped TEBD must realize the optimal truncation error at the gate bond.
+
+    One nearest-neighbor gate on a state whose bonds all sit at the cap can only
+    exceed the cap at the gate bond, so the best reachable infidelity is exactly the
+    discarded Schmidt weight of the exact post-gate state at that cut. This holds only
+    if the two-site split truncates in a canonical gauge; a right-canonical chain with
+    the center at site 0 (the state every gate sees in the circuit loop) is *not* in
+    that gauge for ``left_site > 0``, and truncating anyway lands far above the optimum.
+    """
+    params = DigitalSimParams(observables=[], num_traj=1, max_bond_dim=GAUGE_CHI, svd_threshold=1e-14, get_state=True)
+
+    state = _random_capped_mps(GAUGE_LENGTH, GAUGE_CHI, GAUGE_SEED)
+    if not gauge_known:
+        state.set_center(None)
+
+    gate = GateLibrary.cx()
+    gate.set_sites(left_site, left_site + 1)
+    u_gate = resolve_lr_tensor(gate, left_site, left_site + 1)
+
+    exact = np.tensordot(u_gate, _dense_state(state), axes=([2, 3], [left_site, left_site + 1]))
+    exact = np.moveaxis(exact, [0, 1], [left_site, left_site + 1])
+
+    singular_values = np.linalg.svd(exact.reshape(2 ** (left_site + 1), -1), compute_uv=False)
+    weights = singular_values**2 / np.sum(singular_values**2)
+    optimal_infidelity = float(np.sum(weights[GAUGE_CHI:]))
+    assert optimal_infidelity > 1e-8  # non-vacuous: the cap truncates
+
+    apply_two_qubit_gate_tebd(state, gate, params)
+
+    truncated = _dense_state(state).reshape(-1)
+    exact_vec = exact.reshape(-1)
+    overlap = np.abs(np.vdot(exact_vec, truncated)) ** 2
+    achieved = float(abs(1.0 - overlap / (np.vdot(exact_vec, exact_vec).real * np.vdot(truncated, truncated).real)))
+
+    assert achieved <= optimal_infidelity * (1.0 + GAUGE_OPT_RTOL) + 1e-12
+    assert state.orthogonality_center == left_site + 1
+
+
+def test_tebd_establishes_canonical_gauge() -> None:
+    """TEBD leaves a valid mixed-canonical state with the center on the gate pair."""
+    params = DigitalSimParams(observables=[], num_traj=1, max_bond_dim=GAUGE_CHI, svd_threshold=1e-14, get_state=True)
+    state = _random_capped_mps(GAUGE_LENGTH, GAUGE_CHI, GAUGE_SEED)
+
+    gate = GateLibrary.cx()
+    gate.set_sites(4, 5)
+    apply_two_qubit_gate_tebd(state, gate, params)
+
+    assert state.orthogonality_center == 5
+    assert state.check_canonical_form()[0] == 5


### PR DESCRIPTION
In this PR we fix Issue #530 by simply shifting the orthogonality center onto the gate pair, then truncate — `shift_center_to` when the center is tracked, `set_canonical_form` when the gauge is unknown, nothing when it is already on the pair (which keeps consecutive SWAP-chain splits O(1)). 

- This mirrors what `apply_window` and `MPS.compress` already do; the TEBD path was the only truncating path without the move. Every `gate_mode` benefits, since all route nearest-neighbor gates through it.

## Benchmark Results:

The cleanest measurement: a random right-canonical MPS with **every** bond already at the cap (`N = 12`, `chi = 8`), then one nearest-neighbor CX. Only the gate bond can exceed the cap, so the best infidelity *any* method could reach is exactly the discarded Schmidt weight of the true post-gate state at that cut — a closed-form lower bound, no reference simulator involved.

| gate at `(a, a+1)` | optimal (lower bound) | main (`main`) | main/ optimal |
|---|---|---|---|
| a = 3 | 1.18e-03 | 3.33e-02 | **28.1×** |
| a = 4 | 3.65e-03 | 4.10e-02 | **11.2×** |
| a = 5 | 5.32e-03 | 2.05e-02 | **3.8×** |
| a = 6 | 3.11e-03 | 2.10e-02 | **6.7×** |
| a = 7 | 2.17e-03 | 1.23e-02 | **5.7×** |

With the gauge established before the split, the achieved infidelity lands **exactly on the bound** (ratio 1.000) at every position — panel (a) below. Over full circuits the per-gate excess compounds — panel (b), Haar-1q + Heisenberg-NN brickwork run through the production `Simulator`: both arms are exact while the cap is inactive (the silent phase), then separate by 29× (`chi = 16`) up to 39 000× (`chi = 32`):

<img width="2655" height="963" alt="Image" src="https://github.com/user-attachments/assets/00accd39-f3b1-4fd5-ac81-98f50fa9ca7e" />

## Minimal reproducer of the issue: 

<details>
<summary>Standalone script (YAQS + numpy only) — prints achieved vs optimal per gate position</summary>

```python
import numpy as np
from mqt.yaqs.core.data_structures.mps import MPS
from mqt.yaqs.core.data_structures.simulation_parameters import DigitalSimParams
from mqt.yaqs.core.data_structures.mpo_utils import resolve_lr_tensor
from mqt.yaqs.core.libraries.gate_library import GateLibrary
from mqt.yaqs.digital.digital_tjm import apply_two_qubit_gate_tebd

N, CHI, SEED = 12, 8, 7

def dense(tensors):
    acc = tensors[0].transpose(1, 0, 2)
    for t in tensors[1:]:
        acc = np.tensordot(acc, t.transpose(1, 0, 2), axes=([acc.ndim - 1], [0]))
    return acc.reshape([2] * N)

def random_mps(n, chi, seed):
    rng = np.random.default_rng(seed)
    bonds = [1] + [min(chi, 2**i, 2 ** (n - i)) for i in range(1, n)] + [1]
    tens = [(rng.standard_normal((2, bonds[i], bonds[i + 1]))
             + 1j * rng.standard_normal((2, bonds[i], bonds[i + 1]))) for i in range(n)]
    s = MPS(length=n, tensors=tens)
    s.normalize(form="B", decomposition="QR")   # right-canonical, center at site 0
    return s

def infid(a, b):
    a, b = a.reshape(-1), b.reshape(-1)
    return abs(1.0 - abs(np.vdot(a, b)) ** 2 / (np.vdot(a, a).real * np.vdot(b, b).real))

params = DigitalSimParams(observables=[], num_traj=1, max_bond_dim=CHI,
                          svd_threshold=1e-14, get_state=True)
print("gate at (a, a+1) | optimal (discarded Schmidt weight) | achieved | ratio")
for a in range(3, 8):
    st = random_mps(N, CHI, SEED)
    gate = GateLibrary.cx(); gate.set_sites(a, a + 1)
    u = resolve_lr_tensor(gate, a, a + 1)
    exact = np.moveaxis(np.tensordot(u, dense(st.tensors), axes=([2, 3], [a, a + 1])),
                        [0, 1], [a, a + 1])
    sv = np.linalg.svd(exact.reshape(2 ** (a + 1), -1), compute_uv=False)
    w = sv**2 / (sv**2).sum()
    opt = float(w[CHI:].sum())                  # the best ANY rank-chi truncation can do
    apply_two_qubit_gate_tebd(st, gate, params)
    ach = infid(exact, dense(st.tensors))
    print(f"  a = {a}       |  {opt:.3e}  |  {ach:.3e}  |  {ach / opt:6.2f}x")
```

On `main` the ratios are 3.8×–28×; a correct truncation prints 1.00 at every position.

</details>


## Follow up investigation: 
The added gauge shifts cost ~30% wall time on an N=12 brickwork benchmark; the per-gate `normalize("B")` in the noiseless loop is now partially redundant and could be dropped in a follow-up to reclaim that.