### PR TITLE
fixed small-angle cutoff in MPO rotation gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ releases may include breaking changes.
 
 ### Fixed
 
-- fixed silent deletion of small-angle long-range gates in gate-MPO construction
+- fixed small-angle cutoff in MPO rotation gates
   ([#569]) ([**@Pouri96**])
 - stabilize digital TDVP by pruning null bond directions ([#567])
   ([**@aaronleesander**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,7 @@ releases may include breaking changes.
 
 ### Fixed
 
-- fixed small-angle cutoff in MPO rotation gates
-  ([#569]) ([**@Pouri96**])
+- fixed small-angle cutoff in MPO rotation gates ([#569]) ([**@Pouri96**])
 - fixed gauge-dependent entanglement entropy and Schmidt spectrum observables
   ([#561]) ([**@Pouri96**])
 - stabilize digital TDVP by pruning null bond directions ([#567])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ releases may include breaking changes.
 
 ### Fixed
 
+- fixed silent deletion of small-angle long-range gates in gate-MPO construction
+  ([#569]) ([**@Pouri96**])
 - stabilize digital TDVP by pruning null bond directions ([#567])
   ([**@aaronleesander**])
 - fixed MPS norm definition and construction of arbitrary basis state ([#553])
@@ -258,6 +260,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#569]: https://github.com/munich-quantum-toolkit/yaqs/pull/569
 [#567]: https://github.com/munich-quantum-toolkit/yaqs/pull/567
 [#560]: https://github.com/munich-quantum-toolkit/yaqs/pull/560
 [#545]: https://github.com/munich-quantum-toolkit/yaqs/pull/545

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -25,9 +25,17 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike, NDArray
     from qiskit.circuit import Parameter
 
+# Round-off floor of the site-by-site SVD, not an accuracy target. Gate tensors are unnormalized,
+# so the cutoff is taken relative to the leading singular value: an absolute one would track the
+# scale of the gate rather than its operator-Schmidt rank.
+_GATE_SPLIT_RELATIVE_CUTOFF = 1e-12
+
 
 def split_tensor(tensor: NDArray[np.complex128]) -> list[NDArray[np.complex128]]:
     """Splits a multi-qubit gate tensor into one tensor per site using Singular Value Decomposition (SVD).
+
+    Only round-off-level singular values are discarded, so a weakly entangling gate keeps its full
+    operator-Schmidt rank; truncation to a simulation tolerance happens later, in the state gauge.
 
     Args:
         tensor: A gate tensor of shape ``(2,) * (2 * n)`` for ``n >= 2`` sites, with index
@@ -50,7 +58,7 @@ def split_tensor(tensor: NDArray[np.complex128]) -> list[NDArray[np.complex128]]
     remaining = np.reshape(matrix, (left_bond * 4, 4 ** (num_sites - 1)))
     for _ in range(num_sites - 1):
         u_mat, s_list, v_mat = linalg.svd(remaining, full_matrices=False)
-        keep = linalg.truncate(s_list, mode="hard_cutoff", threshold=1e-6, min_keep=1)
+        keep = linalg.truncate(s_list, mode="relative", threshold=_GATE_SPLIT_RELATIVE_CUTOFF, min_keep=1)
         s_list = s_list[:keep]
         u_mat = u_mat[:, :keep]
         v_mat = v_mat[:keep, :]

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -25,11 +25,6 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike, NDArray
     from qiskit.circuit import Parameter
 
-# Round-off floor of the site-by-site SVD, not an accuracy target. Gate tensors are unnormalized,
-# so the cutoff is taken relative to the leading singular value: an absolute one would track the
-# scale of the gate rather than its operator-Schmidt rank.
-_GATE_SPLIT_RELATIVE_CUTOFF = 1e-12
-
 
 def split_tensor(tensor: NDArray[np.complex128]) -> list[NDArray[np.complex128]]:
     """Splits a multi-qubit gate tensor into one tensor per site using Singular Value Decomposition (SVD).
@@ -58,7 +53,8 @@ def split_tensor(tensor: NDArray[np.complex128]) -> list[NDArray[np.complex128]]
     remaining = np.reshape(matrix, (left_bond * 4, 4 ** (num_sites - 1)))
     for _ in range(num_sites - 1):
         u_mat, s_list, v_mat = linalg.svd(remaining, full_matrices=False)
-        keep = linalg.truncate(s_list, mode="relative", threshold=_GATE_SPLIT_RELATIVE_CUTOFF, min_keep=1)
+        # Relative 1e-12 is a round-off floor, not a simulation tolerance.
+        keep = linalg.truncate(s_list, mode="relative", threshold=1e-12, min_keep=1)
         s_list = s_list[:keep]
         u_mat = u_mat[:, :keep]
         v_mat = v_mat[:keep, :]

--- a/tests/core/libraries/test_gate_library.py
+++ b/tests/core/libraries/test_gate_library.py
@@ -188,6 +188,75 @@ def test_split_tensor_three_site_round_trip() -> None:
     assert_allclose(_mpo_train_to_matrix(tensors), unitary, atol=1e-12)
 
 
+@pytest.mark.parametrize("name", ["rzz", "cp"])
+@pytest.mark.parametrize("theta", [1e-6, 1e-8])
+def test_split_tensor_keeps_small_angle_entanglement(name: str, theta: float) -> None:
+    """Test that a weakly entangling two-qubit gate keeps its operator-Schmidt rank of two.
+
+    ``rzz(theta)`` has operator-Schmidt values ``{2 cos(theta/2), 2 sin(theta/2)}`` and ``cp(theta)``
+    has ``{2 cos(theta/4), 2 sin(theta/4)}``, so the entangling value lies between 2.5e-9 and 1e-6
+    here: far above SVD round-off, and therefore not the split's to discard.
+    """
+    gate = getattr(GateLibrary, name)([theta])
+    gate.set_sites(0, 1)
+
+    tensors = split_tensor(gate.tensor)
+
+    assert [tensor.shape for tensor in tensors] == [(2, 2, 1, 2), (2, 2, 2, 1)]
+    assert_allclose(_mpo_train_to_matrix(tensors), gate.matrix, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("name", "params", "expected_bonds"),
+    [
+        ("cx", None, [2]),
+        ("cz", None, [2]),
+        ("swap", None, [4]),
+        ("rxx", [0.7], [2]),
+        ("ryy", [0.7], [2]),
+        ("rzz", [0.7], [2]),
+        ("cp", [0.7], [2]),
+        ("ccx", None, [2, 2]),
+        ("ccz", None, [2, 2]),
+        ("cswap", None, [2, 4]),
+    ],
+)
+def test_split_tensor_bonds_match_operator_schmidt_rank(
+    name: str, params: list[float] | None, expected_bonds: list[int]
+) -> None:
+    """Test that library gates split at their exact operator-Schmidt rank, with no round-off bonds.
+
+    The bond dimensions are pinned as integers so that lowering the split cutoff cannot inflate the
+    gate MPOs: every discarded singular value has to be an exact or round-off zero.
+    """
+    gate = getattr(GateLibrary, name)(params) if params else getattr(GateLibrary, name)()
+    gate.set_sites(*range(gate.interaction))
+
+    tensors = split_tensor(gate.tensor)
+
+    assert [tensor.shape[3] for tensor in tensors[:-1]] == expected_bonds
+    assert tensors[-1].shape[3] == 1
+    assert_allclose(_mpo_train_to_matrix(tensors), gate.matrix, atol=1e-12)
+
+
+def test_split_tensor_ignores_round_off_at_max_arity() -> None:
+    """Test that an eight-qubit product operator splits at bond one at every cut.
+
+    A tensor product of single-qubit gates has operator-Schmidt rank one everywhere. Eight qubits is
+    the ceiling of the dense matrix fallback, where the gate tensor has Frobenius norm 16 and its
+    SVDs carry the most round-off; any bond above one means the cutoff has sunk into that noise.
+    """
+    rng = np.random.default_rng(0)
+    product = _haar_unitary(2, rng)
+    for _ in range(7):
+        product = np.asarray(np.kron(product, _haar_unitary(2, rng)), dtype=np.complex128)
+
+    tensors = split_tensor(product.reshape((2,) * 16))
+
+    assert [tensor.shape[3] for tensor in tensors] == [1] * 8
+    assert_allclose(_mpo_train_to_matrix(tensors), product, atol=1e-12)
+
+
 def test_extend_gate_three_site_with_identity() -> None:
     """Test extend_gate for a three-qubit gate with gaps between the sites.
 

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1707,6 +1707,29 @@ def test_lr_modes_fid_cap(gate_mode: str) -> None:
     assert_mps_bond_invariants(out, max_bond_dim=8)
 
 
+@pytest.mark.parametrize("gate_mode", ["mpo", "swaps"])
+@pytest.mark.parametrize("theta", [1e-6, 1e-8])
+def test_lr_small_angle_gate_survives_gate_mpo(theta: float, gate_mode: str) -> None:
+    """A long-range rzz with a tiny angle must still act on the state in every gate mode.
+
+    The two rzz gates compose to a single rotation by ``pi / 2 + theta`` on the pair, so the state is
+    ``cos(x)|+...+> - i sin(x) Z_0 Z_5|+...+>`` with ``x = (pi / 2 + theta) / 2`` and every Schmidt
+    value in the span equals ``cos(x)`` or ``sin(x)``, both close to ``1 / sqrt(2)``. No truncation
+    setting can drop either one, so the gate MPO is the only place the rotation can be lost, and
+    ``<X_0> = cos(pi / 2 + theta) = -sin(theta)`` exactly.
+    """
+    length = 8
+    qc = QuantumCircuit(length)
+    qc.h(range(length))
+    qc.rzz(np.pi / 2, 0, 5)
+    qc.rzz(theta, 0, 5)
+
+    params = DigitalSimParams(observables=[Observable(X(), 0)], gate_mode=cast("GateMode", gate_mode))
+    result = Simulator(parallel=False, show_progress=False).run(State(length, initial="zeros"), qc, params, None)
+
+    assert float(np.real(result.expectation_values[0][-1])) == pytest.approx(-np.sin(theta), abs=1e-12)
+
+
 def test_zip_lr_vs_tdvp() -> None:
     """Long-range gates use MPO mode and match full-tdvp."""
     qc = QuantumCircuit(4)


### PR DESCRIPTION
This PR stops the default MPO gate construction path from dropping small-angle long-range two-qubit gates. The gate-tensor SVD now uses a hardcoded relative floor of 1e-12 instead of an absolute 1e-6 cutoff, so weakly entangling rotations keep their operator-Schmidt rank.