### PR TITLE
🔧 Shifted the OC left without flipping the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- shifted the orthogonality center left without flipping the network ([#574])
+  ([**@Pouri96**])
 - localized long-range MPO gate application ([#564]) ([**@Pouri96**])
 - sped up normalization in circuit simulation and fixed TDVP state tracking
   ([#560]) ([**@Pouri96**])
@@ -264,6 +266,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#575]: https://github.com/munich-quantum-toolkit/yaqs/pull/575
+[#574]: https://github.com/munich-quantum-toolkit/yaqs/pull/574
 [#564]: https://github.com/munich-quantum-toolkit/yaqs/pull/564
 [#561]: https://github.com/munich-quantum-toolkit/yaqs/pull/561
 [#567]: https://github.com/munich-quantum-toolkit/yaqs/pull/567

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -20,7 +20,7 @@ import scipy.linalg
 from tqdm import tqdm
 
 from .. import linalg
-from ..methods.decompositions import merge_two_site, right_qr, split_two_site
+from ..methods.decompositions import left_qr, merge_two_site, right_qr, split_two_site
 from ..parallel_utils import available_cpus, get_parallel_context, limit_worker_threads
 
 if TYPE_CHECKING:
@@ -898,7 +898,8 @@ class MPS:
     def shift_orthogonality_center_left(self, current_orthogonality_center: int, decomposition: str = "QR") -> None:
         """Shifts orthogonality center left.
 
-        This function flips the network, performs a right shift, then flips the network again.
+        This function performs a QR decomposition to shift the known current center to the left and move
+        the canonical form. This is essential for maintaining efficient tensor network algorithms.
 
         Args:
             current_orthogonality_center (int): current center
@@ -915,9 +916,41 @@ class MPS:
                 f"shift_orthogonality_center_left: tracked center is {self._orthogonality_center}, "
                 f"but shift requested from site {current_orthogonality_center}."
             )
-        self.flip_network()
-        self.shift_orthogonality_center_right(self.length - current_orthogonality_center - 1, decomposition)
-        self.flip_network()
+        tensor = self.tensors[current_orthogonality_center]
+        if decomposition == "QR" or current_orthogonality_center == 0:
+            site_tensor, bond_tensor = left_qr(tensor)
+            self.tensors[current_orthogonality_center] = site_tensor
+
+            # If normalizing, we just throw away the R
+            if current_orthogonality_center - 1 >= 0:
+                self.tensors[current_orthogonality_center - 1] = oe.contract(
+                    "aij, jk->aik",
+                    self.tensors[current_orthogonality_center - 1],
+                    bond_tensor,
+                )
+        elif decomposition == "SVD":
+            a, b = (
+                self.tensors[current_orthogonality_center - 1],
+                self.tensors[current_orthogonality_center],
+            )
+            merged = merge_two_site(a, b)
+            a_new, b_new = split_two_site(
+                merged,
+                [a.shape[0], b.shape[0]],
+                svd_distribution="left",
+                trunc_mode="discarded_weight",
+                threshold=1e-12,
+                max_bond_dim=None,
+            )
+            (
+                self.tensors[current_orthogonality_center - 1],
+                self.tensors[current_orthogonality_center],
+            ) = (a_new, b_new)
+        if self._orthogonality_center is not None:
+            if current_orthogonality_center - 1 >= 0:
+                self._orthogonality_center = current_orthogonality_center - 1
+            else:
+                self._orthogonality_center = current_orthogonality_center
 
     def set_canonical_form(self, orthogonality_center: int, decomposition: str = "QR") -> None:
         """Sets canonical form of MPS.

--- a/src/mqt/yaqs/core/data_structures/mps.py
+++ b/src/mqt/yaqs/core/data_structures/mps.py
@@ -896,16 +896,16 @@ class MPS:
                 self._orthogonality_center = current_orthogonality_center
 
     def shift_orthogonality_center_left(self, current_orthogonality_center: int, decomposition: str = "QR") -> None:
-        """Shifts orthogonality center left.
+        """Shift the orthogonality center one site to the left.
 
-        This function performs a QR decomposition to shift the known current center to the left and move
-        the canonical form. This is essential for maintaining efficient tensor network algorithms.
+        The method updates only the center tensor and its left neighbor without
+        flipping the network. At site zero, the method normalizes the center
+        tensor and leaves the center at zero.
 
         Args:
-            current_orthogonality_center (int): current center
-            decomposition: Decides between QR or SVD decomposition. QR is faster, SVD allows bond dimension to reduce
-                Default is QR.
-
+            current_orthogonality_center: Site that currently holds the orthogonality center.
+            decomposition: Decomposition used for the shift. ``"QR"`` is faster;
+                ``"SVD"`` can reduce the bond dimension.
         """
         current_orthogonality_center = self._validate_center(
             current_orthogonality_center, name="current_orthogonality_center"
@@ -921,7 +921,6 @@ class MPS:
             site_tensor, bond_tensor = left_qr(tensor)
             self.tensors[current_orthogonality_center] = site_tensor
 
-            # If normalizing, we just throw away the R
             if current_orthogonality_center - 1 >= 0:
                 self.tensors[current_orthogonality_center - 1] = oe.contract(
                     "aij, jk->aik",

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -150,19 +150,21 @@ def crandn(
     )
 
 
-def random_mps(shapes: list[tuple[int, int, int]], *, normalize: bool = True) -> MPS:
+def random_mps(shapes: list[tuple[int, int, int]], *, normalize: bool = True, seed: int | None = None) -> MPS:
     """Create a random MPS with the given shapes.
 
     Args:
         shapes (List[Tuple[int, int, int]]): The shapes of the tensors in the
             MPS.
         normalize (bool): Whether to normalize the MPS.
+        seed: Seed for the complex-normal entries.
 
     Returns:
         MPS: The random MPS.
     """
-    tensors = [crandn(shape) for shape in shapes]
-    mps = MPS(len(shapes), tensors=tensors)
+    rng = np.random.default_rng(seed)
+    tensors = [crandn(shape, seed=rng) for shape in shapes]
+    mps = MPS(len(shapes), tensors=tensors, physical_dimensions=[shape[0] for shape in shapes])
     if normalize:
         mps.normalize()
     return mps
@@ -367,149 +369,86 @@ def test_shift_orthogonality_center_right() -> None:
     assert mps.check_canonical_form() == [3]
 
 
-def test_shift_orthogonality_center_left() -> None:
-    """Test shifting the orthogonality center to the left in an MPS.
+@pytest.mark.parametrize("decomposition", ["QR", "SVD"])
+def test_shift_orthogonality_center_left(decomposition: str) -> None:
+    """Test shifting the orthogonality center left through and at the boundary.
 
-    This test ensures that the left shift operation does not alter the rank (3) of the MPS tensors.
+    Args:
+        decomposition: Local decomposition used for each shift.
     """
     pdim = 2
     shapes = [(pdim, 1, 2), (pdim, 2, 3), (pdim, 3, 3), (pdim, 3, 1)]
     mps = random_mps(shapes)
     mps.set_canonical_form(3)
     assert mps.check_canonical_form() == [3]
-    mps.shift_orthogonality_center_left(current_orthogonality_center=3)
+    mps.shift_orthogonality_center_left(current_orthogonality_center=3, decomposition=decomposition)
     assert mps.check_canonical_form() == [2]
-    mps.shift_orthogonality_center_left(current_orthogonality_center=2)
+    mps.shift_orthogonality_center_left(current_orthogonality_center=2, decomposition=decomposition)
     assert mps.check_canonical_form() == [1]
-    mps.shift_orthogonality_center_left(current_orthogonality_center=1)
+    mps.shift_orthogonality_center_left(current_orthogonality_center=1, decomposition=decomposition)
     assert mps.check_canonical_form() == [0]
-
-
-def _seeded_canonical_mps(shapes: list[tuple[int, int, int]], center: int, seed: int) -> MPS:
-    """Build a seeded unit-norm MPS with the given shapes, canonical around ``center``.
-
-    Args:
-        shapes: Per-site ``(phys, left, right)`` shapes.
-        center: Orthogonality center to establish.
-        seed: Seed for the complex-normal entries.
-
-    Returns:
-        MPS in mixed-canonical form with the center at ``center``.
-    """
-    tensors = [crandn(shape, seed=seed + i) for i, shape in enumerate(shapes)]
-    mps = MPS(len(shapes), tensors=tensors, physical_dimensions=[shape[0] for shape in shapes])
-    mps.normalize(form="B")
-    mps.set_canonical_form(center)
-    return mps
-
-
-def _flip_based_left_shift(mps: MPS, current: int, decomposition: str = "QR") -> MPS:
-    """Shift left the way it was done before: flip, shift right, flip back.
-
-    Args:
-        mps: State to shift; left unmodified.
-        current: Current orthogonality center.
-        decomposition: ``"QR"`` or ``"SVD"``.
-
-    Returns:
-        A shifted deep copy of ``mps``.
-    """
-    reference = copy.deepcopy(mps)
-    reference.flip_network()
-    reference.shift_orthogonality_center_right(reference.length - current - 1, decomposition)
-    reference.flip_network()
-    return reference
+    mps.tensors[0] *= 2.5
+    mps.shift_orthogonality_center_left(0, decomposition)
+    assert mps.orthogonality_center == 0
+    assert 0 in mps.check_canonical_form()
+    assert float(mps.norm()) == pytest.approx(1.0, rel=1e-12, abs=1e-13)
 
 
 @pytest.mark.parametrize("decomposition", ["QR", "SVD"])
-def test_left_shift_at_site_zero_renormalizes_and_keeps_center(decomposition: str) -> None:
-    """A left shift at site 0 has no site to absorb R, so it normalizes and stays put."""
-    shapes = [(2, 1, 2), (2, 2, 3), (2, 3, 3), (2, 3, 1)]
-    mps = _seeded_canonical_mps(shapes, 0, seed=6001)
-    # Every other tensor is an isometry, so scaling the center by 2.5 makes ||psi|| == 2.5.
-    mps.tensors[0] *= 2.5
-    assert mps.norm() == pytest.approx(2.5, abs=1e-12)
+def test_left_shift_preserves_state_center_and_exterior_tensor(decomposition: str) -> None:
+    """A flipped interior shift changes only its bond pair and preserves the state.
 
-    reference = _flip_based_left_shift(mps, 0, decomposition)
-    mps.shift_orthogonality_center_left(0, decomposition)
+    Args:
+        decomposition: Local decomposition used for the shift.
+    """
+    shapes = [(3, 1, 2), (2, 2, 2), (4, 2, 1)]
+    mps = random_mps(shapes, seed=6200)
+    mps.set_canonical_form(1)
+    mps.flip_network()
+    before = mps.to_vec()
+    exterior, exterior_values = mps.tensors[2], mps.tensors[2].copy()
+
+    mps.shift_orthogonality_center_left(1, decomposition)
 
     assert mps.orthogonality_center == 0
-    assert mps.norm() == pytest.approx(1.0, abs=1e-12)
-    for shifted, expected in zip(mps.tensors, reference.tensors, strict=False):
-        assert np.allclose(shifted, expected, atol=1e-13)
+    assert 0 in mps.check_canonical_form()
+    assert mps.flipped is True
+    assert mps.tensors[2] is exterior
+    np.testing.assert_array_equal(mps.tensors[2], exterior_values)
+    np.testing.assert_allclose(mps.to_vec(), before, rtol=1e-12, atol=1e-13)
 
 
-@pytest.mark.parametrize("center", [1, 2, 3])
-def test_left_shift_matches_flip_based_path_at_interior_sites(center: int) -> None:
-    """Interior QR left shifts reproduce the flip-based path tensor for tensor."""
-    shapes = [(2, 1, 2), (2, 2, 4), (2, 4, 3), (2, 3, 1)]
-    mps = _seeded_canonical_mps(shapes, center, seed=6100 + center)
-    reference = _flip_based_left_shift(mps, center)
-    mps.shift_orthogonality_center_left(center)
-
-    assert mps.orthogonality_center == center - 1
-    assert mps.check_canonical_form() == [center - 1]
-    assert np.allclose(mps.to_vec(), reference.to_vec(), atol=1e-13)
-    for shifted, expected in zip(mps.tensors, reference.tensors, strict=False):
-        assert shifted.shape == expected.shape
-        assert np.allclose(shifted, expected, atol=1e-13)
-
-
-def test_left_shift_with_svd_matches_flip_based_path_up_to_a_bond_phase() -> None:
-    """The SVD branch reproduces the state; its gauge differs by one phase on the shared bond."""
-    shapes = [(2, 1, 2), (2, 2, 4), (2, 4, 3), (2, 3, 1)]
-    center = 2
-    mps = _seeded_canonical_mps(shapes, center, seed=6150)
-    reference = _flip_based_left_shift(mps, center, "SVD")
-    mps.shift_orthogonality_center_left(center, "SVD")
-
-    assert mps.orthogonality_center == center - 1
-    assert mps.check_canonical_form() == [center - 1]
-    assert np.allclose(mps.to_vec(), reference.to_vec(), atol=1e-13)
-
-    # Both site tensors are the same isometry up to a diagonal unitary on the shared bond:
-    # ``new[a, i, c] == sum_j ref[a, j, c] phase[j, i]``, i.e. ``phase`` diagonal with ``|.| == 1``.
-    phase = oe.contract("ajc, aic->ji", reference.tensors[center].conj(), mps.tensors[center])
-    assert np.allclose(phase, np.diag(np.diag(phase)), atol=1e-13)
-    assert np.allclose(np.abs(np.diag(phase)), 1.0, atol=1e-13)
-
-
-def test_left_shift_preserves_flip_state_and_physical_dimensions() -> None:
-    """A left shift leaves flipped, physical_dimensions, length, and tensor shapes alone."""
-    shapes = [(3, 1, 2), (2, 2, 4), (4, 4, 3), (2, 3, 1)]
-    mps = _seeded_canonical_mps(shapes, 2, seed=6200)
-    reference = _flip_based_left_shift(mps, 2)
-    mps.shift_orthogonality_center_left(2)
-
-    assert mps.flipped is False
-    assert reference.flipped is False
-    assert mps.physical_dimensions == reference.physical_dimensions == [3, 2, 4, 2]
-    assert mps.length == reference.length == 4
-    assert [t.shape for t in mps.tensors] == [t.shape for t in reference.tensors]
-
-
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [(2, 1, 2), (2, 2, 4), (2, 4, 4), (2, 4, 2), (2, 2, 1)],
-        [(3, 1, 3), (2, 3, 4), (4, 4, 4), (2, 4, 2), (3, 2, 1)],
-    ],
-    ids=["qubits", "qudits"],
-)
-@pytest.mark.parametrize("target", [1, 2, 3, 4])
-def test_center_round_trip_preserves_state_and_canonical_form(shapes: list[tuple[int, int, int]], target: int) -> None:
-    """Walking the center out to ``target`` and back to 0 leaves the state unchanged."""
-    mps = _seeded_canonical_mps(shapes, 0, seed=6300 + target)
+def test_left_shift_with_svd_reduces_a_rank_deficient_bond() -> None:
+    """An SVD left shift removes a null direction without changing the state."""
+    left = np.eye(2, dtype=np.complex128).reshape(2, 1, 2)
+    right = np.zeros((2, 2, 1), dtype=np.complex128)
+    right[0, 0, 0] = 1.0
+    mps = MPS(2, tensors=[left, right])
+    mps.set_center(1)
     before = mps.to_vec()
 
-    mps.shift_center_to(target)
-    assert mps.check_canonical_form() == [target]
+    mps.shift_orthogonality_center_left(1, "SVD")
+
+    assert mps.tensors[0].shape[2] == mps.tensors[1].shape[1] == 1
+    assert mps.orthogonality_center == 0
+    assert 0 in mps.check_canonical_form()
+    np.testing.assert_allclose(mps.to_vec(), before, rtol=1e-12, atol=1e-13)
+
+
+def test_center_round_trip_preserves_a_mixed_dimension_state() -> None:
+    """A full center round trip preserves a mixed-dimension state."""
+    shapes = [(3, 1, 3), (2, 3, 4), (4, 4, 4), (2, 4, 2), (3, 2, 1)]
+    mps = random_mps(shapes, seed=6304)
+    mps.set_canonical_form(0)
+    before = mps.to_vec()
+
+    mps.shift_center_to(4)
     mps.shift_center_to(0)
 
     assert mps.orthogonality_center == 0
-    assert mps.check_canonical_form() == [0]
+    assert 0 in mps.check_canonical_form()
     assert mps.physical_dimensions == [shape[0] for shape in shapes]
-    assert np.allclose(mps.to_vec(), before, atol=1e-13)
+    np.testing.assert_allclose(mps.to_vec(), before, rtol=1e-12, atol=1e-13)
 
 
 @pytest.mark.parametrize("desired_center", [0, 1, 2, 3])

--- a/tests/core/data_structures/test_mps.py
+++ b/tests/core/data_structures/test_mps.py
@@ -385,6 +385,133 @@ def test_shift_orthogonality_center_left() -> None:
     assert mps.check_canonical_form() == [0]
 
 
+def _seeded_canonical_mps(shapes: list[tuple[int, int, int]], center: int, seed: int) -> MPS:
+    """Build a seeded unit-norm MPS with the given shapes, canonical around ``center``.
+
+    Args:
+        shapes: Per-site ``(phys, left, right)`` shapes.
+        center: Orthogonality center to establish.
+        seed: Seed for the complex-normal entries.
+
+    Returns:
+        MPS in mixed-canonical form with the center at ``center``.
+    """
+    tensors = [crandn(shape, seed=seed + i) for i, shape in enumerate(shapes)]
+    mps = MPS(len(shapes), tensors=tensors, physical_dimensions=[shape[0] for shape in shapes])
+    mps.normalize(form="B")
+    mps.set_canonical_form(center)
+    return mps
+
+
+def _flip_based_left_shift(mps: MPS, current: int, decomposition: str = "QR") -> MPS:
+    """Shift left the way it was done before: flip, shift right, flip back.
+
+    Args:
+        mps: State to shift; left unmodified.
+        current: Current orthogonality center.
+        decomposition: ``"QR"`` or ``"SVD"``.
+
+    Returns:
+        A shifted deep copy of ``mps``.
+    """
+    reference = copy.deepcopy(mps)
+    reference.flip_network()
+    reference.shift_orthogonality_center_right(reference.length - current - 1, decomposition)
+    reference.flip_network()
+    return reference
+
+
+@pytest.mark.parametrize("decomposition", ["QR", "SVD"])
+def test_left_shift_at_site_zero_renormalizes_and_keeps_center(decomposition: str) -> None:
+    """A left shift at site 0 has no site to absorb R, so it normalizes and stays put."""
+    shapes = [(2, 1, 2), (2, 2, 3), (2, 3, 3), (2, 3, 1)]
+    mps = _seeded_canonical_mps(shapes, 0, seed=6001)
+    # Every other tensor is an isometry, so scaling the center by 2.5 makes ||psi|| == 2.5.
+    mps.tensors[0] *= 2.5
+    assert mps.norm() == pytest.approx(2.5, abs=1e-12)
+
+    reference = _flip_based_left_shift(mps, 0, decomposition)
+    mps.shift_orthogonality_center_left(0, decomposition)
+
+    assert mps.orthogonality_center == 0
+    assert mps.norm() == pytest.approx(1.0, abs=1e-12)
+    for shifted, expected in zip(mps.tensors, reference.tensors, strict=False):
+        assert np.allclose(shifted, expected, atol=1e-13)
+
+
+@pytest.mark.parametrize("center", [1, 2, 3])
+def test_left_shift_matches_flip_based_path_at_interior_sites(center: int) -> None:
+    """Interior QR left shifts reproduce the flip-based path tensor for tensor."""
+    shapes = [(2, 1, 2), (2, 2, 4), (2, 4, 3), (2, 3, 1)]
+    mps = _seeded_canonical_mps(shapes, center, seed=6100 + center)
+    reference = _flip_based_left_shift(mps, center)
+    mps.shift_orthogonality_center_left(center)
+
+    assert mps.orthogonality_center == center - 1
+    assert mps.check_canonical_form() == [center - 1]
+    assert np.allclose(mps.to_vec(), reference.to_vec(), atol=1e-13)
+    for shifted, expected in zip(mps.tensors, reference.tensors, strict=False):
+        assert shifted.shape == expected.shape
+        assert np.allclose(shifted, expected, atol=1e-13)
+
+
+def test_left_shift_with_svd_matches_flip_based_path_up_to_a_bond_phase() -> None:
+    """The SVD branch reproduces the state; its gauge differs by one phase on the shared bond."""
+    shapes = [(2, 1, 2), (2, 2, 4), (2, 4, 3), (2, 3, 1)]
+    center = 2
+    mps = _seeded_canonical_mps(shapes, center, seed=6150)
+    reference = _flip_based_left_shift(mps, center, "SVD")
+    mps.shift_orthogonality_center_left(center, "SVD")
+
+    assert mps.orthogonality_center == center - 1
+    assert mps.check_canonical_form() == [center - 1]
+    assert np.allclose(mps.to_vec(), reference.to_vec(), atol=1e-13)
+
+    # Both site tensors are the same isometry up to a diagonal unitary on the shared bond:
+    # ``new[a, i, c] == sum_j ref[a, j, c] phase[j, i]``, i.e. ``phase`` diagonal with ``|.| == 1``.
+    phase = oe.contract("ajc, aic->ji", reference.tensors[center].conj(), mps.tensors[center])
+    assert np.allclose(phase, np.diag(np.diag(phase)), atol=1e-13)
+    assert np.allclose(np.abs(np.diag(phase)), 1.0, atol=1e-13)
+
+
+def test_left_shift_preserves_flip_state_and_physical_dimensions() -> None:
+    """A left shift leaves flipped, physical_dimensions, length, and tensor shapes alone."""
+    shapes = [(3, 1, 2), (2, 2, 4), (4, 4, 3), (2, 3, 1)]
+    mps = _seeded_canonical_mps(shapes, 2, seed=6200)
+    reference = _flip_based_left_shift(mps, 2)
+    mps.shift_orthogonality_center_left(2)
+
+    assert mps.flipped is False
+    assert reference.flipped is False
+    assert mps.physical_dimensions == reference.physical_dimensions == [3, 2, 4, 2]
+    assert mps.length == reference.length == 4
+    assert [t.shape for t in mps.tensors] == [t.shape for t in reference.tensors]
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [(2, 1, 2), (2, 2, 4), (2, 4, 4), (2, 4, 2), (2, 2, 1)],
+        [(3, 1, 3), (2, 3, 4), (4, 4, 4), (2, 4, 2), (3, 2, 1)],
+    ],
+    ids=["qubits", "qudits"],
+)
+@pytest.mark.parametrize("target", [1, 2, 3, 4])
+def test_center_round_trip_preserves_state_and_canonical_form(shapes: list[tuple[int, int, int]], target: int) -> None:
+    """Walking the center out to ``target`` and back to 0 leaves the state unchanged."""
+    mps = _seeded_canonical_mps(shapes, 0, seed=6300 + target)
+    before = mps.to_vec()
+
+    mps.shift_center_to(target)
+    assert mps.check_canonical_form() == [target]
+    mps.shift_center_to(0)
+
+    assert mps.orthogonality_center == 0
+    assert mps.check_canonical_form() == [0]
+    assert mps.physical_dimensions == [shape[0] for shape in shapes]
+    assert np.allclose(mps.to_vec(), before, atol=1e-13)
+
+
 @pytest.mark.parametrize("desired_center", [0, 1, 2, 3])
 def test_set_canonical_form(desired_center: int) -> None:
     """Test that set_canonical_form correctly sets the MPS into a canonical form without altering tensor shapes.


### PR DESCRIPTION
Moving the orthogonality centre to the right touches one or two tensors, but moving it to the left
was implemented by flipping the whole network around, shifting right, and flipping back — so a
single-site move rebuilt every tensor in the chain, twice. It now uses `left_qr` directly, which
was already in `decompositions.py`, and mirrors the rightward version step for step. 