### PR TITLE
localized long-range MPO gate application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ releases may include breaking changes.
 
 ### Changed
 
-- restricted long-range gate application to the gate support window and removed
-  a redundant gauge scan ([#564]) ([**@Pouri96**])
+- localized long-range MPO gate application ([#564]) ([**@Pouri96**])
 - sped up normalization in circuit simulation and fixed TDVP state tracking
   ([#560]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- restricted long-range gate application to the gate support window and removed
+  a redundant gauge scan ([#564]) ([**@Pouri96**])
 - sped up normalization in circuit simulation and fixed TDVP state tracking
   ([#560]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])
@@ -258,6 +260,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#564]: https://github.com/munich-quantum-toolkit/yaqs/pull/564
 [#567]: https://github.com/munich-quantum-toolkit/yaqs/pull/567
 [#560]: https://github.com/munich-quantum-toolkit/yaqs/pull/560
 [#545]: https://github.com/munich-quantum-toolkit/yaqs/pull/545

--- a/src/mqt/yaqs/core/data_structures/mpo.py
+++ b/src/mqt/yaqs/core/data_structures/mpo.py
@@ -1521,11 +1521,12 @@ class MPO:
             ValueError: On length mismatch or missing ``sim_params`` when compressing.
 
         Notes:
-            Applies the MPO at every site and invalidates the tracked orthogonality
-            center (``set_center(None)``). With ``compress=False`` the center remains
-            ``None`` until canonicalization or compression is performed elsewhere.
-            Compression re-establishes a center via
-            :meth:`~mqt.yaqs.core.data_structures.mps.MPS.compress`.
+            Applies the MPO at every site, which invalidates the tracked orthogonality
+            center. With ``compress=False`` the center is left ``None`` until
+            canonicalization or compression is performed elsewhere. Compression
+            re-establishes a center via
+            :meth:`~mqt.yaqs.core.data_structures.mps.MPS.compress` and leaves it on the
+            last site.
         """
         if len(self.tensors) != state.length:
             msg = f"MPO length {len(self.tensors)} does not match MPS length {state.length}."
@@ -1534,14 +1535,18 @@ class MPO:
         for site, operator in enumerate(self.tensors):
             state.tensors[site] = contract_mpo_site_with_mps_site(operator, state.tensors[site])
 
-        state.set_center(None)
-
         if not compress:
+            state.set_center(None)
             return
         if sim_params is None:
+            state.set_center(None)
             msg = "sim_params is required when compress=True for MPO.multiply(MPS)."
             raise ValueError(msg)
 
+        # compress() reads the tracked center only to choose where to leave it, and its
+        # truncating sweep ends on the last site. Naming that site skips the gauge scan an
+        # unknown center triggers, and the return sweep that would follow it.
+        state.set_center(state.length - 1)
         state.compress(
             sim_params.svd_threshold,
             max_bond_dim=sim_params.max_bond_dim,

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -573,8 +573,8 @@ def apply_long_range_gate_mpo(
     the matching window of ``state``, so contraction and compression touch
     ``last_site - first_site + 1`` sites instead of :attr:`~mqt.yaqs.core.data_structures.mps.MPS.length`
     sites, and no bond outside the support is truncated, matching the other gate modes.
-    Moving the center onto the window still rewrites the sites it passes; the
-    multiplication and its compression do not.
+    Moving the center to the nearest window boundary still rewrites the sites it
+    passes; the multiplication and its compression do not.
 
     Args:
         state: MPS updated in place.
@@ -590,10 +590,11 @@ def apply_long_range_gate_mpo(
     # The gate MPO has bond dimension 1 at both support boundaries, so the windowed
     # compression matches the full-chain one only while the sites outside
     # [first_site, last_site] are isometric towards the window (cf. apply_two_qubit_gate_tebd).
-    if state.orthogonality_center is None:
+    center = state.orthogonality_center
+    if center is None:
         state.set_canonical_form(first_site)
-    elif not first_site <= state.orthogonality_center <= last_site:
-        state.shift_center_to(first_site)
+    elif not first_site <= center <= last_site:
+        state.shift_center_to(first_site if center < first_site else last_site)
 
     window = MPS(
         length=last_site - first_site + 1,

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -599,16 +599,7 @@ def apply_long_range_gate_mpo(
         physical_dimensions=state.physical_dimensions[first_site : last_site + 1],
     )
     MPO.from_gate(gate, window.length, physical_dimensions=window.physical_dimensions).multiply(
-        window, sim_params=sim_params, compress=False
-    )
-    # compress() reads the tracked center only to choose where to leave it, and its
-    # truncating sweep ends on the last site; naming that site skips the gauge scan the
-    # unknown center would trigger, and the return sweep that would follow it.
-    window.set_center(window.length - 1)
-    window.compress(
-        sim_params.svd_threshold,
-        max_bond_dim=sim_params.max_bond_dim,
-        trunc_mode=sim_params.trunc_mode,
+        window, sim_params=sim_params, compress=True
     )
     state.tensors[first_site : last_site + 1] = window.tensors
     center = window.orthogonality_center

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -569,6 +569,11 @@ def apply_long_range_gate_mpo(
 ) -> tuple[int, int]:
     """Apply a gate on two or more qubits via :meth:`~mqt.yaqs.core.data_structures.mpo.MPO.multiply`.
 
+    The gate MPO is built on the support ``[first_site, last_site]`` and multiplied into
+    the matching window of ``state``, so contraction and compression touch
+    ``last_site - first_site + 1`` sites instead of :attr:`~mqt.yaqs.core.data_structures.mps.MPS.length`
+    sites. Tensors outside the support are left untouched.
+
     Args:
         state: MPS updated in place.
         gate: Gate with sites and MPO data populated.
@@ -579,9 +584,35 @@ def apply_long_range_gate_mpo(
     """
     first_site = min(gate.sites)
     last_site = max(gate.sites)
-    MPO.from_gate(gate, state.length, physical_dimensions=state.physical_dimensions).multiply(
-        state, sim_params=sim_params, compress=True
+
+    # The gate MPO has bond dimension 1 at both support boundaries, so the windowed
+    # compression matches the full-chain one only while the sites outside
+    # [first_site, last_site] are isometric towards the window (cf. apply_two_qubit_gate_tebd).
+    if state.orthogonality_center is None:
+        state.set_canonical_form(first_site)
+    elif not first_site <= state.orthogonality_center <= last_site:
+        state.shift_center_to(first_site)
+
+    window = MPS(
+        length=last_site - first_site + 1,
+        tensors=state.tensors[first_site : last_site + 1],
+        physical_dimensions=state.physical_dimensions[first_site : last_site + 1],
     )
+    MPO.from_gate(gate, window.length, physical_dimensions=window.physical_dimensions).multiply(
+        window, sim_params=sim_params, compress=False
+    )
+    # compress() reads the tracked center only to choose where to leave it, and its
+    # truncating sweep ends on the last site; naming that site skips the gauge scan the
+    # unknown center would trigger, and the return sweep that would follow it.
+    window.set_center(window.length - 1)
+    window.compress(
+        sim_params.svd_threshold,
+        max_bond_dim=sim_params.max_bond_dim,
+        trunc_mode=sim_params.trunc_mode,
+    )
+    state.tensors[first_site : last_site + 1] = window.tensors
+    center = window.orthogonality_center
+    state.set_center(None if center is None else first_site + center)
     return first_site, last_site
 
 

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -572,7 +572,9 @@ def apply_long_range_gate_mpo(
     The gate MPO is built on the support ``[first_site, last_site]`` and multiplied into
     the matching window of ``state``, so contraction and compression touch
     ``last_site - first_site + 1`` sites instead of :attr:`~mqt.yaqs.core.data_structures.mps.MPS.length`
-    sites. Tensors outside the support are left untouched.
+    sites, and no bond outside the support is truncated, matching the other gate modes.
+    Moving the center onto the window still rewrites the sites it passes; the
+    multiplication and its compression do not.
 
     Args:
         state: MPS updated in place.

--- a/tests/core/data_structures/test_mpo.py
+++ b/tests/core/data_structures/test_mpo.py
@@ -1077,6 +1077,24 @@ def test_multiply_mps_invalidates_then_restores_center() -> None:
     assert no_compress.orthogonality_center is None
 
 
+def test_multiply_mps_leaves_center_on_last_site() -> None:
+    """Compression after ``multiply(MPS)`` leaves a genuine center on the last site."""
+    length = 6
+    state = MPS(length, state="haar-random", pad=4)
+    state.normalize("B")
+    gate = GateLibrary.cx()
+    gate.set_sites(1, 4)
+    gate_mpo = MPO.from_gate(gate, length)
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], preset="exact")
+
+    gate_mpo.multiply(state, sim_params=sim_params, compress=True)
+
+    # ``compress`` ends its truncating sweep on the last site, so that site is named before
+    # the call; the tracked center must therefore be a genuine canonical center there.
+    assert state.orthogonality_center == length - 1
+    assert state.orthogonality_center in state.check_canonical_form()
+
+
 def test_multiply_mps_compress_requires_sim_params() -> None:
     """Compression without ``sim_params`` raises ``ValueError``."""
     state = MPS(2, state="zeros")

--- a/tests/digital/test_mps_utils.py
+++ b/tests/digital/test_mps_utils.py
@@ -343,6 +343,65 @@ def test_capped_long_range_gate_truncates_inside_its_support_only() -> None:
     assert max(bonds_mpo[first:last]) <= cap
 
 
+def _seeded_qudit_mps(physical_dimensions: list[int], *, seed: int) -> MPS:
+    """Build a deterministic bond-2 MPS with the given per-site physical dimensions.
+
+    Args:
+        physical_dimensions: Local dimension of every site.
+        seed: NumPy RNG seed.
+
+    Returns:
+        Normalized MPS in B form.
+    """
+    rng = np.random.default_rng(seed)
+    length = len(physical_dimensions)
+    bonds = [1, *[2] * (length - 1), 1]
+    tensors = [
+        (
+            rng.normal(size=(dim, bonds[site], bonds[site + 1]))
+            + 1j * rng.normal(size=(dim, bonds[site], bonds[site + 1]))
+        ).astype(np.complex128)
+        for site, dim in enumerate(physical_dimensions)
+    ]
+    state = MPS(length, tensors=tensors, physical_dimensions=list(physical_dimensions))
+    state.normalize("B")
+    return state
+
+
+@pytest.mark.parametrize(
+    ("physical_dimensions", "sites"),
+    [
+        ([2, 3, 2], (0, 2)),
+        ([2, 2, 3, 2, 2], (1, 4)),
+        ([3, 2, 3, 2, 4, 2, 3], (1, 5)),
+    ],
+    ids=["qutrit_spectator", "offset_window", "qudits_inside_and_outside"],
+)
+def test_long_range_gate_on_qudit_spectators_matches_full_chain_mpo(
+    physical_dimensions: list[int], sites: tuple[int, int]
+) -> None:
+    """The window slices ``physical_dimensions``, so qudit spectators must survive the re-basing.
+
+    ``get_support_mpo`` indexes its dimensions by ``site - first_site`` while the sites stay
+    absolute, so a window that does not start at site 0 is where a mis-based slice would show.
+    """
+    length = len(physical_dimensions)
+    gate = GateLibrary.cx()
+    gate.set_sites(*sites)
+    state = _seeded_qudit_mps(physical_dimensions, seed=20260901)
+    state.set_canonical_form(min(sites))
+
+    reference = copy.deepcopy(state)
+    MPO.from_gate(gate, length, physical_dimensions=physical_dimensions).multiply(reference, compress=False)
+    expected = reference.to_vec()
+
+    apply_long_range_gate_mpo(state, gate, _sim_params())
+
+    assert _fidelity(state.to_vec(), expected) >= 1.0 - 1e-12
+    assert [tensor.shape[0] for tensor in state.tensors] == physical_dimensions
+    assert state.orthogonality_center in state.check_canonical_form()
+
+
 @pytest.mark.parametrize("known_gauge", [True, False], ids=["known_gauge", "unknown_gauge"])
 def test_long_range_gate_tracks_orthogonality_center(*, known_gauge: bool) -> None:
     """The tracked center after the gate is a genuine canonical center of the full chain."""

--- a/tests/digital/test_mps_utils.py
+++ b/tests/digital/test_mps_utils.py
@@ -9,12 +9,14 @@
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 from qiskit import QuantumCircuit
 from qiskit.converters import circuit_to_dag
-from qiskit.quantum_info import Statevector
+from qiskit.quantum_info import Operator, Statevector, random_unitary
 
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.mps import MPS
@@ -22,8 +24,11 @@ from mqt.yaqs.core.data_structures.simulation_parameters import DigitalSimParams
 from mqt.yaqs.core.libraries.gate_library import BaseGate, GateLibrary, Z
 from mqt.yaqs.digital.digital_tjm import apply_long_range_gate_mpo, apply_two_qubit_gate_tebd
 from mqt.yaqs.digital.utils.dag_utils import convert_dag_to_tensor_algorithm
+from tests.core.methods.tdvp.conftest import _fidelity, _haar_random_mps
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from numpy.typing import NDArray
 
 
@@ -226,3 +231,106 @@ def test_from_gate_reuses_mpo_tensors() -> None:
     first = MPO.from_gate(gate, length)
     second = MPO.from_gate(gate, length)
     np.testing.assert_allclose(first.to_matrix(), second.to_matrix(), atol=1e-12)
+
+
+# --- gate support window ---
+
+# Long-range, spread multi-qubit, and matrix-backed gates that reach apply_long_range_gate_mpo.
+_SUPPORT_CASES: list[tuple[str, Callable[[QuantumCircuit], None]]] = [
+    ("rzz_0_5", lambda qc: qc.rzz(0.7, 0, 5)),
+    ("cx_1_6", lambda qc: qc.cx(1, 6)),
+    ("cphase_2_7", lambda qc: qc.cp(0.9, 2, 7)),
+    ("ccz_0_2_4", lambda qc: qc.ccz(0, 2, 4)),
+    ("cswap_0_2_4", lambda qc: qc.cswap(0, 2, 4)),
+    ("matrix_1_3_5", lambda qc: qc.unitary(random_unitary(8, seed=99), [1, 3, 5])),
+]
+
+
+def _single_gate_circuit(length: int, build: Callable[[QuantumCircuit], None]) -> QuantumCircuit:
+    """Build a circuit holding exactly the gate under test.
+
+    Args:
+        length: Number of qubits.
+        build: Callable appending the single operation.
+
+    Returns:
+        Circuit with one operation.
+    """
+    qc = QuantumCircuit(length)
+    build(qc)
+    return qc
+
+
+def test_long_range_gate_leaves_sites_outside_support_unchanged() -> None:
+    """A gate on ``[3, 8]`` rewrites only those tensors of a 30-site chain."""
+    length, first, last = 30, 3, 8
+    state = _haar_random_mps(length, pad=8, seed=20260829)
+    state.set_canonical_form(first)
+    exterior = {site: state.tensors[site].copy() for site in range(length) if not first <= site <= last}
+
+    gate = _gate_from_circuit(_single_gate_circuit(length, lambda qc: qc.cp(0.9, first, last)))
+    apply_long_range_gate_mpo(state, gate, _sim_params())
+
+    for site, tensor in exterior.items():
+        assert np.array_equal(state.tensors[site], tensor), f"site {site} outside the gate support changed"
+    assert state.orthogonality_center is not None
+    assert first <= state.orthogonality_center <= last
+
+
+@pytest.mark.parametrize(("case", "build"), _SUPPORT_CASES, ids=[case for case, _ in _SUPPORT_CASES])
+@pytest.mark.parametrize("entangled", [False, True], ids=["product", "entangled"])
+def test_long_range_gate_matches_dense_gate_operator(
+    case: str,
+    build: Callable[[QuantumCircuit], None],
+    *,
+    entangled: bool,
+) -> None:
+    """Support-windowed application reproduces the dense gate operator.
+
+    The entangled fixtures are seeded Haar-random MPS; generic-state coverage is the point.
+    """
+    del case
+    length = 10
+    qc = _single_gate_circuit(length, build)
+    gate = _gate_from_circuit(qc)
+    state = _haar_random_mps(length, pad=8, seed=20260829) if entangled else MPS(length, state="x+")
+    state.set_canonical_form(min(gate.sites))
+
+    expected = np.asarray(Operator(qc).data, dtype=np.complex128) @ np.asarray(state.to_vec(), dtype=np.complex128)
+    apply_long_range_gate_mpo(state, gate, _sim_params())
+
+    assert _fidelity(state.to_vec(), expected) >= 1.0 - 1e-10
+
+
+def test_capped_long_range_gate_is_no_less_accurate_than_full_chain_compression() -> None:
+    """Under a bond cap, windowed truncation is at least as accurate as compressing the whole chain."""
+    length, cap = 12, 8
+    qc = _single_gate_circuit(length, lambda circuit: circuit.cp(0.9, 2, 9))
+    gate = _gate_from_circuit(qc)
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], preset="exact", gate_mode="mpo", max_bond_dim=cap)
+
+    state = _haar_random_mps(length, pad=cap, seed=20260829)
+    state.set_canonical_form(min(gate.sites))
+    expected = np.asarray(Operator(qc).data, dtype=np.complex128) @ np.asarray(state.to_vec(), dtype=np.complex128)
+
+    full_chain = copy.deepcopy(state)
+    MPO.from_gate(gate, length).multiply(full_chain, sim_params=sim_params, compress=True)
+    apply_long_range_gate_mpo(state, gate, sim_params)
+
+    assert _fidelity(state.to_vec(), expected) >= _fidelity(full_chain.to_vec(), expected) - 1e-12
+
+
+@pytest.mark.parametrize("known_gauge", [True, False], ids=["known_gauge", "unknown_gauge"])
+def test_long_range_gate_tracks_orthogonality_center(*, known_gauge: bool) -> None:
+    """The tracked center after the gate is a genuine canonical center of the full chain."""
+    length = 10
+    gate = _gate_from_circuit(_single_gate_circuit(length, lambda qc: qc.cx(1, 6)))
+    state = _haar_random_mps(length, pad=8, seed=20260829)
+    if known_gauge:
+        state.set_canonical_form(0)
+    else:
+        state.set_center(None)
+
+    apply_long_range_gate_mpo(state, gate, _sim_params())
+
+    assert state.orthogonality_center in state.check_canonical_form()

--- a/tests/digital/test_mps_utils.py
+++ b/tests/digital/test_mps_utils.py
@@ -320,6 +320,29 @@ def test_capped_long_range_gate_is_no_less_accurate_than_full_chain_compression(
     assert _fidelity(state.to_vec(), expected) >= _fidelity(full_chain.to_vec(), expected) - 1e-12
 
 
+def test_capped_long_range_gate_truncates_inside_its_support_only() -> None:
+    """A chain entering above the cap keeps its exterior bonds, as the ``swaps`` route leaves them."""
+    length, cap, first, last = 12, 4, 4, 7
+    gate = _gate_from_circuit(_single_gate_circuit(length, lambda qc: qc.cp(0.9, first, last)))
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], preset="exact", gate_mode="mpo", max_bond_dim=cap)
+
+    state = _haar_random_mps(length, pad=16, seed=20260829)
+    state.set_canonical_form(first)
+    bonds_before = [tensor.shape[2] for tensor in state.tensors[:-1]]
+
+    swaps_state = copy.deepcopy(state)
+    apply_two_qubit_gate_tebd(swaps_state, gate, sim_params)
+    apply_long_range_gate_mpo(state, gate, sim_params)
+
+    bonds_mpo = [tensor.shape[2] for tensor in state.tensors[:-1]]
+    bonds_swaps = [tensor.shape[2] for tensor in swaps_state.tensors[:-1]]
+    exterior = [bond for bond in range(length - 1) if bond < first or bond >= last]
+
+    assert [bonds_mpo[bond] for bond in exterior] == [bonds_before[bond] for bond in exterior]
+    assert [bonds_mpo[bond] for bond in exterior] == [bonds_swaps[bond] for bond in exterior]
+    assert max(bonds_mpo[first:last]) <= cap
+
+
 @pytest.mark.parametrize("known_gauge", [True, False], ids=["known_gauge", "unknown_gauge"])
 def test_long_range_gate_tracks_orthogonality_center(*, known_gauge: bool) -> None:
     """The tracked center after the gate is a genuine canonical center of the full chain."""

--- a/tests/digital/test_mps_utils.py
+++ b/tests/digital/test_mps_utils.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -415,4 +416,22 @@ def test_long_range_gate_tracks_orthogonality_center(*, known_gauge: bool) -> No
 
     apply_long_range_gate_mpo(state, gate, _sim_params())
 
+    assert state.orthogonality_center in state.check_canonical_form()
+
+
+def test_long_range_gate_enters_window_from_right_at_nearest_boundary() -> None:
+    """A right-side center moves only to the window's right boundary before a correct gate update."""
+    length, last_site = 10, 6
+    qc = _single_gate_circuit(length, lambda circuit: circuit.cx(1, last_site))
+    gate = _gate_from_circuit(qc)
+    state = _haar_random_mps(length, pad=8, seed=20260829)
+    state.set_canonical_form(length - 1)
+    expected = np.asarray(Statevector(state.to_vec()).evolve(qc).data, dtype=np.complex128)
+
+    with patch.object(state, "shift_center_to", wraps=state.shift_center_to) as shift_center_to:
+        apply_long_range_gate_mpo(state, gate, _sim_params())
+
+    shift_center_to.assert_called_once_with(last_site)
+    assert _fidelity(state.to_vec(), expected) >= 1.0 - 1e-10
+    assert state.orthogonality_center == last_site
     assert state.orthogonality_center in state.check_canonical_form()

--- a/tests/digital/test_mps_utils.py
+++ b/tests/digital/test_mps_utils.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.converters import circuit_to_dag
-from qiskit.quantum_info import Operator, Statevector, random_unitary
+from qiskit.quantum_info import Statevector, random_unitary
 
 from mqt.yaqs.core.data_structures.mpo import MPO
 from mqt.yaqs.core.data_structures.mps import MPS
@@ -296,7 +296,7 @@ def test_long_range_gate_matches_dense_gate_operator(
     state = _haar_random_mps(length, pad=8, seed=20260829) if entangled else MPS(length, state="x+")
     state.set_canonical_form(min(gate.sites))
 
-    expected = np.asarray(Operator(qc).data, dtype=np.complex128) @ np.asarray(state.to_vec(), dtype=np.complex128)
+    expected = np.asarray(Statevector(state.to_vec()).evolve(qc).data, dtype=np.complex128)
     apply_long_range_gate_mpo(state, gate, _sim_params())
 
     assert _fidelity(state.to_vec(), expected) >= 1.0 - 1e-10
@@ -311,7 +311,7 @@ def test_capped_long_range_gate_is_no_less_accurate_than_full_chain_compression(
 
     state = _haar_random_mps(length, pad=cap, seed=20260829)
     state.set_canonical_form(min(gate.sites))
-    expected = np.asarray(Operator(qc).data, dtype=np.complex128) @ np.asarray(state.to_vec(), dtype=np.complex128)
+    expected = np.asarray(Statevector(state.to_vec()).evolve(qc).data, dtype=np.complex128)
 
     full_chain = copy.deepcopy(state)
     MPO.from_gate(gate, length).multiply(full_chain, sim_params=sim_params, compress=True)
@@ -383,7 +383,7 @@ def test_long_range_gate_on_qudit_spectators_matches_full_chain_mpo(
     """The window slices ``physical_dimensions``, so qudit spectators must survive the re-basing.
 
     ``get_support_mpo`` indexes its dimensions by ``site - first_site`` while the sites stay
-    absolute, so a window that does not start at site 0 is where a mis-based slice would show.
+    absolute, so a window that does not start at site 0 exposes an incorrectly based slice.
     """
     length = len(physical_dimensions)
     gate = GateLibrary.cx()

--- a/tests/digital/test_mps_utils.py
+++ b/tests/digital/test_mps_utils.py
@@ -236,7 +236,7 @@ def test_from_gate_reuses_mpo_tensors() -> None:
 # --- gate support window ---
 
 # Long-range, spread multi-qubit, and matrix-backed gates that reach apply_long_range_gate_mpo.
-_SUPPORT_CASES: list[tuple[str, Callable[[QuantumCircuit], None]]] = [
+_SUPPORT_CASES: list[tuple[str, Callable[[QuantumCircuit], object]]] = [
     ("rzz_0_5", lambda qc: qc.rzz(0.7, 0, 5)),
     ("cx_1_6", lambda qc: qc.cx(1, 6)),
     ("cphase_2_7", lambda qc: qc.cp(0.9, 2, 7)),
@@ -246,7 +246,7 @@ _SUPPORT_CASES: list[tuple[str, Callable[[QuantumCircuit], None]]] = [
 ]
 
 
-def _single_gate_circuit(length: int, build: Callable[[QuantumCircuit], None]) -> QuantumCircuit:
+def _single_gate_circuit(length: int, build: Callable[[QuantumCircuit], object]) -> QuantumCircuit:
     """Build a circuit holding exactly the gate under test.
 
     Args:
@@ -281,7 +281,7 @@ def test_long_range_gate_leaves_sites_outside_support_unchanged() -> None:
 @pytest.mark.parametrize("entangled", [False, True], ids=["product", "entangled"])
 def test_long_range_gate_matches_dense_gate_operator(
     case: str,
-    build: Callable[[QuantumCircuit], None],
+    build: Callable[[QuantumCircuit], object],
     *,
     entangled: bool,
 ) -> None:


### PR DESCRIPTION
This PR makes long-range MPO gates operate only on the sites between the gate’s endpoints instead of the full MPS. This reduces contraction and compression work, avoids truncating unrelated bonds outside the gate’s support, and removes a redundant canonicalization sweep.