### PR TITLE
sped up normalization in circuit simulation and fixed TDVP state tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- replaced per-gate full-chain renormalization with an orthogonality-center
+  rescale ([#560]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])
 - dropped support for Python 3.10 ([#556]) ([**@denialhaag**])
 - updated BUG to use alternating endpoint root ([#539]) ([**@aaronleesander**])
@@ -257,6 +259,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#567]: https://github.com/munich-quantum-toolkit/yaqs/pull/567
+[#560]: https://github.com/munich-quantum-toolkit/yaqs/pull/560
 [#545]: https://github.com/munich-quantum-toolkit/yaqs/pull/545
 [#556]: https://github.com/munich-quantum-toolkit/yaqs/pull/556
 [#553]: https://github.com/munich-quantum-toolkit/yaqs/pull/553

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
-- sped up normalization in circuit simulation and fix TDVP state tracking ([#560]) ([**@Pouri96**])
+- sped up normalization in circuit simulation and fixed TDVP state tracking
+  ([#560]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])
 - dropped support for Python 3.10 ([#556]) ([**@denialhaag**])
 - updated BUG to use alternating endpoint root ([#539]) ([**@aaronleesander**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ releases may include breaking changes.
 
 ### Changed
 
-- replaced per-gate full-chain renormalization with an orthogonality-center
-  rescale ([#560]) ([**@Pouri96**])
+- sped up normalization in circuit simulation and fix TDVP state tracking ([#560]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])
 - dropped support for Python 3.10 ([#556]) ([**@denialhaag**])
 - updated BUG to use alternating endpoint root ([#539]) ([**@aaronleesander**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
-- sped up normalization in circuit simulation and fix TDVP state tracking ([#560]) ([**@Pouri96**])
+- sped up normalization in circuit simulation and fix TDVP state tracking
+  ([#560]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])
 - dropped support for Python 3.10 ([#556]) ([**@denialhaag**])
 - updated BUG to use alternating endpoint root ([#539]) ([**@aaronleesander**])

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -717,6 +717,7 @@ def digital_tjm(
         diagnostics = np.zeros((3, num_cols), dtype=np.float64)
         n_obs = len(sim_params.sorted_observables)
         if sim_params.sample_layers:
+            state.normalize(form="B", decomposition="QR")
             results = np.zeros((n_obs, mid + 2))
             state.record_diagnostics(diagnostics, 0)
             if wants_obs:

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -313,16 +313,18 @@ def _renormalize(state: MPS) -> None:
         state: MPS normalized in place.
 
     Raises:
-        ValueError: If the orthogonality-center tensor has zero or non-finite norm.
+        ValueError: If the MPS norm is zero or non-finite.
     """
+    msg = "Cannot normalize MPS: norm is zero or non-finite."
     center = state.orthogonality_center
     if center is None:
-        state.normalize(form="B", decomposition="QR")
-        return
+        if not all(np.isfinite(tensor).all() for tensor in state.tensors):
+            raise ValueError(msg)
+        center = 0
+        state.set_canonical_form(center, decomposition="QR")
     center_tensor = state.tensors[center]
     norm = float(np.linalg.norm(center_tensor))
     if norm <= 0.0 or not np.isfinite(norm):
-        msg = "Cannot normalize MPS: orthogonality-center tensor norm is zero or non-finite."
         raise ValueError(msg)
     state.tensors[center] = center_tensor / norm
 
@@ -463,13 +465,12 @@ def apply_two_qubit_gate_tdvp(
     mpo, first_site, last_site = construct_generator_mpo(gate, state.length, state.physical_dimensions)
 
     window_size = 1
-    gauge_known = state.orthogonality_center is not None
     short_state, short_mpo, window = apply_window(state, mpo, first_site, last_site, window_size)
 
     evolve_window(short_state, short_mpo, sim_params)
     for i in range(window[0], window[1] + 1):
         state.tensors[i] = short_state.tensors[i - window[0]]
-    if gauge_known and short_state.orthogonality_center is not None:
+    if short_state.orthogonality_center is not None:
         state.set_center(window[0] + short_state.orthogonality_center)
     else:
         state.set_center(None)

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -301,6 +301,27 @@ def process_layer(dag: DAGCircuit) -> tuple[list[DAGOpNode], list[DAGOpNode], li
     return single_qubit_nodes, even_nodes, odd_nodes, measure_barriers
 
 
+def _renormalize(state: MPS) -> None:
+    """Normalize ``state`` in place, rescaling the center tensor when the gauge is known.
+
+    With the orthogonality center tracked at site ``c``, every other tensor is an
+    isometry and ``||psi|| == ||tensors[c]||_F``, so dividing that one tensor by its
+    Frobenius norm normalizes the state without touching the rest of the chain. The
+    center is left where it is; an unknown gauge falls back to a full-chain sweep.
+
+    Args:
+        state: MPS normalized in place.
+    """
+    center = state.orthogonality_center
+    if center is None:
+        state.normalize(form="B", decomposition="QR")
+        return
+    center_tensor = state.tensors[center]
+    norm = float(np.linalg.norm(center_tensor))
+    if norm > 0.0:
+        state.tensors[center] = center_tensor / norm
+
+
 def _apply_single_qubit_gate(state: MPS, gate: BaseGate) -> None:
     """Apply one translated single-qubit gate to an MPS in place."""
     site = gate.sites[0]
@@ -711,13 +732,16 @@ def digital_tjm(
                 _first_site, _last_site = _apply_two_qubit_gate(state, gate, sim_params)
 
                 if not noisy:
-                    state.normalize(form="B", decomposition="QR")
+                    _renormalize(state)
                 else:
                     local_noise_model = create_local_noise_model(noise_model, gate.sites)
                     apply_dissipation(state, local_noise_model, dt=1, sim_params=sim_params)
                     state = stochastic_process(state, local_noise_model, dt=1, sim_params=sim_params, rng=rng)
 
-        if sim_params.sample_layers:
+        if sim_params.sample_layers and layer.sample_points:
+            # Bond-dimension diagnostics and the entropy observables read the tensors
+            # directly, so sample them in B form as before.
+            state.normalize(form="B", decomposition="QR")
             for _ in range(layer.sample_points):
                 col_idx += 1
                 assert diagnostics is not None
@@ -726,6 +750,9 @@ def digital_tjm(
                 state.evaluate_observables(sim_params, results, col_idx)
 
     counts: dict[int, int] | None = None
+    # The gate loop leaves the center on the last gate; returned states and following
+    # analog segments are handed the chain in B form.
+    state.normalize(form="B", decomposition="QR")
     final = state if sim_params.get_state else None
 
     if shots_only:
@@ -733,9 +760,6 @@ def digital_tjm(
         per_call = _per_call_shots(sim_params, traj_idx) if has_explicit_shot_plan or not noisy else 1
         counts = state.measure_shots(per_call) if per_call > 0 else {}
         return None, None, counts, final
-
-    if state.orthogonality_center is None:
-        state.normalize(form="B", decomposition="QR")
 
     assert diagnostics is not None
     assert results is not None

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -325,9 +325,9 @@ def _renormalize(state: MPS) -> None:
 def _apply_single_qubit_gate(state: MPS, gate: BaseGate) -> None:
     """Apply one translated single-qubit gate to an MPS in place."""
     site = gate.sites[0]
+    # Circuit translation admits only unitary single-site gates, which preserve
+    # left- and right-canonicality, so the tracked center stays valid.
     state.tensors[site] = oe.contract("ab, bcd->acd", gate.tensor, state.tensors[site])
-    if state.orthogonality_center is not None and state.orthogonality_center != site:
-        state.set_center(None)
 
 
 def apply_single_qubit_gate(state: MPS, node: DAGOpNode) -> None:

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -377,11 +377,12 @@ def apply_window(state: MPS, mpo: MPO, first_site: int, last_site: int, window_s
     window[0] = max(window[0], 0)
     window[1] = min(window[1], state.length - 1)
 
-    # Shift the orthogonality center to the start of the window.
+    # Shift the orthogonality center to the start of the window. ``sweep_2site`` seeds a
+    # left environment of identity and takes the window as right-canonical, so the center
+    # must sit on the window's first site, not merely inside the window.
     if state.orthogonality_center is not None:
         rel_center = state.orthogonality_center - window[0]
-        window_len = window[1] - window[0] + 1
-        if rel_center < 0 or rel_center >= window_len:
+        if rel_center != 0:
             state.shift_center_to(window[0])
             rel_center = 0
     else:
@@ -443,12 +444,13 @@ def apply_two_qubit_gate_tdvp(
     evolve_window(short_state, short_mpo, sim_params)
     for i in range(window[0], window[1] + 1):
         state.tensors[i] = short_state.tensors[i - window[0]]
-    if uses_fixed_chi(sim_params):
-        renorm_drift(state, sim_params)
     if gauge_known and short_state.orthogonality_center is not None:
         state.set_center(window[0] + short_state.orthogonality_center)
     else:
         state.set_center(None)
+    # After the graft, so that a drift renormalization's own gauge is the one recorded.
+    if uses_fixed_chi(sim_params):
+        renorm_drift(state, sim_params)
 
     return first_site, last_site
 

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -412,9 +412,8 @@ def apply_window(state: MPS, mpo: MPO, first_site: int, last_site: int, window_s
             state.shift_center_to(window[0])
             rel_center = 0
     else:
-        for i in range(window[0]):
-            state.shift_orthogonality_center_right(i)
-        rel_center = None
+        state.set_canonical_form(window[0], decomposition="QR")
+        rel_center = 0
 
     short_mpo = MPO()
     short_mpo.custom(mpo.tensors[window[0] : window[1] + 1], transpose=False)

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -311,6 +311,9 @@ def _renormalize(state: MPS) -> None:
 
     Args:
         state: MPS normalized in place.
+
+    Raises:
+        ValueError: If the orthogonality-center tensor has zero or non-finite norm.
     """
     center = state.orthogonality_center
     if center is None:
@@ -318,8 +321,10 @@ def _renormalize(state: MPS) -> None:
         return
     center_tensor = state.tensors[center]
     norm = float(np.linalg.norm(center_tensor))
-    if norm > 0.0:
-        state.tensors[center] = center_tensor / norm
+    if norm <= 0.0 or not np.isfinite(norm):
+        msg = "Cannot normalize MPS: orthogonality-center tensor norm is zero or non-finite."
+        raise ValueError(msg)
+    state.tensors[center] = center_tensor / norm
 
 
 def _apply_single_qubit_gate(state: MPS, gate: BaseGate) -> None:

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -2814,12 +2814,22 @@ def test_layer_sampling_reads_the_state_in_b_form() -> None:
     original = MPS.record_diagnostics
 
     def recording(self: MPS, diagnostics: NDArray[np.float64], column_index: int) -> None:
+        """Record the center before writing a diagnostics column.
+
+        Args:
+            self: MPS being sampled.
+            diagnostics: Array that stores diagnostic values.
+            column_index: Column to fill.
+        """
         centers.append(self.orthogonality_center)
         original(self, diagnostics, column_index)
 
+    initial_mps = _random_capped_mps(6, GAUGE_CHI, GAUGE_SEED)
+    initial_mps.shift_center_to(4)
+    assert initial_mps.orthogonality_center == 4
     sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], gate_mode="mpo", preset="exact", sample_layers=True)
     with patch.object(MPS, "record_diagnostics", recording):
-        Simulator(parallel=False, show_progress=False).run(State(6, initial="zeros"), qc, sim_params, None)
+        Simulator(parallel=False, show_progress=False).run(State.from_mps(initial_mps), qc, sim_params, None)
 
     assert len(centers) >= 3  # initial sample, one per barrier, and the final column
     assert set(centers) == {0}

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1104,17 +1104,41 @@ def test_mixed_gate2_norm_unit() -> None:
 
 
 @pytest.mark.parametrize("chi", [16, 32])
-def test_mixed_zeros_full(chi: int) -> None:
-    """Full mixed_small L=10 zeros circuit matches exact evolution under hybrid TDVP."""
+@pytest.mark.tdvp_regression
+def test_mixed_zeros_full_replay_matches_the_simulator(chi: int) -> None:
+    """Replaying gates through the public API gives what the circuit loop gives.
+
+    The replay applies gates back to back without the loop's per-gate renormalization,
+    so it reaches ``apply_two_qubit_gate`` with the center wherever the previous gate
+    left it. The gate application gauges the window itself, so both routes agree.
+    """
+    qc = _mixed_small_zeros_circuit(MIXED_SMALL_ZEROS_LENGTH)
+    params = _hybrid_tdvp_replay_params(max_bond_dim=chi)
+    state = _replay_hybrid_tdvp_through_gate(qc, len(list(circuit_to_dag(qc).topological_op_nodes())), params=params)
+    assert abs(float(state.mps.norm()) - 1.0) < NORM_TOL
+
+    loop_params = _hybrid_tdvp_replay_params(max_bond_dim=chi)
+    loop_params.observables = [Observable(Z(), 0)]
+    result = Simulator(parallel=False, show_progress=False).run(
+        State(MIXED_SMALL_ZEROS_LENGTH, initial="zeros"), qc, loop_params, None
+    )
+    assert result.output_state is not None
+    assert _fidelity(result.output_state.mps.to_vec(), state.mps.to_vec()) == pytest.approx(1.0, abs=1e-10)
+
+
+@pytest.mark.parametrize("chi", [16, 32])
+@pytest.mark.tdvp_regression
+@pytest.mark.xfail(
+    reason="a long-range generator gate is under-applied once a preceding two-qubit gate has "
+    "changed the bond structure; gate_mode='mpo' is exact on the same circuit",
+    strict=True,
+)
+def test_mixed_zeros_full_is_exact(chi: int) -> None:
+    """The hybrid TDVP route should reproduce the exact state for this circuit."""
     qc = _mixed_small_zeros_circuit(MIXED_SMALL_ZEROS_LENGTH)
     ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
     params = _hybrid_tdvp_replay_params(max_bond_dim=chi)
-    state = _replay_hybrid_tdvp_through_gate(
-        qc,
-        len(list(circuit_to_dag(qc).topological_op_nodes())),
-        params=params,
-    )
-    assert abs(float(state.mps.norm()) - 1.0) < NORM_TOL
+    state = _replay_hybrid_tdvp_through_gate(qc, len(list(circuit_to_dag(qc).topological_op_nodes())), params=params)
     assert _fidelity(ref, state.mps.to_vec()) > 0.99
 
 
@@ -2602,6 +2626,51 @@ def test_tebd_establishes_canonical_gauge() -> None:
 
     assert state.orthogonality_center == 5
     assert state.check_canonical_form()[0] == 5
+
+
+# ---- windowed TDVP gauge ----------------------------------------------------------------
+
+WINDOW_LENGTH = 10
+WINDOW_SEED = 11
+
+
+@pytest.mark.parametrize("center", [0, 4, 9])
+def test_windowed_tdvp_gate_is_exact_for_any_incoming_center(center: int) -> None:
+    """An uncapped windowed RZZ must reproduce the exact gate wherever the center starts.
+
+    ``sweep_2site`` takes its window right-canonical from the first site, so a center left
+    anywhere else has to be moved there first. A center on the window's last site is the
+    case that bites: with the window's right edge at the chain end there is no dangling
+    bond to absorb the mismatch.
+    """
+    theta = 0.6
+    sites = (1, WINDOW_LENGTH - 2)  # window [0, 9] — right edge is the chain end
+    state = _random_capped_mps(WINDOW_LENGTH, GAUGE_CHI, WINDOW_SEED)
+    eigenvalues = np.array([1.0, -1.0])
+    phases = np.exp(-0.5j * theta * np.multiply.outer(eigenvalues, eigenvalues))
+    expected = _dense_state(state) * phases.reshape([2 if site in sites else 1 for site in range(WINDOW_LENGTH)])
+
+    state.shift_center_to(center)
+    gate = GateLibrary.rzz([theta])
+    gate.set_sites(*sites)
+    apply_two_qubit_gate_tdvp(state, gate, _tdvp_params(max_bond_dim=None, tdvp_sweeps=1))
+
+    got = _dense_state(state).reshape(-1)
+    assert _fidelity(got, expected.reshape(-1)) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_fixed_chi_windowed_tdvp_gate_leaves_a_truthful_center() -> None:
+    """A drift renormalization inside the window path must not be overwritten by a stale center."""
+    params = _tdvp_params(max_bond_dim=2, tdvp_sweeps=1)
+    state = _random_capped_mps(WINDOW_LENGTH, GAUGE_CHI, WINDOW_SEED)
+    state.shift_center_to(4)
+
+    gate = GateLibrary.rzz([0.6])
+    gate.set_sites(3, 7)
+    apply_two_qubit_gate_tdvp(state, gate, params)
+
+    assert state.orthogonality_center is not None
+    assert state.orthogonality_center in state.check_canonical_form()
 
 
 # --- multi-qubit local noise -------------------------------------------------

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1105,41 +1105,17 @@ def test_mixed_gate2_norm_unit() -> None:
 
 
 @pytest.mark.parametrize("chi", [16, 32])
-@pytest.mark.tdvp_regression
-def test_mixed_zeros_full_replay_matches_the_simulator(chi: int) -> None:
-    """Replaying gates through the public API gives what the circuit loop gives.
-
-    The replay applies gates back to back without the loop's per-gate renormalization,
-    so it reaches ``apply_two_qubit_gate`` with the center wherever the previous gate
-    left it. The gate application gauges the window itself, so both routes agree.
-    """
-    qc = _mixed_small_zeros_circuit(MIXED_SMALL_ZEROS_LENGTH)
-    params = _hybrid_tdvp_replay_params(max_bond_dim=chi)
-    state = _replay_hybrid_tdvp_through_gate(qc, len(list(circuit_to_dag(qc).topological_op_nodes())), params=params)
-    assert abs(float(state.mps.norm()) - 1.0) < NORM_TOL
-
-    loop_params = _hybrid_tdvp_replay_params(max_bond_dim=chi)
-    loop_params.observables = [Observable(Z(), 0)]
-    result = Simulator(parallel=False, show_progress=False).run(
-        State(MIXED_SMALL_ZEROS_LENGTH, initial="zeros"), qc, loop_params, None
-    )
-    assert result.output_state is not None
-    assert _fidelity(result.output_state.mps.to_vec(), state.mps.to_vec()) == pytest.approx(1.0, abs=1e-10)
-
-
-@pytest.mark.parametrize("chi", [16, 32])
-@pytest.mark.tdvp_regression
-@pytest.mark.xfail(
-    reason="a long-range generator gate is under-applied once a preceding two-qubit gate has "
-    "changed the bond structure; gate_mode='mpo' is exact on the same circuit",
-    strict=True,
-)
-def test_mixed_zeros_full_is_exact(chi: int) -> None:
-    """The hybrid TDVP route should reproduce the exact state for this circuit."""
+def test_mixed_zeros_full(chi: int) -> None:
+    """Full mixed_small L=10 zeros circuit matches exact evolution under hybrid TDVP."""
     qc = _mixed_small_zeros_circuit(MIXED_SMALL_ZEROS_LENGTH)
     ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
     params = _hybrid_tdvp_replay_params(max_bond_dim=chi)
-    state = _replay_hybrid_tdvp_through_gate(qc, len(list(circuit_to_dag(qc).topological_op_nodes())), params=params)
+    state = _replay_hybrid_tdvp_through_gate(
+        qc,
+        len(list(circuit_to_dag(qc).topological_op_nodes())),
+        params=params,
+    )
+    assert abs(float(state.mps.norm()) - 1.0) < NORM_TOL
     assert _fidelity(ref, state.mps.to_vec()) > 0.99
 
 

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -2720,6 +2720,16 @@ def test_center_rescale_normalizes_without_moving_the_center() -> None:
     assert 0 in state.check_canonical_form()
 
 
+@pytest.mark.parametrize("invalid_value", [0.0, np.nan, np.inf])
+def test_center_rescale_rejects_invalid_norm(invalid_value: float) -> None:
+    """A zero or non-finite center norm cannot represent a normalizable state."""
+    state = MPS(3, state="zeros")
+    state.tensors[0] = np.full_like(state.tensors[0], invalid_value)
+
+    with pytest.raises(ValueError, match="zero or non-finite"):
+        _renormalize(state)
+
+
 def test_renormalization_falls_back_to_a_full_sweep_when_the_gauge_is_unknown() -> None:
     """With no tracked center the state is renormalized by a full-chain sweep."""
     state = MPS(3, state="zeros")

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -2611,14 +2611,15 @@ WINDOW_LENGTH = 10
 WINDOW_SEED = 11
 
 
-@pytest.mark.parametrize("center", [0, 4, 9])
-def test_windowed_tdvp_gate_is_exact_for_any_incoming_center(center: int) -> None:
-    """An uncapped windowed RZZ must reproduce the exact gate wherever the center starts.
+@pytest.mark.parametrize("center", [0, 4, 9, None])
+def test_windowed_tdvp_gate_is_exact_for_any_incoming_center(center: int | None) -> None:
+    """An uncapped windowed RZZ must be exact for any incoming or unknown center.
 
     ``sweep_2site`` takes its window right-canonical from the first site, so a center left
     anywhere else has to be moved there first. A center on the window's last site is the
     case that bites: with the window's right edge at the chain end there is no dangling
-    bond to absorb the mismatch.
+    bond to absorb the mismatch. The unknown-center case hides that same gauge to verify
+    that the fallback reconstructs it at the window start.
     """
     theta = 0.6
     sites = (1, WINDOW_LENGTH - 2)  # window [0, 9] — right edge is the chain end
@@ -2627,7 +2628,8 @@ def test_windowed_tdvp_gate_is_exact_for_any_incoming_center(center: int) -> Non
     phases = np.exp(-0.5j * theta * np.multiply.outer(eigenvalues, eigenvalues))
     expected = _dense_state(state) * phases.reshape([2 if site in sites else 1 for site in range(WINDOW_LENGTH)])
 
-    state.shift_center_to(center)
+    state.shift_center_to(WINDOW_LENGTH - 1 if center is None else center)
+    state.set_center(center)
     gate = GateLibrary.rzz([theta])
     gate.set_sites(*sites)
     apply_two_qubit_gate_tdvp(state, gate, _tdvp_params(max_bond_dim=None, tdvp_sweeps=1))

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -2622,7 +2622,7 @@ def test_windowed_tdvp_gate_is_exact_for_any_incoming_center(center: int | None)
     that the fallback reconstructs it at the window start.
     """
     theta = 0.6
-    sites = (1, WINDOW_LENGTH - 2)  # window [0, 9] — right edge is the chain end
+    sites = (2, WINDOW_LENGTH - 2)  # window [1, 9] — right edge is the chain end
     state = _random_capped_mps(WINDOW_LENGTH, GAUGE_CHI, WINDOW_SEED)
     eigenvalues = np.array([1.0, -1.0])
     phases = np.exp(-0.5j * theta * np.multiply.outer(eigenvalues, eigenvalues))
@@ -2636,6 +2636,8 @@ def test_windowed_tdvp_gate_is_exact_for_any_incoming_center(center: int | None)
 
     got = _dense_state(state).reshape(-1)
     assert _fidelity(got, expected.reshape(-1)) == pytest.approx(1.0, abs=1e-12)
+    assert state.orthogonality_center is not None
+    assert state.orthogonality_center in state.check_canonical_form()
 
 
 def test_fixed_chi_windowed_tdvp_gate_leaves_a_truthful_center() -> None:
@@ -2722,11 +2724,13 @@ def test_center_rescale_normalizes_without_moving_the_center() -> None:
     assert 0 in state.check_canonical_form()
 
 
+@pytest.mark.parametrize("center", [0, None])
 @pytest.mark.parametrize("invalid_value", [0.0, np.nan, np.inf])
-def test_center_rescale_rejects_invalid_norm(invalid_value: float) -> None:
-    """A zero or non-finite center norm cannot represent a normalizable state."""
+def test_center_rescale_rejects_invalid_norm(invalid_value: float, center: int | None) -> None:
+    """A zero or non-finite state cannot be normalized with a known or unknown gauge."""
     state = MPS(3, state="zeros")
     state.tensors[0] = np.full_like(state.tensors[0], invalid_value)
+    state.set_center(center)
 
     with pytest.raises(ValueError, match="zero or non-finite"):
         _renormalize(state)

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -35,6 +35,7 @@ from mqt.yaqs.core.methods.stochastic_process import create_probability_distribu
 from mqt.yaqs.core.methods.tdvp.sweep_utils import renorm_drift, uses_fixed_chi
 from mqt.yaqs.core.methods.tdvp.tdvp import evolve_window
 from mqt.yaqs.digital.digital_tjm import (
+    _renormalize,  # ruff: ignore[import-private-name]  # module-private gauge-aware normalization
     apply_long_range_gate_mpo,
     apply_single_qubit_gate,
     apply_two_qubit_gate,
@@ -2671,6 +2672,182 @@ def test_fixed_chi_windowed_tdvp_gate_leaves_a_truthful_center() -> None:
 
     assert state.orthogonality_center is not None
     assert state.orthogonality_center in state.check_canonical_form()
+
+
+# ---- center-local renormalization -------------------------------------------------------
+
+RESCALE_LENGTH = 10
+ALL_GATE_MODES: list[GateMode] = ["mpo", "swaps", "tdvp", "full-tdvp"]
+
+
+def _mixed_circuit(length: int) -> QuantumCircuit:
+    """Circuit exercising every two-qubit gate path: TEBD, gate MPO, and a three-qubit gate.
+
+    Args:
+        length: Number of qubits.
+
+    Returns:
+        Circuit with single-qubit layers, a nearest-neighbor CZ brickwork, one long-range
+        RZZ, and one contiguous CCZ.
+    """
+    qc = QuantumCircuit(length)
+    for q in range(length):
+        qc.rx(0.3 + 0.07 * q, q)
+    for q in range(0, length - 1, 2):
+        qc.cz(q, q + 1)
+    for q in range(1, length - 1, 2):
+        qc.cz(q, q + 1)
+    for q in range(length):
+        qc.ry(0.21 + 0.05 * q, q)
+    qc.rzz(0.6, 1, length - 4)
+    qc.ccz(0, 1, 2)
+    return qc
+
+
+def _run_mixed_circuit(gate_mode: GateMode, length: int = RESCALE_LENGTH, max_bond_dim: int | None = None) -> MPS:
+    """Run :func:`_mixed_circuit` noiselessly under ``gate_mode``.
+
+    Args:
+        gate_mode: Two-qubit gate routing mode.
+        length: Number of qubits.
+        max_bond_dim: Optional bond-dimension cap; a small cap makes the gates truncate.
+
+    Returns:
+        Final MPS of the run.
+    """
+    qc = _mixed_circuit(length)
+    sim_params = DigitalSimParams(
+        observables=[Observable(Z(), 0)],
+        gate_mode=gate_mode,
+        preset="exact",
+        svd_threshold=1e-14,
+        max_bond_dim=max_bond_dim,
+        get_state=True,
+    )
+    result = Simulator(parallel=False, show_progress=False).run(State(length, initial="zeros"), qc, sim_params, None)
+    assert result.output_state is not None
+    return result.output_state.mps
+
+
+def test_center_rescale_normalizes_without_moving_the_center() -> None:
+    """Rescaling the center tensor normalizes the state and leaves the gauge in place."""
+    state = MPS(3, state="zeros")
+    assert state.orthogonality_center == 0
+    # |000> has unit norm, so scaling the center tensor by 0.8 makes ||psi|| = 0.8 exactly.
+    state.tensors[0] *= 0.8
+    assert float(state.norm()) == pytest.approx(0.8, abs=1e-12)
+
+    _renormalize(state)
+
+    assert state.orthogonality_center == 0
+    assert float(state.norm()) == pytest.approx(1.0, abs=1e-12)
+    assert 0 in state.check_canonical_form()
+
+
+def test_renormalization_falls_back_to_a_full_sweep_when_the_gauge_is_unknown() -> None:
+    """With no tracked center the state is renormalized by a full-chain sweep."""
+    state = MPS(3, state="zeros")
+    state.tensors[0] *= 0.8
+    state.set_center(None)
+
+    _renormalize(state)
+
+    assert state.orthogonality_center == 0
+    assert float(state.norm()) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_unitary_single_qubit_gate_keeps_the_tracked_center() -> None:
+    """Unitary single-site gates preserve canonicality, so the tracked center stays valid."""
+    state = _random_capped_mps(GAUGE_LENGTH, GAUGE_CHI, GAUGE_SEED)
+    state.shift_center_to(4)
+    expected = _dense_state(state)
+
+    circuit = QuantumCircuit(GAUGE_LENGTH)
+    circuit.rx(0.7, 1)
+    circuit.h(6)
+    circuit.t(2)
+    circuit.unitary(Operator(GateLibrary.h().matrix), [5], label="custom_h")
+    for node in circuit_to_dag(circuit).op_nodes():
+        apply_single_qubit_gate(state, node)
+        site = circuit.find_bit(node.qargs[0]).index
+        expected = np.moveaxis(np.tensordot(Operator(node.op).data, expected, axes=([1], [site])), 0, site)
+
+    assert state.orthogonality_center == 4
+    assert 4 in state.check_canonical_form()
+
+    np.testing.assert_allclose(_dense_state(state), expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("gate_mode", ["mpo", "swaps"])
+def test_noiseless_run_matches_the_statevector_in_exact_gate_modes(gate_mode: GateMode) -> None:
+    """Center-local renormalization leaves the exact gate paths exact."""
+    mps = _run_mixed_circuit(gate_mode)
+    reference = np.asarray(Statevector(_mixed_circuit(RESCALE_LENGTH)).data)
+
+    assert _fidelity(mps.to_vec(), reference) >= 1.0 - 1e-10
+    assert float(mps.norm()) == pytest.approx(1.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("max_bond_dim", [None, 2])
+@pytest.mark.parametrize("gate_mode", ALL_GATE_MODES)
+def test_noiseless_run_stays_normalized_in_every_gate_mode(gate_mode: GateMode, max_bond_dim: int | None) -> None:
+    """Every two-qubit gate path leaves a normalized state with a valid tracked center.
+
+    ``max_bond_dim=2`` truncates hard on this circuit, so the run also covers absorbing the
+    norm a truncating gate discards.
+    """
+    mps = _run_mixed_circuit(gate_mode, max_bond_dim=max_bond_dim)
+
+    assert float(mps.norm()) == pytest.approx(1.0, abs=1e-12)
+    assert mps.orthogonality_center is not None
+    assert mps.orthogonality_center in mps.check_canonical_form()
+
+
+def test_layer_sampling_reads_the_state_in_b_form() -> None:
+    """Mid-circuit samples see B form, so gauge-reading observables are unaffected.
+
+    ``record_diagnostics`` and the entropy observables read the tensors directly rather
+    than through a center-shifting copy, so the gauge they are sampled in is part of the
+    result.
+    """
+    qc = QuantumCircuit(6)
+    for layer in range(2):
+        for q in range(6):
+            qc.rx(0.37 + 0.11 * q, q)
+        for q in range(layer % 2, 5, 2):
+            qc.cz(q, q + 1)
+        qc.barrier(label="SAMPLE_OBSERVABLES")
+
+    centers: list[int | None] = []
+    original = MPS.record_diagnostics
+
+    def recording(self: MPS, diagnostics: NDArray[np.float64], column_index: int) -> None:
+        centers.append(self.orthogonality_center)
+        original(self, diagnostics, column_index)
+
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], gate_mode="mpo", preset="exact", sample_layers=True)
+    with patch.object(MPS, "record_diagnostics", recording):
+        Simulator(parallel=False, show_progress=False).run(State(6, initial="zeros"), qc, sim_params, None)
+
+    assert len(centers) >= 3  # initial sample, one per barrier, and the final column
+    assert set(centers) == {0}
+
+
+def test_unknown_gauge_run_is_normalized_before_observables() -> None:
+    """A trajectory started from an ungauged MPS still reports observables on a unit state."""
+    mps = MPS(6, state="zeros")
+    mps.tensors[0] *= 0.8
+    mps.set_center(None)
+
+    qc = QuantumCircuit(6)
+    for q in range(6):
+        qc.h(q)
+
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], gate_mode="mpo", preset="exact", get_state=True)
+    _results, _diagnostics, _counts, final = digital_tjm((0, mps, None, sim_params, qc))
+
+    assert final is not None
+    assert float(final.norm()) == pytest.approx(1.0, abs=1e-12)
 
 
 # --- multi-qubit local noise -------------------------------------------------


### PR DESCRIPTION
This PR replaces per-gate full-chain normalization in digital circuit simulation with a rescale and corrects TDVP window gauge handling. This improves runtime by using the known orthogonality center to skip a full chain canonicalization. Tests cover known and unknown gauges across all gate modes.

AI assistance was used for diagnosis, implementation, and validation.
