### PR TITLE
removed redundant center shifting in long-range TEBD swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- removed redundant orthogonality center transport from long-range SWAP routing
+  ([#XXX]) ([**@Pouri96**])
 - restored testing on Python 3.13 and 3.14 ([#556]) ([**@denialhaag**])
 - dropped support for Python 3.10 ([#556]) ([**@denialhaag**])
 - updated BUG to use alternating endpoint root ([#539]) ([**@aaronleesander**])
@@ -256,6 +258,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#XXX]: https://github.com/munich-quantum-toolkit/yaqs/pull/XXX
 [#567]: https://github.com/munich-quantum-toolkit/yaqs/pull/567
 [#545]: https://github.com/munich-quantum-toolkit/yaqs/pull/545
 [#556]: https://github.com/munich-quantum-toolkit/yaqs/pull/556

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ releases may include breaking changes.
 
 ### Changed
 
-- removed redundant center shifting in long-range TEBD swaps
-  ([#571]) ([**@Pouri96**])
+- removed redundant center shifting in long-range TEBD swaps ([#571])
+  ([**@Pouri96**])
 - shifted the orthogonality center left without flipping the network ([#574])
   ([**@Pouri96**])
 - localized long-range MPO gate application ([#564]) ([**@Pouri96**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ releases may include breaking changes.
 
 ### Changed
 
-- removed redundant orthogonality center transport from long-range SWAP routing
+- removed redundant center shifting in long-range TEBD swaps
   ([#571]) ([**@Pouri96**])
 - sped up normalization in circuit simulation and fixed TDVP state tracking
   ([#560]) ([**@Pouri96**])
@@ -260,7 +260,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
-[#XXX]: https://github.com/munich-quantum-toolkit/yaqs/pull/XXX
+[#571]: https://github.com/munich-quantum-toolkit/yaqs/pull/571
 [#567]: https://github.com/munich-quantum-toolkit/yaqs/pull/567
 [#560]: https://github.com/munich-quantum-toolkit/yaqs/pull/560
 [#545]: https://github.com/munich-quantum-toolkit/yaqs/pull/545

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit, DAGOpNode
 
     from ..core.data_structures.simulation_parameters import DigitalSimParams, GateMode
+    from ..core.methods.decompositions import SvdDistribution
 
 
 @dataclass(frozen=True)
@@ -453,10 +454,11 @@ def apply_two_qubit_gate_tdvp(
     return first_site, last_site
 
 
-def apply_two_qubit_gate_tebd(
+def _apply_two_qubit_gate_tebd(
     state: MPS,
     gate: BaseGate,
     sim_params: DigitalSimParams,
+    svd_distribution: SvdDistribution,
 ) -> tuple[int, int]:
     """Apply a two-qubit gate via TEBD/SVD, inserting adjacent SWAPs if needed.
 
@@ -469,15 +471,19 @@ def apply_two_qubit_gate_tebd(
         state: MPS updated in place.
         gate: Internal gate object from the gate library.
         sim_params: Truncation settings shared with TDVP/MPS splitting.
+        svd_distribution: Side the singular values are absorbed into, which is where
+            the split leaves the center. ``"left"`` for the SWAP pass that walks
+            leftward, so its center lands on the pair visited next; ``"right"``
+            otherwise.
 
     Returns:
         ``(left_site, right_site)`` spanning the gate support in MPS order.
     """
 
-    def apply_swap(site_left: int) -> None:
+    def apply_swap(site_left: int, swap_distribution: SvdDistribution) -> None:
         swap_gate = GateLibrary.swap()
         swap_gate.set_sites(site_left, site_left + 1)
-        apply_two_qubit_gate_tebd(state, swap_gate, sim_params)
+        _apply_two_qubit_gate_tebd(state, swap_gate, sim_params, swap_distribution)
 
     site0, site1 = gate.sites[0], gate.sites[1]
     if abs(site0 - site1) != 1:
@@ -485,17 +491,17 @@ def apply_two_qubit_gate_tebd(
         right = max(site0, site1)
 
         for i in range(right - 1, left, -1):
-            apply_swap(i)
+            apply_swap(i, "left")
 
         gate_adj = copy.deepcopy(gate)
         if site0 == left:
             gate_adj.set_sites(left, left + 1)
         else:
             gate_adj.set_sites(left + 1, left)
-        apply_two_qubit_gate_tebd(state, gate_adj, sim_params)
+        _apply_two_qubit_gate_tebd(state, gate_adj, sim_params, "right")
 
         for i in range(left + 1, right):
-            apply_swap(i)
+            apply_swap(i, "right")
 
         return left, right
 
@@ -522,7 +528,7 @@ def apply_two_qubit_gate_tebd(
     new_left, new_right = split_two_site(
         merged_new,
         [d_left, d_right],
-        svd_distribution="right",
+        svd_distribution=svd_distribution,
         trunc_mode=sim_params.trunc_mode,
         threshold=sim_params.svd_threshold,
         max_bond_dim=sim_params.max_bond_dim,
@@ -530,8 +536,26 @@ def apply_two_qubit_gate_tebd(
     )
     state.tensors[left_site] = new_left
     state.tensors[right_site] = new_right
-    state.update_center_after_split(left_site, right_site, "right")
+    state.update_center_after_split(left_site, right_site, svd_distribution)
     return left_site, right_site
+
+
+def apply_two_qubit_gate_tebd(
+    state: MPS,
+    gate: BaseGate,
+    sim_params: DigitalSimParams,
+) -> tuple[int, int]:
+    """Apply a two-qubit gate via TEBD/SVD, inserting adjacent SWAPs if needed.
+
+    Args:
+        state: MPS updated in place.
+        gate: Internal gate object from the gate library.
+        sim_params: Truncation settings shared with TDVP/MPS splitting.
+
+    Returns:
+        ``(left_site, right_site)`` spanning the gate support in MPS order.
+    """
+    return _apply_two_qubit_gate_tebd(state, gate, sim_params, "right")
 
 
 def apply_long_range_gate_mpo(

--- a/src/mqt/yaqs/digital/digital_tjm.py
+++ b/src/mqt/yaqs/digital/digital_tjm.py
@@ -482,11 +482,12 @@ def apply_two_qubit_gate_tdvp(
     return first_site, last_site
 
 
-def _apply_two_qubit_gate_tebd(
+def apply_two_qubit_gate_tebd(
     state: MPS,
     gate: BaseGate,
     sim_params: DigitalSimParams,
-    svd_distribution: SvdDistribution,
+    *,
+    svd_distribution: SvdDistribution = "right",
 ) -> tuple[int, int]:
     """Apply a two-qubit gate via TEBD/SVD, inserting adjacent SWAPs if needed.
 
@@ -495,14 +496,17 @@ def _apply_two_qubit_gate_tebd(
     gauge is not equivalent to discarding the smallest Schmidt values of the state and
     can leave errors far above the optimal truncation error at the same bond dimension.
 
+    ``svd_distribution`` applies only to the adjacent SVD, including each SWAP step of
+    a long-range route. A long-range gate chooses ``"left"`` on the descending SWAP
+    pass and ``"right"`` on the transported gate and the return pass, so a
+    caller-supplied distribution is not used for the route as a whole.
+
     Args:
         state: MPS updated in place.
         gate: Internal gate object from the gate library.
         sim_params: Truncation settings shared with TDVP/MPS splitting.
-        svd_distribution: Side the singular values are absorbed into, which is where
-            the split leaves the center. ``"left"`` for the SWAP pass that walks
-            leftward, so its center lands on the pair visited next; ``"right"``
-            otherwise.
+        svd_distribution: Side the singular values are absorbed into after an
+            adjacent split, which is where the split leaves the center.
 
     Returns:
         ``(left_site, right_site)`` spanning the gate support in MPS order.
@@ -511,7 +515,7 @@ def _apply_two_qubit_gate_tebd(
     def apply_swap(site_left: int, swap_distribution: SvdDistribution) -> None:
         swap_gate = GateLibrary.swap()
         swap_gate.set_sites(site_left, site_left + 1)
-        _apply_two_qubit_gate_tebd(state, swap_gate, sim_params, swap_distribution)
+        apply_two_qubit_gate_tebd(state, swap_gate, sim_params, svd_distribution=swap_distribution)
 
     site0, site1 = gate.sites[0], gate.sites[1]
     if abs(site0 - site1) != 1:
@@ -526,7 +530,7 @@ def _apply_two_qubit_gate_tebd(
             gate_adj.set_sites(left, left + 1)
         else:
             gate_adj.set_sites(left + 1, left)
-        _apply_two_qubit_gate_tebd(state, gate_adj, sim_params, "right")
+        apply_two_qubit_gate_tebd(state, gate_adj, sim_params, svd_distribution="right")
 
         for i in range(left + 1, right):
             apply_swap(i, "right")
@@ -566,24 +570,6 @@ def _apply_two_qubit_gate_tebd(
     state.tensors[right_site] = new_right
     state.update_center_after_split(left_site, right_site, svd_distribution)
     return left_site, right_site
-
-
-def apply_two_qubit_gate_tebd(
-    state: MPS,
-    gate: BaseGate,
-    sim_params: DigitalSimParams,
-) -> tuple[int, int]:
-    """Apply a two-qubit gate via TEBD/SVD, inserting adjacent SWAPs if needed.
-
-    Args:
-        state: MPS updated in place.
-        gate: Internal gate object from the gate library.
-        sim_params: Truncation settings shared with TDVP/MPS splitting.
-
-    Returns:
-        ``(left_site, right_site)`` spanning the gate support in MPS order.
-    """
-    return _apply_two_qubit_gate_tebd(state, gate, sim_params, "right")
 
 
 def apply_long_range_gate_mpo(

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1495,10 +1495,10 @@ def test_nn_gate_prunes_only_null_schmidt_directions(
     assert mps.bond_dimensions() == [expected_rank]
 
 
-@pytest.mark.parametrize("distance", [2, 5, 8])
-def test_swaps_route_does_not_shift_the_center_backwards(distance: int) -> None:
+def test_swaps_route_does_not_shift_the_center_backwards() -> None:
     """The SWAP route leaves the center on the pair it visits next, so it shifts nothing."""
     length = 12
+    distance = 5
     mps = MPS(length, state="x+")
     # Start on the pair the route touches first, so any shift counted below is the route's own.
     mps.set_canonical_form(length - 1)
@@ -1520,46 +1520,6 @@ def test_swaps_route_does_not_shift_the_center_backwards(distance: int) -> None:
     assert left.call_count == 0
     assert right.call_count == 0
     assert mps.orthogonality_center == length - 1
-
-
-def test_nearest_neighbor_tebd_amplitudes() -> None:
-    """CZ on |++> flips the sign of |11> only: amplitudes are exactly (1, 1, 1, -1) / 2."""
-    mps = MPS(2, state="x+")
-    mps.set_canonical_form(0)
-
-    gate = GateLibrary.cz()
-    gate.set_sites(0, 1)
-    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], preset="exact", gate_mode="swaps")
-
-    left_site, right_site = apply_two_qubit_gate_tebd(mps, gate, sim_params)
-
-    assert (left_site, right_site) == (0, 1)
-    assert mps.orthogonality_center == right_site
-    np.testing.assert_allclose(mps.to_vec(), np.array([1, 1, 1, -1]) / 2, atol=1e-15)
-
-
-@pytest.mark.parametrize("gate_mode", ["swaps", "mpo"])
-def test_lr_gate_modes_match_statevector(gate_mode: str) -> None:
-    """SWAP routing and the gate MPO both reproduce a multi-gate LR circuit exactly at L = 10."""
-    length = 10
-    qc = QuantumCircuit(length)
-    qc.h(range(length))
-    for control, target, theta in ((0, 6, 0.4), (2, 9, 0.7), (1, 5, 1.1)):
-        qc.rzz(theta, control, target)
-    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
-
-    params = DigitalSimParams(
-        preset="exact",
-        get_state=True,
-        max_bond_dim=None,
-        gate_mode=cast("GateMode", gate_mode),
-        tdvp_sweeps=16,
-        svd_threshold=1e-14,
-        krylov_tol=1e-12,
-    )
-    result = Simulator(parallel=False, show_progress=False).run(State(length, initial="zeros"), qc, params, None)
-    assert result.output_state is not None
-    assert _fidelity(ref, result.output_state.mps.to_vec()) == pytest.approx(1.0, abs=1e-8)
 
 
 def test_tebd_lr_cx() -> None:

--- a/tests/digital/test_digital_tjm.py
+++ b/tests/digital/test_digital_tjm.py
@@ -1494,6 +1494,73 @@ def test_nn_gate_prunes_only_null_schmidt_directions(
     assert mps.bond_dimensions() == [expected_rank]
 
 
+@pytest.mark.parametrize("distance", [2, 5, 8])
+def test_swaps_route_does_not_shift_the_center_backwards(distance: int) -> None:
+    """The SWAP route leaves the center on the pair it visits next, so it shifts nothing."""
+    length = 12
+    mps = MPS(length, state="x+")
+    # Start on the pair the route touches first, so any shift counted below is the route's own.
+    mps.set_canonical_form(length - 1)
+
+    gate = GateLibrary.rzz([0.7])
+    gate.set_sites(length - 1 - distance, length - 1)
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], preset="exact", gate_mode="swaps")
+
+    original_left = MPS.shift_orthogonality_center_left
+    original_right = MPS.shift_orthogonality_center_right
+    with (
+        patch.object(MPS, "shift_orthogonality_center_left", autospec=True, side_effect=original_left) as left,
+        patch.object(MPS, "shift_orthogonality_center_right", autospec=True, side_effect=original_right) as right,
+    ):
+        apply_two_qubit_gate_tebd(mps, gate, sim_params)
+
+    # Descending pass absorbs S left and ascending pass absorbs S right, so each split already
+    # leaves the center on the following pair: no single-site move is needed anywhere.
+    assert left.call_count == 0
+    assert right.call_count == 0
+    assert mps.orthogonality_center == length - 1
+
+
+def test_nearest_neighbor_tebd_amplitudes() -> None:
+    """CZ on |++> flips the sign of |11> only: amplitudes are exactly (1, 1, 1, -1) / 2."""
+    mps = MPS(2, state="x+")
+    mps.set_canonical_form(0)
+
+    gate = GateLibrary.cz()
+    gate.set_sites(0, 1)
+    sim_params = DigitalSimParams(observables=[Observable(Z(), 0)], preset="exact", gate_mode="swaps")
+
+    left_site, right_site = apply_two_qubit_gate_tebd(mps, gate, sim_params)
+
+    assert (left_site, right_site) == (0, 1)
+    assert mps.orthogonality_center == right_site
+    np.testing.assert_allclose(mps.to_vec(), np.array([1, 1, 1, -1]) / 2, atol=1e-15)
+
+
+@pytest.mark.parametrize("gate_mode", ["swaps", "mpo"])
+def test_lr_gate_modes_match_statevector(gate_mode: str) -> None:
+    """SWAP routing and the gate MPO both reproduce a multi-gate LR circuit exactly at L = 10."""
+    length = 10
+    qc = QuantumCircuit(length)
+    qc.h(range(length))
+    for control, target, theta in ((0, 6, 0.4), (2, 9, 0.7), (1, 5, 1.1)):
+        qc.rzz(theta, control, target)
+    ref = np.asarray(Statevector(qc).data, dtype=np.complex128)
+
+    params = DigitalSimParams(
+        preset="exact",
+        get_state=True,
+        max_bond_dim=None,
+        gate_mode=cast("GateMode", gate_mode),
+        tdvp_sweeps=16,
+        svd_threshold=1e-14,
+        krylov_tol=1e-12,
+    )
+    result = Simulator(parallel=False, show_progress=False).run(State(length, initial="zeros"), qc, params, None)
+    assert result.output_state is not None
+    assert _fidelity(ref, result.output_state.mps.to_vec()) == pytest.approx(1.0, abs=1e-8)
+
+
 def test_tebd_lr_cx() -> None:
     """TEBD applies CX(1, 3) on |1111> via SWAP insertion."""
     length = 4


### PR DESCRIPTION
This PR fixes issue #572 :

With `gate_mode="swaps"`, a gate between two distant qubits is applied by walking one qubit next
to the other through a chain of SWAPs. Each SWAP left the orthogonality center one site beyond the
pair the walk visits next, so the center had to be shifted back before every SWAP, which the
return walk never needed. 

In this branch, each SWAP leave the center where the walk is already headed,
which removes those shifts and speeds up circuits that use long-range gates. The resulting state
is unchanged, because the truncation keeps the same singular values either way. 

Tests cover the shift count, agreement with a dense statevector across gate modes, and unchanged nearest-neighbor behavior.